### PR TITLE
fix: initialize status bar with document count and build ID on startup

### DIFF
--- a/emdx/ui/browser_container.py
+++ b/emdx/ui/browser_container.py
@@ -59,8 +59,8 @@ class BrowserContainer(App):
         
         # Browser will have parent reference automatically after mounting
         
-        # Update status
-        self.update_status("Document Browser | f=files | d=git | q=quit")
+        # Don't set a default status - let the browser update it once it loads
+        # The DocumentBrowser will call update_status() from its update_table() method
         
     def update_status(self, text: str) -> None:
         """Update the status bar."""

--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -341,7 +341,7 @@ class DocumentBrowser(Widget):
             if hasattr(app, 'update_status'):
                 status_text = f"{len(self.filtered_docs)}/{len(self.documents)} docs"
                 if self.mode == "NORMAL":
-                    status_text += " | e=edit | /=search | t=tag | q=quit"
+                    status_text += " | e=edit | /=search | t=tag | f=files | d=git | q=quit"
                 elif self.mode == "SEARCH":
                     status_text += " | Enter=apply | ESC=cancel"
                 status_text += f" | {BUILD_ID}"


### PR DESCRIPTION
## Summary
- Fixes status bar initialization bug where document count and build ID weren't showing until a tag operation was performed
- Ensures the status bar displays proper information immediately when the TUI browser loads

## Changes
- Removed default status message from `BrowserContainer` initialization
- Let `DocumentBrowser` update the status bar from its `update_table()` method
- Added all available keyboard shortcuts (including f=files, d=git) to the status bar

## Test plan
- [x] Launch EMDX TUI browser (`emdx gui`)
- [x] Verify status bar shows document count and build ID immediately
- [x] Verify all keyboard shortcuts are displayed in the status bar
- [x] Confirm status bar updates correctly during operations (search, tag, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)