### PR TITLE
feat: improve log browser layout and fix crashes (Issue #774)

### DIFF
--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -72,7 +72,7 @@ class LogBrowser(Widget):
     }
     
     #log-sidebar {
-        width: 1fr;
+        width: 2fr;
         min-width: 50;
         height: 100%;
         layout: vertical;
@@ -93,7 +93,7 @@ class LogBrowser(Widget):
     }
     
     #log-preview-container {
-        width: 2fr;
+        width: 1fr;
         min-width: 40;
         padding: 0 1;
     }
@@ -119,10 +119,10 @@ class LogBrowser(Widget):
     def compose(self) -> ComposeResult:
         """Compose the log browser layout."""
         with Horizontal(classes="log-browser-content"):
-            # Left sidebar (1/3 width) - contains table + details
+            # Left sidebar (2/3 width) - contains table + details
             with Vertical(id="log-sidebar") as sidebar:
                 # Apply direct styles for precise control
-                sidebar.styles.width = "1fr"
+                sidebar.styles.width = "2fr"
                 sidebar.styles.min_width = 50
                 sidebar.styles.height = "100%"
                 
@@ -151,9 +151,9 @@ class LogBrowser(Widget):
                         auto_scroll=False
                     )
             
-            # Right preview panel (2/3 width) - now takes more space
+            # Right preview panel (1/3 width) - matches document browser
             with Vertical(id="log-preview-container") as preview_container:
-                preview_container.styles.width = "2fr"
+                preview_container.styles.width = "1fr"
                 preview_container.styles.min_width = 40
                 preview_container.styles.padding = (0, 1)
                 
@@ -172,8 +172,8 @@ class LogBrowser(Widget):
         # Set up the table
         table = self.query_one("#log-table", DataTable)
         table.add_column("#", width=4)
-        table.add_column("Status", width=10)
-        table.add_column("Document", width=30)
+        table.add_column("Status", width=3)
+        table.add_column("Document", width=40)
         
         # Focus the table
         table.focus()
@@ -203,7 +203,7 @@ class LogBrowser(Widget):
                 
                 table.add_row(
                     f"{i+1}",
-                    f"{status_icon} {execution.status}",
+                    status_icon,
                     execution.doc_title[:30] + "..." if len(execution.doc_title) > 30 else execution.doc_title
                 )
                 

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -72,7 +72,7 @@ class LogBrowser(Widget):
     }
     
     #log-sidebar {
-        width: 2fr;
+        width: 1fr;
         min-width: 50;
         height: 100%;
         layout: vertical;
@@ -93,7 +93,7 @@ class LogBrowser(Widget):
     }
     
     #log-preview-container {
-        width: 1fr;
+        width: 2fr;
         min-width: 40;
         padding: 0 1;
     }
@@ -119,10 +119,10 @@ class LogBrowser(Widget):
     def compose(self) -> ComposeResult:
         """Compose the log browser layout."""
         with Horizontal(classes="log-browser-content"):
-            # Left sidebar (2/3 width) - contains table + details
+            # Left sidebar (1/3 width) - contains table + details
             with Vertical(id="log-sidebar") as sidebar:
                 # Apply direct styles for precise control
-                sidebar.styles.width = "2fr"
+                sidebar.styles.width = "1fr"
                 sidebar.styles.min_width = 50
                 sidebar.styles.height = "100%"
                 
@@ -151,9 +151,9 @@ class LogBrowser(Widget):
                         auto_scroll=False
                     )
             
-            # Right preview panel (1/3 width) - matches document browser
+            # Right preview panel (2/3 width) - matches document browser
             with Vertical(id="log-preview-container") as preview_container:
-                preview_container.styles.width = "1fr"
+                preview_container.styles.width = "2fr"
                 preview_container.styles.min_width = 40
                 preview_container.styles.padding = (0, 1)
                 

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -19,7 +19,7 @@ from rich.text import Text
 from textual import events
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal, ScrollableContainer
+from textual.containers import Horizontal, ScrollableContainer, Vertical
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import DataTable, RichLog, Static
@@ -148,8 +148,7 @@ class LogBrowser(Widget):
                         id="log-details",
                         wrap=True,
                         markup=True,
-                        auto_scroll=False,
-                        can_focus=False
+                        auto_scroll=False
                     )
             
             # Right preview panel (1/3 width) - unchanged functionality

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -72,7 +72,7 @@ class LogBrowser(Widget):
     }
     
     #log-sidebar {
-        width: 2fr;
+        width: 1fr;
         min-width: 50;
         height: 100%;
         layout: vertical;
@@ -93,7 +93,7 @@ class LogBrowser(Widget):
     }
     
     #log-preview-container {
-        width: 1fr;
+        width: 2fr;
         min-width: 40;
         padding: 0 1;
     }
@@ -119,10 +119,10 @@ class LogBrowser(Widget):
     def compose(self) -> ComposeResult:
         """Compose the log browser layout."""
         with Horizontal(classes="log-browser-content"):
-            # Left sidebar (2/3 width) - contains table + details
+            # Left sidebar (1/3 width) - contains table + details
             with Vertical(id="log-sidebar") as sidebar:
                 # Apply direct styles for precise control
-                sidebar.styles.width = "2fr"
+                sidebar.styles.width = "1fr"
                 sidebar.styles.min_width = 50
                 sidebar.styles.height = "100%"
                 
