### PR TITLE
feat: Improve GUI document viewing experience

### DIFF
--- a/emdx/core.py
+++ b/emdx/core.py
@@ -18,7 +18,8 @@ from emdx.database import db
 from emdx.utils import get_git_project
 
 app = typer.Typer()
-console = Console()
+# Force color output even when not connected to a terminal
+console = Console(force_terminal=True, color_system="auto")
 
 
 @app.command()
@@ -166,6 +167,7 @@ def view(
     identifier: str = typer.Argument(..., help="Document ID or title"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Show raw markdown without formatting"),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable pager (for piping output)"),
+    no_header: bool = typer.Option(False, "--no-header", help="Hide document header information"),
 ):
     """View a document from the knowledge base"""
     try:
@@ -182,12 +184,13 @@ def view(
         # Display document with or without pager
         if no_pager:
             # Direct output without pager
-            console.print(f"\n[bold cyan]#{doc['id']}:[/bold cyan] [bold]{doc['title']}[/bold]")
-            console.print("=" * 60)
-            console.print(f"[dim]Project:[/dim] {doc['project'] or 'None'}")
-            console.print(f"[dim]Created:[/dim] {doc['created_at'].strftime('%Y-%m-%d %H:%M')}")
-            console.print(f"[dim]Views:[/dim] {doc['access_count']}")
-            console.print("=" * 60 + "\n")
+            if not no_header:
+                console.print(f"\n[bold cyan]#{doc['id']}:[/bold cyan] [bold]{doc['title']}[/bold]")
+                console.print("=" * 60)
+                console.print(f"[dim]Project:[/dim] {doc['project'] or 'None'}")
+                console.print(f"[dim]Created:[/dim] {doc['created_at'].strftime('%Y-%m-%d %H:%M')}")
+                console.print(f"[dim]Views:[/dim] {doc['access_count']}")
+                console.print("=" * 60 + "\n")
             
             if raw:
                 console.print(doc['content'])
@@ -195,14 +198,18 @@ def view(
                 markdown = Markdown(doc['content'])
                 console.print(markdown)
         else:
-            # Use Rich's pager
+            # Use Rich's pager with color support
+            # Set LESS environment variable if not already set
+            if 'LESS' not in os.environ:
+                os.environ['LESS'] = '-R'
             with console.pager():
-                console.print(f"\n[bold cyan]#{doc['id']}:[/bold cyan] [bold]{doc['title']}[/bold]")
-                console.print("=" * 60)
-                console.print(f"[dim]Project:[/dim] {doc['project'] or 'None'}")
-                console.print(f"[dim]Created:[/dim] {doc['created_at'].strftime('%Y-%m-%d %H:%M')}")
-                console.print(f"[dim]Views:[/dim] {doc['access_count']}")
-                console.print("=" * 60 + "\n")
+                if not no_header:
+                    console.print(f"\n[bold cyan]#{doc['id']}:[/bold cyan] [bold]{doc['title']}[/bold]")
+                    console.print("=" * 60)
+                    console.print(f"[dim]Project:[/dim] {doc['project'] or 'None'}")
+                    console.print(f"[dim]Created:[/dim] {doc['created_at'].strftime('%Y-%m-%d %H:%M')}")
+                    console.print(f"[dim]Views:[/dim] {doc['access_count']}")
+                    console.print("=" * 60 + "\n")
                 
                 if raw:
                     console.print(doc['content'])

--- a/emdx/gui.py
+++ b/emdx/gui.py
@@ -151,7 +151,7 @@ def gui():
             preview_cmd = f"{sys.executable} {preview_script_path} {{1}}"
         
         # Simple commands using emdx - made portable for all shells
-        view_cmd = f"{emdx_cmd} view {{1}} < /dev/tty"
+        view_cmd = f"{emdx_cmd} view {{1}} --no-pager < /dev/tty"
         edit_cmd = f"{emdx_cmd} edit {{1}} < /dev/tty"
         # Use Python for the delete confirmation to be shell-agnostic
         delete_cmd = f"{sys.executable} -c \"import sys; print('Delete document {{1}}? (soft delete - can be restored)'); print('Press y to confirm, any other key to cancel: ', end='', flush=True); import termios, tty; fd = sys.stdin.fileno(); old = termios.tcgetattr(fd); try: tty.setraw(fd); ch = sys.stdin.read(1); finally: termios.tcsetattr(fd, termios.TCSADRAIN, old); print(); sys.exit(0 if ch.lower() == 'y' else 1)\" < /dev/tty && {emdx_cmd} delete {{1}} < /dev/tty"

--- a/emdx/gui.py
+++ b/emdx/gui.py
@@ -151,7 +151,12 @@ def gui():
             preview_cmd = f"{sys.executable} {preview_script_path} {{1}}"
         
         # Simple commands using emdx - made portable for all shells
-        view_cmd = f"{emdx_cmd} view {{1}} --no-pager < /dev/tty"
+        # Use mdcat for better markdown viewing
+        if subprocess.run(["which", "mdcat"], capture_output=True).returncode == 0:
+            view_cmd = f"{emdx_cmd} view {{1}} --raw --no-pager --no-header | mdcat --paginate"
+        else:
+            # Fallback to less if mdcat not available
+            view_cmd = f"FORCE_COLOR=1 {emdx_cmd} view {{1}} --no-pager --no-header 2>&1 | less -R"
         edit_cmd = f"{emdx_cmd} edit {{1}} < /dev/tty"
         # Use Python for the delete confirmation to be shell-agnostic
         delete_cmd = f"{sys.executable} -c \"import sys; print('Delete document {{1}}? (soft delete - can be restored)'); print('Press y to confirm, any other key to cancel: ', end='', flush=True); import termios, tty; fd = sys.stdin.fileno(); old = termios.tcgetattr(fd); try: tty.setraw(fd); ch = sys.stdin.read(1); finally: termios.tcsetattr(fd, termios.TCSADRAIN, old); print(); sys.exit(0 if ch.lower() == 'y' else 1)\" < /dev/tty && {emdx_cmd} delete {{1}} < /dev/tty"


### PR DESCRIPTION
## Summary
Enhanced the GUI document viewing experience with cleaner output and better color support.

## Changes
- ✨ Added `--no-header` option to view command to hide metadata
- 🎨 Use mdcat for document viewing in GUI (with fallback to less)
- 🎯 Force color output in console for better terminal compatibility
- 🧹 Remove header clutter when viewing from interactive browser

## Benefits
- Cleaner viewing experience matching the previous mdcat behavior
- Proper color rendering in all environments
- Consistent paging behavior with mdcat when available

## Test plan
- [x] Test GUI viewing with mdcat installed
- [x] Test GUI viewing without mdcat (fallback to less)
- [x] Verify colors are preserved in both cases
- [x] Confirm no header metadata is shown

🤖 Generated with [Claude Code](https://claude.ai/code)