### PR TITLE
Fix duplicate widget ID error on GUI startup

### DIFF
--- a/emdx/textual_browser_minimal.py
+++ b/emdx/textual_browser_minimal.py
@@ -453,20 +453,6 @@ class MinimalDocumentBrowser(App):
 
     def on_mount(self) -> None:
         try:
-            # ENSURE CLEAN STATE - remove any existing widgets from preview
-            container = self.query_one("#preview", ScrollableContainer)
-            container.remove_children()
-            
-            # Mount a fresh RichLog widget
-            richlog = RichLog(
-                id="preview-content",
-                wrap=True,
-                highlight=True,
-                markup=True,
-                auto_scroll=False
-            )
-            container.mount(richlog)
-            
             self.load_documents()
             self.setup_table()
             self.update_status()
@@ -523,6 +509,13 @@ class MinimalDocumentBrowser(App):
             )
 
         table.focus()
+        
+        # Select the first row to show content in preview
+        if len(self.filtered_docs) > 0:
+            table.move_cursor(row=0)
+            # Manually trigger the first preview update
+            self.current_doc_id = self.filtered_docs[0]["id"]
+            self.update_preview(self.current_doc_id)
 
     def on_row_selected(self):
         table = self.query_one("#doc-table", DataTable)


### PR DESCRIPTION
## Summary
- Fix duplicate widget ID error that prevented GUI from launching
- Remove redundant widget creation from on_mount() method
- GUI now launches successfully without crashing

## Problem
The GUI was failing to start with the error:
```
Error during startup: Tried to insert a widget with ID 'preview-content', but a 
widget RichLog(id='preview-content') already exists with that ID in this list of
children. The children of a widget must have unique IDs.
```

## Root Cause
Recent commits had introduced redundant widget creation in the `on_mount()` method that conflicted with widgets already created in the `compose()` method. The `compose()` method creates the initial widget layout, but `on_mount()` was trying to create another widget with the same ID.

## Solution
- Removed the redundant widget creation code from `on_mount()` 
- Kept the existing widget creation in `compose()` which is the proper place
- Added explicit first row selection to ensure preview content loads

## Test plan
- [x] GUI launches without duplicate widget error
- [x] Basic navigation works (document list displays)
- [x] No regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)