### PR TITLE
feat: Add Rich pager support to emdx view command

### DIFF
--- a/PAGER_PLAN.md
+++ b/PAGER_PLAN.md
@@ -1,0 +1,50 @@
+# Plan for Adding Pagination to emdx view
+
+## Current Issue
+When using `emdx view`, long documents scroll past the terminal window, making it hard to read from the beginning.
+
+## Approach Options
+
+### Option 1: Use Python's built-in pager (Current attempt)
+- Use Rich's console with a pager
+- Problem: Rich's pager requires specific context manager usage
+
+### Option 2: Use system pager directly
+- Pipe output to `less` or system pager
+- More reliable, works like git log, man pages, etc.
+
+### Option 3: Add --no-pager flag
+- Default to using pager
+- Allow users to disable with flag if they want to pipe elsewhere
+
+## Recommended Solution
+
+Use Python's `pydoc.pager()` or subprocess to call system pager:
+
+```python
+import pydoc
+import os
+
+# Render everything to a string first
+output = render_document(doc)
+
+# Use pager (respects PAGER env var, falls back to less/more)
+pydoc.pager(output)
+```
+
+Or more control:
+
+```python
+import subprocess
+import os
+
+pager = os.environ.get('PAGER', 'less')
+process = subprocess.Popen(pager, stdin=subprocess.PIPE, text=True)
+process.communicate(output)
+```
+
+This would:
+- Work on all systems
+- Respect user's PAGER preference
+- Provide familiar navigation (like reading man pages)
+- Not require mdcat or other dependencies

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A powerful command-line tool for managing your personal knowledge base with Post
 
 - Python 3.8+
 - fzf (for interactive mode)
+- mdcat (optional, for better markdown viewing with pagination)
 
 ### Install from source
 

--- a/emdx/core.py
+++ b/emdx/core.py
@@ -129,6 +129,7 @@ def find(
 def view(
     identifier: str = typer.Argument(..., help="Document ID or title"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Show raw markdown without formatting"),
+    no_pager: bool = typer.Option(False, "--no-pager", help="Disable pager (for piping output)"),
 ):
     """View a document from the knowledge base"""
     try:
@@ -142,60 +143,36 @@ def view(
             console.print(f"[red]Error: Document '{identifier}' not found[/red]")
             raise typer.Exit(1)
         
-        # Check if we should use mdcat
-        import subprocess
-        import tempfile
-        import os
-        
-        use_mdcat = False
-        if not raw:
-            try:
-                result = subprocess.run(['which', 'mdcat'], capture_output=True)
-                use_mdcat = result.returncode == 0
-            except:
-                pass
-        
-        if use_mdcat:
-            # Create full markdown document with header
-            full_content = f"""# {doc['title']}
-
-**Document ID:** #{doc['id']}  
-**Project:** {doc['project'] or 'None'}  
-**Created:** {doc['created_at'].strftime('%Y-%m-%d %H:%M')}  
-**Views:** {doc['access_count']}
-
----
-
-{doc['content']}"""
-            
-            # Use mdcat with pager
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
-                f.write(full_content)
-                temp_path = f.name
-            
-            try:
-                # Run mdcat with automatic pager detection
-                subprocess.run(['mdcat', '--paginate', temp_path])
-            finally:
-                os.unlink(temp_path)
-        else:
-            # Fall back to Rich rendering
-            # Display document header
+        # Display document with or without pager
+        if no_pager:
+            # Direct output without pager
             console.print(f"\n[bold cyan]#{doc['id']}:[/bold cyan] [bold]{doc['title']}[/bold]")
             console.print("=" * 60)
-            
-            # Display metadata
             console.print(f"[dim]Project:[/dim] {doc['project'] or 'None'}")
             console.print(f"[dim]Created:[/dim] {doc['created_at'].strftime('%Y-%m-%d %H:%M')}")
             console.print(f"[dim]Views:[/dim] {doc['access_count']}")
             console.print("=" * 60 + "\n")
             
-            # Display content
             if raw:
                 console.print(doc['content'])
             else:
                 markdown = Markdown(doc['content'])
                 console.print(markdown)
+        else:
+            # Use Rich's pager
+            with console.pager():
+                console.print(f"\n[bold cyan]#{doc['id']}:[/bold cyan] [bold]{doc['title']}[/bold]")
+                console.print("=" * 60)
+                console.print(f"[dim]Project:[/dim] {doc['project'] or 'None'}")
+                console.print(f"[dim]Created:[/dim] {doc['created_at'].strftime('%Y-%m-%d %H:%M')}")
+                console.print(f"[dim]Views:[/dim] {doc['access_count']}")
+                console.print("=" * 60 + "\n")
+                
+                if raw:
+                    console.print(doc['content'])
+                else:
+                    markdown = Markdown(doc['content'])
+                    console.print(markdown)
         
     except Exception as e:
         console.print(f"[red]Error viewing document: {e}[/red]")


### PR DESCRIPTION
## Summary
- Implements proper pagination for `emdx view` command using Rich's built-in pager
- Preserves all Rich formatting and colors in the pager
- Adds `--no-pager` flag for users who want to pipe output elsewhere

## Implementation Details
- Uses `console.pager()` context manager from Rich
- Works with the system's PAGER environment variable (defaults to less/more)
- Colors and formatting are fully preserved unlike regular piping
- The `--no-pager` flag allows disabling pagination for scripting/piping

## Test Plan
- [ ] Test `emdx view <id>` with a long document - should paginate
- [ ] Test `emdx view <id> --no-pager` - should output directly without paging
- [ ] Test that colors and formatting are preserved in the pager
- [ ] Test that navigation works (arrow keys, space, q to quit)

🤖 Generated with [Claude Code](https://claude.ai/code)