### PR TITLE
Fix installation issues and add tag support to save_document

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,18 +174,24 @@ EMDX is a powerful command-line knowledge base and documentation management syst
 
 ### Development Setup
 ```bash
-# Install with poetry (recommended)
-poetry install
+# Install with pipx (recommended for global CLI usage)
+pipx install -e . --python python3.13
 emdx --help
 
-# Or with pip
+# Or with poetry (for development)
+poetry install
+poetry run emdx --help
+
+# Or with pip in a virtual environment
+python3 -m venv venv
+source venv/bin/activate
 pip install -e .
 emdx --help
 
 # Run tests
 pytest
 # or
-pytest
+poetry run pytest
 ```
 
 ### Useful Commands

--- a/emdx/__main__.py
+++ b/emdx/__main__.py
@@ -1,0 +1,5 @@
+"""Entry point for emdx when run as a module."""
+from emdx.main import run
+
+if __name__ == "__main__":
+    run()

--- a/emdx/database/__init__.py
+++ b/emdx/database/__init__.py
@@ -41,8 +41,8 @@ class SQLiteDatabase:
         return self._connection.ensure_schema()
 
     # Document operations - delegate to documents module
-    def save_document(self, title, content, project=None):
-        return save_document(title, content, project)
+    def save_document(self, title, content, project=None, tags=None, parent_id=None):
+        return save_document(title, content, project, tags, parent_id)
 
     def get_document(self, identifier):
         return get_document(identifier)

--- a/emdx/database/documents.py
+++ b/emdx/database/documents.py
@@ -8,19 +8,26 @@ from typing import Any, Optional
 from .connection import db_connection
 
 
-def save_document(title: str, content: str, project: Optional[str] = None) -> int:
+def save_document(title: str, content: str, project: Optional[str] = None, tags: Optional[list[str]] = None, parent_id: Optional[int] = None) -> int:
     """Save a document to the knowledge base"""
     with db_connection.get_connection() as conn:
         cursor = conn.execute(
             """
-            INSERT INTO documents (title, content, project)
-            VALUES (?, ?, ?)
+            INSERT INTO documents (title, content, project, parent_id)
+            VALUES (?, ?, ?, ?)
         """,
-            (title, content, project),
+            (title, content, project, parent_id),
         )
 
         conn.commit()
-        return cursor.lastrowid
+        doc_id = cursor.lastrowid
+        
+        # Add tags if provided
+        if tags:
+            from emdx.models.tags import add_tags_to_document
+            add_tags_to_document(doc_id, tags)
+        
+        return doc_id
 
 
 def get_document(identifier: str) -> Optional[dict[str, Any]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 python = "^3.9"
 typer = {extras = ["all"], version = "^0.9.0"}
 rich = "^13.0.0"
-click = "^8.0.0"
+click = "~8.1.7"
 python-dotenv = "^1.0.0"
 gitpython = "^3.1.0"
 pygments = "^2.0.0"


### PR DESCRIPTION
## Summary
- Fixed emdx command not working due to missing `__main__.py` and version incompatibilities
- Added proper tag support to the database layer
- Updated installation documentation to recommend pipx

## Changes
1. **Added missing `__main__.py`** - Required for proper Python module execution
2. **Fixed click/typer compatibility** - Pinned click to ~8.1.7 to work with typer 0.9.x
3. **Added tag support to save_document** - Database layer now properly handles tags and parent_id parameters
4. **Updated CLAUDE.md** - Added pipx installation instructions as the recommended method

## Test plan
- [x] Tested installation with pipx and Python 3.13
- [x] Verified `emdx save` works with tags
- [x] Confirmed saved documents display correctly with `emdx view`

## Example
```bash
echo "Test note" | emdx save --title "Test" --tags "notes,success"
```

🤖 Generated with [Claude Code](https://claude.ai/code)