@@ -151,9 +151,9 @@ class LogBrowser(Widget):
                         auto_scroll=False
                     )
             
-            # Right preview panel (1/3 width) - unchanged functionality
+            # Right preview panel (2/3 width) - now takes more space
             with Vertical(id="log-preview-container") as preview_container:
-                preview_container.styles.width = "1fr"
+                preview_container.styles.width = "2fr"
                 preview_container.styles.min_width = 40
                 preview_container.styles.padding = (0, 1)
                 

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -173,8 +173,7 @@ class LogBrowser(Widget):
         table = self.query_one("#log-table", DataTable)
         table.add_column("#", width=4)
         table.add_column("Status", width=10)
-        table.add_column("Document", width=25)
-        table.add_column("Started", width=8)
+        table.add_column("Document", width=30)
         
         # Focus the table
         table.focus()
@@ -205,8 +204,7 @@ class LogBrowser(Widget):
                 table.add_row(
                     f"{i+1}",
                     f"{status_icon} {execution.status}",
-                    execution.doc_title[:25] + "..." if len(execution.doc_title) > 25 else execution.doc_title,
-                    execution.started_at.strftime("%H:%M")
+                    execution.doc_title[:30] + "..." if len(execution.doc_title) > 30 else execution.doc_title
                 )
                 
             self.update_status(f"📋 {len(self.executions)} executions | j/k=navigate | s=select | q=back")

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -72,7 +72,7 @@ class LogBrowser(Widget):
     }
     
     #log-sidebar {
-        width: 1fr;
+        width: 2fr;
         min-width: 50;
         height: 100%;
         layout: vertical;
@@ -93,7 +93,7 @@ class LogBrowser(Widget):
     }
     
     #log-preview-container {
-        width: 2fr;
+        width: 1fr;
         min-width: 40;
         padding: 0 1;
     }
@@ -119,10 +119,10 @@ class LogBrowser(Widget):
     def compose(self) -> ComposeResult:
         """Compose the log browser layout."""
         with Horizontal(classes="log-browser-content"):
-            # Left sidebar (1/3 width) - contains table + details
+            # Left sidebar (2/3 width) - contains table + details
             with Vertical(id="log-sidebar") as sidebar:
                 # Apply direct styles for precise control
-                sidebar.styles.width = "1fr"
+                sidebar.styles.width = "2fr"
                 sidebar.styles.min_width = 50
                 sidebar.styles.height = "100%"
                 
@@ -151,9 +151,9 @@ class LogBrowser(Widget):
                         auto_scroll=False
                     )
             
-            # Right preview panel (2/3 width) - matches document browser
+            # Right preview panel (1/3 width) - matches document browser
             with Vertical(id="log-preview-container") as preview_container:
-                preview_container.styles.width = "2fr"
+                preview_container.styles.width = "1fr"
                 preview_container.styles.min_width = 40
                 preview_container.styles.padding = (0, 1)
                 

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -72,7 +72,7 @@ class LogBrowser(Widget):
     }
     
     #log-sidebar {
-        width: 2fr;
+        width: 1fr;
         min-width: 50;
         height: 100%;
         layout: vertical;
@@ -119,10 +119,10 @@ class LogBrowser(Widget):
     def compose(self) -> ComposeResult:
         """Compose the log browser layout."""
         with Horizontal(classes="log-browser-content"):
-            # Left sidebar (2/3 width) - contains table + details
+            # Left sidebar (50% width) - contains table + details
             with Vertical(id="log-sidebar") as sidebar:
                 # Apply direct styles for precise control
-                sidebar.styles.width = "2fr"
+                sidebar.styles.width = "1fr"
                 sidebar.styles.min_width = 50
                 sidebar.styles.height = "100%"
                 
@@ -151,7 +151,7 @@ class LogBrowser(Widget):
                         auto_scroll=False
                     )
             
-            # Right preview panel (1/3 width) - matches document browser
+            # Right preview panel (50% width) - equal split
             with Vertical(id="log-preview-container") as preview_container:
                 preview_container.styles.width = "1fr"
                 preview_container.styles.min_width = 40


### PR DESCRIPTION
## Summary
- Fixed crashes in log browser due to missing imports and invalid parameters
- Implemented consistent 50/50 split layout between table/details and preview panels
- Simplified status column to show only emojis (🔄/✅/❌)
- Removed confusing truncated "Started" time column
- Added execution metadata panel with 2/3-1/3 vertical split in left sidebar

## Test Plan
- [ ] Run `emdx gui` and press 'l' to open log browser
- [ ] Verify no crashes occur when opening log browser
- [ ] Confirm 50/50 horizontal split between left sidebar and right preview
- [ ] Check that status column shows only emojis without text
- [ ] Verify execution metadata appears in bottom 1/3 of left sidebar
- [ ] Test navigation with j/k keys works correctly
- [ ] Confirm selection mode (s key) still functions

## Changes Made
1. Added missing `Vertical` import from textual.containers
2. Removed unsupported `can_focus` parameter from RichLog widget
3. Implemented 2/3-1/3 vertical split in left sidebar for table and details
4. Set horizontal split to 50/50 (1fr-1fr) for consistent layout
5. Simplified status display to show only emojis
6. Removed truncated "Started" column that was showing partial time values

🤖 Generated with [Claude Code](https://claude.ai/code)