### PR TITLE
fix: Replace bare except clauses with specific exceptions (Issue #422)

### DIFF
--- a/emdx/gist.py
+++ b/emdx/gist.py
@@ -148,12 +148,12 @@ def copy_to_clipboard(text: str) -> bool:
         # macOS
         subprocess.run(["pbcopy"], input=text.encode(), check=True)
         return True
-    except:
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         try:
             # Linux (X11)
             subprocess.run(["xclip", "-selection", "clipboard"], input=text.encode(), check=True)
             return True
-        except:
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
             # Windows or fallback - would need pyperclip
             return False
 

--- a/emdx/nvim_wrapper.py
+++ b/emdx/nvim_wrapper.py
@@ -14,7 +14,7 @@ def save_terminal_state():
     try:
         fd = sys.stdin.fileno()
         return termios.tcgetattr(fd)
-    except:
+    except (OSError, ValueError, termios.error):
         return None
 
 
@@ -24,7 +24,7 @@ def restore_terminal_state(state):
         try:
             fd = sys.stdin.fileno()
             termios.tcsetattr(fd, termios.TCSADRAIN, state)
-        except:
+        except (OSError, ValueError, termios.error):
             pass
 
 


### PR DESCRIPTION
## Summary
- Fixed bare except clauses in nvim_wrapper.py and gist.py
- Replaced with specific exception types as outlined in gameplan #422

## Changes
1. **nvim_wrapper.py** (lines 17 and 27):
   - Changed bare `except:` to `except (OSError, ValueError, termios.error):`
   - These exceptions cover terminal-related errors that may occur when getting/setting terminal attributes

2. **gist.py** (lines 151 and 156):
   - Changed bare `except:` to `except (subprocess.CalledProcessError, FileNotFoundError, OSError):`
   - These exceptions cover subprocess and file system errors that may occur when accessing clipboard commands

## Test Plan
- [x] Code changes are syntactically correct
- [x] Exception types match those specified in the gameplan
- [ ] Tests pass on CI (monitoring build)

🤖 Generated with [Claude Code](https://claude.ai/code)