### PR TITLE
feat: Add edit and delete keybindings to GUI

### DIFF
--- a/emdx/__init__.py
+++ b/emdx/__init__.py
@@ -2,4 +2,4 @@
 emdx - Documentation Index Management System
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/emdx/gui.py
+++ b/emdx/gui.py
@@ -134,6 +134,8 @@ def gui():
         
         # Simple commands using emdx
         view_cmd = f"{emdx_cmd} view {{1}} < /dev/tty"
+        edit_cmd = f"{emdx_cmd} edit {{1}} < /dev/tty"
+        delete_cmd = f"echo 'Delete document {{1}}? (soft delete - can be restored)' && read -p 'Press y to confirm, any other key to cancel: ' -n 1 confirm && echo && [ \"$confirm\" = 'y' ] && {emdx_cmd} delete {{1}} < /dev/tty"
         reload_cmd = f"{sys.executable} -c 'from emdx.gui import format_document_list; print(\"\\n\".join(format_document_list()))'"
         
         # Create fzf command
@@ -145,6 +147,8 @@ def gui():
             "--bind=k:up",
             "--bind=/:toggle-search",
             f"--bind=enter:execute({view_cmd})",
+            f"--bind=e:execute({edit_cmd})+reload({reload_cmd})",
+            f"--bind=d:execute({delete_cmd})+reload({reload_cmd})",
             "--bind=ctrl-d:preview-page-down",
             "--bind=ctrl-u:preview-page-up",
             "--bind=ctrl-f:preview-page-down",
@@ -154,8 +158,8 @@ def gui():
             f"--bind=ctrl-r:reload({reload_cmd})",
             "--bind=q:abort",
             "--bind=ctrl-c:abort",
-            "--bind=ctrl-h:execute(echo -e \"\\n📚 emdx - Help\\n\\nNavigation:\\n  j/k, ↑/↓    Move up/down\\n  g/G         First/last item\\n  /           Toggle search\\n  Mouse       Click & scroll\\n\\nActions:\\n  Enter       View document\\n  Ctrl-R      Refresh list\\n\\nPreview:\\n  Ctrl-D/U    Scroll down/up\\n  Ctrl-F/B    Page down/up\\n\\nOther:\\n  q, Ctrl-C   Quit\\n\\nPress any key to continue...\" && read -n 1)",
-            "--header=📚 emdx - Documentation Index (/: search, ctrl-h: help, q: quit)",
+            "--bind=ctrl-h:execute(echo -e \"\\n📚 emdx - Help\\n\\nNavigation:\\n  j/k, ↑/↓    Move up/down\\n  g/G         First/last item\\n  /           Toggle search\\n  Mouse       Click & scroll\\n\\nActions:\\n  Enter       View document\\n  e           Edit document\\n  d           Delete document (soft)\\n  Ctrl-R      Refresh list\\n\\nPreview:\\n  Ctrl-D/U    Scroll down/up\\n  Ctrl-F/B    Page down/up\\n\\nOther:\\n  q, Ctrl-C   Quit\\n\\nPress any key to continue...\" && read -n 1)",
+            "--header=📚 emdx - Documentation Index (enter: view, e: edit, d: delete, /: search, ctrl-h: help, q: quit)",
             "--delimiter= │ ",
             "--with-nth=1,2,3,4",
             "--info=inline",

--- a/emdx/sqlite_database.py
+++ b/emdx/sqlite_database.py
@@ -104,10 +104,6 @@ class SQLiteDatabase:
                 CREATE INDEX IF NOT EXISTS idx_documents_accessed ON documents(accessed_at DESC)
             """)
             
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_documents_deleted ON documents(is_deleted, deleted_at)
-            """)
-            
             # Add soft delete columns to existing databases (migration)
             # Check if columns exist first
             cursor = conn.execute("PRAGMA table_info(documents)")
@@ -118,6 +114,11 @@ class SQLiteDatabase:
             
             if 'is_deleted' not in columns:
                 conn.execute("ALTER TABLE documents ADD COLUMN is_deleted BOOLEAN DEFAULT FALSE")
+            
+            # Create index after columns exist
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_documents_deleted ON documents(is_deleted, deleted_at)
+            """)
             
             conn.commit()
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "emdx"
-version = "0.2.0"
+version = "0.2.1"
 description = "Documentation Index Management System - A powerful knowledge base for developers"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- Adds keyboard shortcuts to the fzf-based GUI for edit and delete operations
- Follow-up to PR #5 which added the underlying edit/delete functionality

## Features Added
- Press `e` to edit the selected document (opens in $EDITOR)
- Press `d` to delete with confirmation prompt (soft delete, can be restored)
- Both operations automatically refresh the document list
- Updated help text (Ctrl-H) to show new keybindings
- Updated header to display available actions

## User Experience
The GUI now supports full CRUD operations without leaving the interface:
- Browse documents with preview
- View full document (Enter)
- Edit documents (e)
- Delete documents (d)
- Automatic refresh after modifications

🤖 Generated with [Claude Code](https://claude.ai/code)