### PR TITLE
feat: enhance document browser table with tags column and improved layout

### DIFF
--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -237,9 +237,13 @@ class DocumentBrowser(Widget):
         
         # Setup table
         table = self.query_one("#doc-table", DataTable)
-        table.add_columns("ID", "Title")
+        table.add_column("ID", width=4)
+        table.add_column("Tags", width=8)  
+        table.add_column(" ", width=1)  # Padding column
+        table.add_column("Title", width=38)
         table.cursor_type = "row"
         table.show_header = True
+        table.cell_padding = 0  # Remove cell padding for tight spacing
         
         # Disable focus on non-interactive widgets
         preview_content = self.query_one("#preview-content")
@@ -314,11 +318,19 @@ class DocumentBrowser(Widget):
         table.clear()
         
         for doc in self.filtered_docs:
-            # Format row data - simplified to just ID and Title
-            title = truncate_emoji_safe(doc["title"], 60)  # Longer title since we have more space
+            # Format row data - ID, Tags, and Title
+            title, was_truncated = truncate_emoji_safe(doc["title"], 40)
+            if was_truncated:
+                title += "..."
+            
+            # Get first 3 tags as emojis with spaces between, pad to 5 chars
+            doc_tags = get_document_tags(doc["id"])
+            tags_display = " ".join(doc_tags[:3]).ljust(8)  # Pad to exactly 8 chars
             
             table.add_row(
                 str(doc["id"]),
+                tags_display,
+                "",  # Empty padding column
                 title,
             )
             


### PR DESCRIPTION
## Summary
- Added Tags column between ID and Title displaying first 3 emoji tags with spaces
- Optimized table layout with precise column widths for better visual hierarchy
- Fixed title truncation bug (tuple unpacking issue)
- Set zero cell padding for tight, professional spacing

## Layout Changes
- **ID**: 4 characters wide
- **Tags**: 8 characters wide (accommodates 3 emojis + 2 spaces)  
- **Padding**: 1 character separator
- **Title**: 38 characters wide with proper truncation

## Test plan
- [ ] Test TUI browser shows tags correctly for documents with 0-3 tags
- [ ] Verify column spacing looks clean and professional
- [ ] Test title truncation works properly with "..." suffix
- [ ] Verify emoji tags display correctly in terminal

🤖 Generated with [Claude Code](https://claude.ai/code)