### PR TITLE
feat: Use mdcat for markdown viewing with automatic pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A powerful command-line tool for managing your personal knowledge base with Post
 
 - Python 3.8+
 - fzf (for interactive mode)
+- mdcat (optional, for better markdown viewing with pagination)
 
 ### Install from source
 


### PR DESCRIPTION
Improves the `emdx view` command to use mdcat when available for better markdown rendering and automatic pagination.

## Changes
- 🎨 Use mdcat for beautiful markdown rendering with syntax highlighting
- 📄 Automatic pagination for long documents (no more scrolling past the content\!)
- 🔄 Graceful fallback to Rich rendering if mdcat is not installed
- 📝 Document metadata included in the mdcat output
- 🔧 Preserves `--raw` flag behavior

## How it works
1. Checks if mdcat is available in PATH
2. If found, creates a temporary markdown file with document metadata
3. Runs `mdcat --paginate` for automatic pager detection
4. Falls back to Rich's Markdown renderer if mdcat is not available

## Installation
```bash
# macOS
brew install mdcat

# Other platforms
cargo install mdcat
```

Now long documents are much easier to read with proper pagination\! 📖