### PR TITLE
Fix critical save command bug causing empty documents

### DIFF
--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -61,10 +61,12 @@ def get_input_content(input_arg: Optional[str]) -> InputContent:
     # Priority 1: Check if stdin has data
     if not sys.stdin.isatty():
         content = sys.stdin.read()
-        return InputContent(content=content, source_type="stdin")
+        if content.strip():  # Only use stdin if it has actual content
+            return InputContent(content=content, source_type="stdin")
+        # Fall through to check input_arg if stdin is empty
 
     # Priority 2: Check if input is provided
-    elif input_arg:
+    if input_arg:
         # Check if it's a file path
         file_path = Path(input_arg)
         if file_path.exists() and file_path.is_file():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 from test_fixtures import TestDatabase
 
-from emdx.tags import add_tags_to_document
+from emdx.models.tags import add_tags_to_document
 
 
 @pytest.fixture

--- a/tests/test_input_content.py
+++ b/tests/test_input_content.py
@@ -1,0 +1,147 @@
+"""Tests for get_input_content function bug fix."""
+
+import io
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from emdx.commands.core import get_input_content, InputContent
+
+
+class TestGetInputContent:
+    """Test the get_input_content function, especially the stdin/file path bug fix."""
+
+    def test_file_path_with_empty_stdin_in_subprocess_context(self):
+        """Test that file paths work when stdin appears available but is empty (like in poetry run)."""
+        # Create a temporary file with content
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as temp_file:
+            temp_file.write("# Test Content\n\nThis should be read from file, not from empty stdin.")
+            temp_file_path = temp_file.name
+
+        try:
+            # Mock subprocess context where stdin.isatty() returns False but stdin is empty
+            empty_stdin = io.StringIO("")
+            
+            with patch('sys.stdin', empty_stdin):
+                with patch('sys.stdin.isatty', return_value=False):
+                    result = get_input_content(temp_file_path)
+            
+            # Should read from file, not empty stdin
+            assert result.source_type == "file"
+            assert "This should be read from file" in result.content
+            assert result.source_path == Path(temp_file_path)
+            
+        finally:
+            # Clean up
+            Path(temp_file_path).unlink()
+
+    def test_stdin_with_actual_content_takes_priority(self):
+        """Test that stdin content is used when it actually contains data."""
+        stdin_content = "# Stdin Content\n\nThis comes from stdin and should take priority."
+        mock_stdin = io.StringIO(stdin_content)
+        
+        with patch('sys.stdin', mock_stdin):
+            with patch('sys.stdin.isatty', return_value=False):
+                result = get_input_content("some_file.md")
+        
+        # Should use stdin content, not file
+        assert result.source_type == "stdin"
+        assert "This comes from stdin" in result.content
+        assert result.source_path is None
+
+    def test_stdin_with_only_whitespace_falls_through_to_file(self):
+        """Test that stdin with only whitespace falls through to file processing."""
+        # Create a temporary file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as temp_file:
+            temp_file.write("# File Content\n\nThis should be used when stdin has only whitespace.")
+            temp_file_path = temp_file.name
+
+        try:
+            # Mock stdin with only whitespace
+            whitespace_stdin = io.StringIO("   \n\t  \n  ")
+            
+            with patch('sys.stdin', whitespace_stdin):
+                with patch('sys.stdin.isatty', return_value=False):
+                    result = get_input_content(temp_file_path)
+            
+            # Should read from file since stdin only has whitespace
+            assert result.source_type == "file"
+            assert "This should be used when stdin" in result.content
+            assert result.source_path == Path(temp_file_path)
+            
+        finally:
+            Path(temp_file_path).unlink()
+
+    def test_interactive_terminal_prioritizes_file_over_stdin(self):
+        """Test that in interactive terminal (tty), file arguments take precedence."""
+        # Create a temporary file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as temp_file:
+            temp_file.write("# File Content\n\nThis should be used in interactive mode.")
+            temp_file_path = temp_file.name
+
+        try:
+            # Mock interactive terminal (stdin.isatty() returns True)
+            with patch('sys.stdin.isatty', return_value=True):
+                result = get_input_content(temp_file_path)
+            
+            # Should read from file in interactive mode
+            assert result.source_type == "file"
+            assert "This should be used in interactive mode" in result.content
+            assert result.source_path == Path(temp_file_path)
+            
+        finally:
+            Path(temp_file_path).unlink()
+
+    def test_nonexistent_file_returns_direct_input(self):
+        """Test that nonexistent file path is treated as direct text input."""
+        with patch('sys.stdin.isatty', return_value=True):
+            result = get_input_content("This is direct text input")
+        
+        assert result.source_type == "direct"
+        assert result.content == "This is direct text input"
+        assert result.source_path is None
+
+    def test_no_input_raises_exit(self):
+        """Test that no input raises typer.Exit."""
+        import typer
+        
+        with patch('sys.stdin.isatty', return_value=True):
+            with pytest.raises(typer.Exit):
+                get_input_content(None)
+
+    def test_regression_poetry_run_context(self):
+        """
+        Regression test for the specific bug: poetry run context with empty stdin.
+        
+        This simulates the exact conditions that caused the bug:
+        - sys.stdin.isatty() returns False (subprocess context)
+        - sys.stdin.read() returns empty string
+        - File path argument provided
+        
+        Before fix: would return empty content from stdin
+        After fix: should fall through to file reading
+        """
+        # Create test file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as temp_file:
+            temp_file.write("# Regression Test\n\nThis content should be saved, not empty string.")
+            temp_file_path = temp_file.name
+
+        try:
+            # Exact conditions from poetry run that caused the bug
+            empty_stdin = io.StringIO("")
+            
+            with patch('sys.stdin', empty_stdin):
+                with patch('sys.stdin.isatty', return_value=False):  # subprocess context
+                    result = get_input_content(temp_file_path)
+            
+            # After fix: should read file content, not empty stdin
+            assert result.source_type == "file"
+            assert len(result.content.strip()) > 0  # Not empty!
+            assert "This content should be saved" in result.content
+            assert result.source_path == Path(temp_file_path)
+            
+        finally:
+            Path(temp_file_path).unlink()


### PR DESCRIPTION
## Summary

Fixes a critical bug where `emdx save /path/to/file.md` produced empty documents while `cat file.md | emdx save` worked correctly.

## Root Cause

The `get_input_content()` function in `emdx/commands/core.py` incorrectly prioritized empty stdin over file arguments when running under `poetry run`. This happened because:

1. `sys.stdin.isatty()` returns `False` in subprocess contexts like `poetry run`
2. Code assumed stdin had content and read empty string
3. Function returned immediately, never reaching file reading logic

## Fix

Modified the logic to only use stdin content if it actually contains data:

```python
if not sys.stdin.isatty():
    content = sys.stdin.read()
    if content.strip():  # Only use stdin if it has actual content
        return InputContent(content=content, source_type="stdin")
    # Fall through to check input_arg if stdin is empty

if input_arg:  # Changed from elif to if to allow fallthrough
```

## Testing

Added comprehensive test suite with 7 test cases:
- ✅ Regression test for exact poetry run bug scenario
- ✅ Empty stdin + file path (main bug case)  
- ✅ Actual stdin content takes priority
- ✅ Whitespace-only stdin falls through to file
- ✅ Interactive vs subprocess contexts
- ✅ Direct text input handling
- ✅ Error handling for no input

## Impact

This fixes the reported issue where ~50% of document saves resulted in empty documents, making EMDX reliable for preserving notes and analyses.

🤖 Generated with [Claude Code](https://claude.ai/code)