### PR TITLE
fix: sort documents by ID descending in browser

### DIFF
--- a/emdx/database/documents.py
+++ b/emdx/database/documents.py
@@ -91,7 +91,7 @@ def list_documents(project: Optional[str] = None, limit: int = 50) -> list[dict[
                 SELECT id, title, project, created_at, access_count
                 FROM documents
                 WHERE project = ? AND is_deleted = FALSE
-                ORDER BY created_at DESC
+                ORDER BY id DESC
                 LIMIT ?
             """,
                 (project, limit),
@@ -102,7 +102,7 @@ def list_documents(project: Optional[str] = None, limit: int = 50) -> list[dict[
                 SELECT id, title, project, created_at, access_count
                 FROM documents
                 WHERE is_deleted = FALSE
-                ORDER BY created_at DESC
+                ORDER BY id DESC
                 LIMIT ?
             """,
                 (limit,),

--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -194,7 +194,7 @@ class DocumentBrowser(Widget):
                     SELECT id, title, project, created_at, accessed_at, access_count
                     FROM documents
                     WHERE is_deleted = 0
-                    ORDER BY accessed_at DESC
+                    ORDER BY id DESC
                 """)
                 self.documents = cursor.fetchall()
                 self.filtered_docs = self.documents


### PR DESCRIPTION
## Summary
- Changed document sorting from accessed_at/created_at to ID descending
- Ensures newest documents (highest IDs) appear first in the browser
- Applied to both document_browser.py and database list_documents function

## Test plan
- [x] Updated document_browser.py ORDER BY clause
- [x] Updated database/documents.py list_documents ORDER BY clause
- [ ] Test TUI browser shows documents in ID descending order
- [ ] Verify document browser widget shows correct ordering

🤖 Generated with [Claude Code](https://claude.ai/code)