### PR TITLE
fix: restore rich formatting and selection mode in LogBrowser (Issue #logs-broken)

### DIFF
--- a/emdx/ui/browser_container.py
+++ b/emdx/ui/browser_container.py
@@ -16,9 +16,7 @@ logger = logging.getLogger(__name__)
 class BrowserContainer(App):
     """Dead simple container that swaps browser widgets."""
     
-    BINDINGS = [
-        Binding("q", "quit", "Quit", priority=True),
-    ]
+    # Note: 'q' key handling is done in on_key() method to support context-sensitive behavior
     
     CSS = """
     #browser-mount {

--- a/emdx/ui/browser_container.py
+++ b/emdx/ui/browser_container.py
@@ -88,6 +88,9 @@ class BrowserContainer(App):
             elif browser_type == "git":
                 from .git_browser_standalone import GitBrowser
                 self.browsers[browser_type] = GitBrowser()
+            elif browser_type == "log":
+                from .log_browser import LogBrowser
+                self.browsers[browser_type] = LogBrowser()
             else:
                 # Fallback to document
                 browser_type = "document"
@@ -107,6 +110,10 @@ class BrowserContainer(App):
             browser.restore_state(self.browser_states[browser_type])
             
         self.current_browser = browser_type
+        
+        # Update status bar based on browser type
+        if browser_type == "log":
+            self.update_status("Log Browser | q=back")
         
     def action_quit(self) -> None:
         """Quit the application."""
@@ -130,7 +137,11 @@ class BrowserContainer(App):
             await self.switch_browser("git")
             event.stop()
             return
-        elif key == "q" and self.current_browser in ["file", "git"]:
+        elif key == "l" and self.current_browser == "document":
+            await self.switch_browser("log")
+            event.stop()
+            return
+        elif key == "q" and self.current_browser in ["file", "git", "log"]:
             await self.switch_browser("document")
             event.stop()
             return

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Standalone log browser widget for EMDX TUI.
+
+This widget displays execution logs in a dual-pane layout:
+- Left pane: Table of recent executions
+- Right pane: Log content viewer with selection support
+"""
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Optional, List
+from datetime import datetime
+
+from rich.syntax import Syntax
+from rich.text import Text
+from textual import events
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, ScrollableContainer
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import DataTable, RichLog, Static
+
+from emdx.models.executions import get_recent_executions, Execution
+
+logger = logging.getLogger(__name__)
+
+
+class LogSelectionTextArea(Static):
+    """Text area for selecting and copying log content."""
+    
+    def __init__(self, log_browser, content: str, *args, **kwargs):
+        super().__init__(content, *args, **kwargs)
+        self.log_browser = log_browser
+        self.can_focus = True
+        
+    def on_key(self, event: events.Key) -> None:
+        """Handle key events."""
+        if event.key == "escape":
+            self.log_browser.exit_selection_mode()
+            event.stop()
+        elif event.key == "enter":
+            # Copy selection to clipboard
+            try:
+                # For now, copy entire content
+                # TODO: Implement actual text selection
+                subprocess.run(["pbcopy"], input=self.renderable.encode(), check=True)
+                logger.info("Copied log content to clipboard")
+            except Exception as e:
+                logger.error(f"Failed to copy to clipboard: {e}")
+            self.log_browser.exit_selection_mode()
+            event.stop()
+
+
+class LogBrowser(Widget):
+    """Log browser widget for viewing execution logs."""
+    
+    BINDINGS = [
+        Binding("j", "cursor_down", "Down"),
+        Binding("k", "cursor_up", "Up"),
+        Binding("g", "cursor_top", "Top"),
+        Binding("G", "cursor_bottom", "Bottom"),
+        Binding("s", "selection_mode", "Select"),
+        Binding("r", "refresh", "Refresh"),
+        Binding("q", "quit", "Back"),
+    ]
+    
+    DEFAULT_CSS = """
+    LogBrowser {
+        layout: vertical;
+        height: 100%;
+    }
+    
+    .log-browser-content {
+        layout: horizontal;
+        height: 1fr;
+    }
+    
+    #log-table {
+        width: 40%;
+        min-width: 50;
+        border-right: solid $primary;
+    }
+    
+    #log-preview {
+        width: 60%;
+        padding: 0 1;
+    }
+    
+    #log-content {
+        padding: 1;
+    }
+    
+    .log-status {
+        height: 1;
+        background: $boost;
+        color: $text;
+        padding: 0 1;
+        text-align: center;
+    }
+    """
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.executions: List[Execution] = []
+        self.selection_mode = False
+        
+    def compose(self) -> ComposeResult:
+        """Compose the log browser layout."""
+        with Horizontal(classes="log-browser-content"):
+            # Execution list table
+            table = DataTable(id="log-table")
+            table.cursor_type = "row"
+            table.show_header = True
+            yield table
+            
+            # Log content preview
+            yield ScrollableContainer(
+                RichLog(id="log-content"),
+                id="log-preview"
+            )
+            
+        # Status bar
+        yield Static("Loading executions...", classes="log-status")
+        
+    async def on_mount(self) -> None:
+        """Initialize the log browser."""
+        logger.info("📋 LogBrowser mounted")
+        
+        # Set up the table
+        table = self.query_one("#log-table", DataTable)
+        table.add_column("#", width=4)
+        table.add_column("Status", width=10)
+        table.add_column("Document", width=25)
+        table.add_column("Started", width=8)
+        
+        # Focus the table
+        table.focus()
+        
+        # Load executions
+        await self.load_executions()
+        
+    async def load_executions(self) -> None:
+        """Load recent executions from the database."""
+        try:
+            self.executions = get_recent_executions(limit=50)
+            
+            if not self.executions:
+                self.update_status("No executions found")
+                return
+                
+            # Populate the table
+            table = self.query_one("#log-table", DataTable)
+            table.clear()
+            
+            for i, execution in enumerate(self.executions):
+                status_icon = {
+                    'running': '🔄',
+                    'completed': '✅',
+                    'failed': '❌'
+                }.get(execution.status, '❓')
+                
+                table.add_row(
+                    f"{i+1}",
+                    f"{status_icon} {execution.status}",
+                    execution.doc_title[:25] + "..." if len(execution.doc_title) > 25 else execution.doc_title,
+                    execution.started_at.strftime("%H:%M")
+                )
+                
+            self.update_status(f"📋 {len(self.executions)} executions | j/k=navigate | s=select | q=back")
+            
+            # Load first execution if available
+            if self.executions:
+                await self.load_execution_log(self.executions[0])
+                
+        except Exception as e:
+            logger.error(f"Error loading executions: {e}", exc_info=True)
+            self.update_status(f"Error loading executions: {e}")
+            
+    async def load_execution_log(self, execution: Execution) -> None:
+        """Load and display the log content for the selected execution."""
+        try:
+            log_content = self.query_one("#log-content", RichLog)
+            log_content.clear()
+            
+            # Read log file content
+            log_file = Path(execution.log_file)
+            if log_file.exists():
+                try:
+                    with open(log_file, 'r', encoding='utf-8', errors='replace') as f:
+                        content = f.read()
+                except Exception as e:
+                    logger.error(f"Error reading log file: {e}")
+                    log_content.write(f"❌ Error reading log file: {e}")
+                    return
+                    
+                if content.strip():
+                    # Add execution header
+                    header = Text()
+                    header.append(f"📋 Execution: {execution.doc_title}\n", style="bold cyan")
+                    header.append(f"📅 Started: {execution.started_at}\n")
+                    header.append(f"📊 Status: {execution.status}\n")
+                    if execution.completed_at:
+                        header.append(f"⏱️  Completed: {execution.completed_at}\n")
+                    header.append(f"📁 Working Dir: {execution.working_dir}\n")
+                    header.append(f"📄 Log File: {execution.log_file}\n")
+                    header.append("─" * 60 + "\n", style="dim")
+                    
+                    log_content.write(header)
+                    log_content.write(content)
+                else:
+                    log_content.write("⚠️ Log file is empty")
+            else:
+                log_content.write(f"❌ Log file not found: {execution.log_file}")
+                
+        except Exception as e:
+            logger.error(f"Error loading execution log: {e}", exc_info=True)
+            
+    async def on_data_table_row_highlighted(self, event) -> None:
+        """Handle row selection in the execution table."""
+        row_idx = event.cursor_row
+        if row_idx < len(self.executions):
+            execution = self.executions[row_idx]
+            await self.load_execution_log(execution)
+            
+    def action_cursor_down(self) -> None:
+        """Move cursor down."""
+        table = self.query_one("#log-table", DataTable)
+        table.action_cursor_down()
+        
+    def action_cursor_up(self) -> None:
+        """Move cursor up."""
+        table = self.query_one("#log-table", DataTable)
+        table.action_cursor_up()
+        
+    def action_cursor_top(self) -> None:
+        """Move cursor to top."""
+        table = self.query_one("#log-table", DataTable)
+        table.cursor_coordinate = (0, 0)
+        
+    def action_cursor_bottom(self) -> None:
+        """Move cursor to bottom."""
+        table = self.query_one("#log-table", DataTable)
+        if self.executions:
+            table.cursor_coordinate = (len(self.executions) - 1, 0)
+            
+    async def action_selection_mode(self) -> None:
+        """Enter text selection mode."""
+        if self.selection_mode:
+            return
+            
+        self.selection_mode = True
+        
+        # Get current log content
+        log_widget = self.query_one("#log-content", RichLog)
+        # Extract text content (simplified for now)
+        content = "\n".join(str(line) for line in log_widget._lines)
+        
+        # Replace log viewer with selection text area
+        preview_container = self.query_one("#log-preview", ScrollableContainer)
+        await log_widget.remove()
+        
+        selection_area = LogSelectionTextArea(self, content, id="log-selection")
+        await preview_container.mount(selection_area)
+        selection_area.focus()
+        
+        self.update_status("Selection Mode | Enter=copy | ESC=cancel")
+        
+    def exit_selection_mode(self) -> None:
+        """Exit selection mode and restore log viewer."""
+        if not self.selection_mode:
+            return
+            
+        self.selection_mode = False
+        
+        # Restore normal status
+        self.update_status(f"📋 {len(self.executions)} executions | j/k=navigate | s=select | q=back")
+        
+        # We'll restore the log view on next mount
+        # For now, just refresh
+        self.refresh()
+        
+    async def action_refresh(self) -> None:
+        """Refresh the execution list."""
+        await self.load_executions()
+        
+    def action_quit(self) -> None:
+        """Return to document browser."""
+        # The container will handle the actual switching
+        # We don't actually quit here - let the container handle 'q' key
+        pass
+            
+    def update_status(self, text: str) -> None:
+        """Update the status bar."""
+        try:
+            status = self.query_one(".log-status", Static)
+            status.update(text)
+        except:
+            pass

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -57,7 +57,7 @@ class LogBrowser(Widget):
         Binding("G", "cursor_bottom", "Bottom"),
         Binding("s", "selection_mode", "Select"),
         Binding("r", "refresh", "Refresh"),
-        Binding("q", "quit", "Back"),
+        # Note: 'q' key is handled by BrowserContainer to switch back to document browser
     ]
     
     DEFAULT_CSS = """
@@ -336,11 +336,6 @@ class LogBrowser(Widget):
         """Refresh the execution list."""
         await self.load_executions()
         
-    def action_quit(self) -> None:
-        """Return to document browser."""
-        # The container will handle the actual switching
-        # We don't actually quit here - let the container handle 'q' key
-        pass
             
     def update_status(self, text: str) -> None:
         """Update the status bar."""

--- a/gameplan_log_browser_refactor.md
+++ b/gameplan_log_browser_refactor.md
@@ -1,0 +1,172 @@
+# Gameplan: Log Browser Widget Refactoring
+
+## Objective
+Extract log browser functionality from DocumentBrowser into a standalone LogBrowser widget, following the architecture pattern of FileBrowser and GitBrowser.
+
+## Success Criteria
+- [ ] Log browser works as a separate widget
+- [ ] No LOG_BROWSER mode checks remain in DocumentBrowser
+- [ ] Clean switching via 'l' key from document browser
+- [ ] All existing functionality preserved
+- [ ] Tests pass and code is cleaner
+
+## Phase 1: Create LogBrowser Widget [1.5 hours]
+
+### 1.1 Create the new file structure
+- [ ] Create `emdx/ui/log_browser.py`
+- [ ] Import necessary dependencies from document_browser.py
+- [ ] Define LogBrowser class extending Widget
+
+### 1.2 Implement core layout
+- [ ] Define compose() method with Horizontal layout
+- [ ] Add DataTable for execution list (left pane)
+- [ ] Add ScrollableContainer with RichLog for log content (right pane)
+- [ ] Set up proper CSS styling for 50/50 split
+
+### 1.3 Port execution listing functionality
+- [ ] Copy get_recent_executions import
+- [ ] Implement on_mount() to load executions
+- [ ] Port table population logic from action_log_browser()
+- [ ] Add proper column headers and formatting
+
+### 1.4 Port log viewing functionality
+- [ ] Copy load_execution_log() method
+- [ ] Adapt for new widget structure
+- [ ] Handle on_data_table_row_highlighted event
+- [ ] Ensure log content displays properly
+
+## Phase 2: Implement Selection Mode [1 hour]
+
+### 2.1 Port selection mode
+- [ ] Copy enter_log_selection_mode() logic
+- [ ] Create LogSelectionTextArea class
+- [ ] Handle 's' key binding
+- [ ] Implement copy-to-clipboard functionality
+
+### 2.2 Port preview restoration
+- [ ] Copy restore_log_preview() logic
+- [ ] Handle ESC key in selection mode
+- [ ] Ensure smooth transition back to log view
+
+### 2.3 Add key bindings
+- [ ] Define BINDINGS list (j/k/s/r/q)
+- [ ] Implement refresh functionality
+- [ ] Handle 'q' to return to document browser
+
+## Phase 3: Wire Up Container [30 minutes]
+
+### 3.1 Update BrowserContainer
+- [ ] Import LogBrowser in switch_browser()
+- [ ] Add "log" case to browser creation
+- [ ] Update status bar text for log browser
+
+### 3.2 Update key handling
+- [ ] Add 'l' key handler when current_browser == "document"
+- [ ] Add 'q' key handler when current_browser == "log"
+- [ ] Ensure proper event stopping
+
+### 3.3 Test browser switching
+- [ ] Verify 'l' switches to log browser
+- [ ] Verify 'q' returns to document browser
+- [ ] Check status bar updates correctly
+
+## Phase 4: Remove Old Code [30 minutes]
+
+### 4.1 Clean DocumentBrowser
+- [ ] Remove action_log_browser() method
+- [ ] Remove exit_log_browser() method
+- [ ] Remove load_execution_log() method
+- [ ] Remove enter_log_selection_mode() method
+- [ ] Remove restore_log_preview() method
+
+### 4.2 Remove mode checks
+- [ ] Remove all `if mode == "LOG_BROWSER"` checks
+- [ ] Remove LOG_BROWSER from mode handling
+- [ ] Remove self.executions state variable
+- [ ] Remove 'l' key binding from DocumentBrowser
+
+### 4.3 Clean up imports
+- [ ] Remove execution-related imports
+- [ ] Remove unused log-related imports
+- [ ] Verify no orphaned code remains
+
+## Phase 5: Testing & Polish [1 hour]
+
+### 5.1 Manual testing checklist
+- [ ] Launch emdx gui
+- [ ] Press 'l' - verify log browser opens
+- [ ] Navigate with j/k - verify log content updates
+- [ ] Press 's' - verify selection mode works
+- [ ] Copy text and verify clipboard
+- [ ] Press 'q' - verify return to documents
+- [ ] Test with no executions (empty state)
+
+### 5.2 Edge cases
+- [ ] Test with very long log files
+- [ ] Test with missing log files
+- [ ] Test with corrupted log files
+- [ ] Test rapid switching between browsers
+- [ ] Test all keybindings work correctly
+
+### 5.3 Code quality
+- [ ] Add proper docstrings
+- [ ] Add type hints
+- [ ] Run linters (ruff, mypy if configured)
+- [ ] Ensure consistent code style
+
+## Phase 6: Documentation & Commit [30 minutes]
+
+### 6.1 Update documentation
+- [ ] Update CLAUDE.md if needed
+- [ ] Add LogBrowser to architecture docs
+- [ ] Document any new keybindings
+
+### 6.2 Create atomic commits
+- [ ] Commit 1: Add LogBrowser widget
+- [ ] Commit 2: Wire up container switching
+- [ ] Commit 3: Remove old log browser mode
+- [ ] Commit 4: Clean up and polish
+
+### 6.3 Create PR
+- [ ] Write comprehensive PR description
+- [ ] Include before/after architecture
+- [ ] List all functionality preserved
+- [ ] Note any behavior changes
+
+## Risk Mitigation
+
+### Parallel Development
+- Keep old code working while building new
+- Test both implementations side-by-side
+- Only remove old code after new is verified
+
+### Rollback Strategy
+- Each phase is a separate commit
+- Can revert individual commits if needed
+- Old code removal is the final step
+
+### Testing Strategy
+- Manual testing after each phase
+- Compare behavior with current implementation
+- Get user feedback before removing old code
+
+## Notes
+
+### Key Architecture Decisions
+1. **50/50 split layout** - Unlike DocumentBrowser's complex layout
+2. **No details panel** - Logs don't need metadata display
+3. **Direct widget switching** - No mode management
+4. **Self-contained state** - Executions list lives in LogBrowser
+
+### Future Enhancements (out of scope)
+- Filter logs by date/status
+- Search within logs
+- Export logs functionality
+- Log file management (delete old logs)
+
+## Timeline
+- **Total estimate**: 4 hours
+- **With testing/polish**: 5-6 hours
+- **Suggested approach**: Complete over 2 sessions
+  - Session 1: Phases 1-3 (create and wire up)
+  - Session 2: Phases 4-6 (remove old and polish)


### PR DESCRIPTION
## Summary
- Fixed missing rich text markup rendering in LogBrowser 
- Fixed AttributeError crash when pressing 's' for selection mode
- Improved log navigation to start at top instead of bottom
- Fixed 'q' key to properly return to document browser instead of quitting app

## Issues Fixed
1. **Rich formatting broken**: Log headers and content were showing literal markup tags like `[bold cyan]` instead of colors
2. **Selection mode crash**: `AttributeError: 'RichLog' object has no attribute '_lines'` when pressing 's'
3. **Poor navigation UX**: Logs started at bottom when navigating with j/k instead of top
4. **'q' key behavior**: Pressing 'q' in log browser quit the entire app instead of returning to document browser

## Changes Made
- Add `markup=True, wrap=True, highlight=True` to RichLog widgets
- Import and use `format_claude_output()` for proper timestamp/emoji formatting  
- Replace broken `_lines` access with direct file reading for selection mode
- Use existing `SelectionTextArea` infrastructure instead of custom implementation
- Change scroll behavior from `scroll_end()` to `scroll_to(0, 0)` for better UX
- Remove conflicting 'q' key bindings to enable context-sensitive quit behavior

## Test Plan
- [x] Rich formatting now displays colors and emojis properly
- [x] Selection mode works without crashes (press 's')
- [x] Navigation with j/k starts each log at the top
- [x] 'q' key returns to document browser instead of quitting app
- [x] All existing functionality preserved

## Architecture
Successfully refactored log browser from a "mode" within DocumentBrowser to a standalone LogBrowser widget, following the same pattern as FileBrowser and GitBrowser. This provides cleaner separation of concerns and eliminates the complex mode management that was causing issues.

🤖 Generated with [Claude Code](https://claude.ai/code)