### PR TITLE
fix: correct document ordering to show newest documents first

### DIFF
--- a/emdx/database/documents.py
+++ b/emdx/database/documents.py
@@ -91,7 +91,7 @@ def list_documents(project: Optional[str] = None, limit: int = 50) -> list[dict[
                 SELECT id, title, project, created_at, access_count
                 FROM documents
                 WHERE project = ? AND is_deleted = FALSE
-                ORDER BY created_at DESC
+                ORDER BY id DESC
                 LIMIT ?
             """,
                 (project, limit),
@@ -102,7 +102,7 @@ def list_documents(project: Optional[str] = None, limit: int = 50) -> list[dict[
                 SELECT id, title, project, created_at, access_count
                 FROM documents
                 WHERE is_deleted = FALSE
-                ORDER BY created_at DESC
+                ORDER BY id DESC
                 LIMIT ?
             """,
                 (limit,),

--- a/emdx/database/search.py
+++ b/emdx/database/search.py
@@ -82,9 +82,9 @@ def search_documents(
         if conditions:
             base_query += " AND " + " AND ".join(conditions)
         
-        # Order by rank for text searches, by date for date-only searches
+        # Order by rank for text searches, by id for date-only searches
         if query == "*":
-            base_query += " ORDER BY d.created_at DESC LIMIT ?"
+            base_query += " ORDER BY d.id DESC LIMIT ?"
         else:
             base_query += " ORDER BY rank LIMIT ?"
         params.append(limit)

--- a/emdx/models/tags.py
+++ b/emdx/models/tags.py
@@ -248,7 +248,7 @@ def search_by_tags(
             query += " AND d.project = ?"
             params.append(project)
 
-        query += " GROUP BY d.id ORDER BY d.created_at DESC LIMIT ?"
+        query += " GROUP BY d.id ORDER BY d.id DESC LIMIT ?"
         params.append(limit)
 
         cursor = conn.execute(query, params)

--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -297,7 +297,7 @@ class DocumentBrowser(Widget):
                     SELECT id, title, project, created_at, accessed_at, access_count
                     FROM documents
                     WHERE is_deleted = 0
-                    ORDER BY accessed_at DESC
+                    ORDER BY id DESC
                 """)
                 self.documents = cursor.fetchall()
                 self.filtered_docs = self.documents


### PR DESCRIPTION
## Summary
- Fixed document ordering across all EMDX interfaces to show newest documents (highest IDs) first
- Changed ORDER BY clauses from created_at/accessed_at DESC to id DESC in 4 key locations
- Ensures consistent newest-first ordering in TUI browser, CLI list, tag search, and general search

## Test plan
- [ ] Test TUI browser shows newest documents at top
- [ ] Test CLI `emdx list` shows newest documents first  
- [ ] Test tag-based searches show newest matching documents first
- [ ] Test general searches with wildcard show newest documents first

🤖 Generated with [Claude Code](https://claude.ai/code)