### PR TITLE
feat: improve log browser UI and layout (Issue #774)

### DIFF
--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -201,7 +201,7 @@ class LogBrowser(Widget):
                 }.get(execution.status, '❓')
                 
                 # Format title with ID prefix
-                title_with_id = f"({execution.id}) {execution.doc_title}"
+                title_with_id = f"#{execution.id} - {execution.doc_title}"
                 # Truncate if needed
                 if len(title_with_id) > 47:
                     title_with_id = title_with_id[:44] + "..."

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -171,9 +171,9 @@ class LogBrowser(Widget):
         
         # Set up the table
         table = self.query_one("#log-table", DataTable)
-        table.add_column("ID", width=4)
+        table.add_column("ID", width=25)
         table.add_column("Status", width=8)
-        table.add_column("Title", width=40)
+        table.add_column("Title", width=35)
         
         # Focus the table
         table.focus()
@@ -202,7 +202,7 @@ class LogBrowser(Widget):
                 }.get(execution.status, '❓')
                 
                 table.add_row(
-                    f"{i+1}",
+                    execution.id,
                     status_icon,
                     execution.doc_title[:30] + "..." if len(execution.doc_title) > 30 else execution.doc_title
                 )

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -171,8 +171,8 @@ class LogBrowser(Widget):
         
         # Set up the table
         table = self.query_one("#log-table", DataTable)
-        table.add_column("#", width=6)
-        table.add_column("Title", width=45)
+        table.add_column("", width=3)  # Status emoji column, no header
+        table.add_column("Title", width=50)
         
         # Focus the table
         table.focus()
@@ -200,12 +200,15 @@ class LogBrowser(Widget):
                     'failed': '❌'
                 }.get(execution.status, '❓')
                 
-                # Combine ID and status in a compact format
-                id_with_status = f"{status_icon}{execution.id}"
+                # Format title with ID prefix
+                title_with_id = f"({execution.id}) {execution.doc_title}"
+                # Truncate if needed
+                if len(title_with_id) > 47:
+                    title_with_id = title_with_id[:44] + "..."
                 
                 table.add_row(
-                    id_with_status,
-                    execution.doc_title[:40] + "..." if len(execution.doc_title) > 40 else execution.doc_title
+                    status_icon,
+                    title_with_id
                 )
                 
             self.update_status(f"📋 {len(self.executions)} executions | j/k=navigate | s=select | q=back")

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -171,9 +171,8 @@ class LogBrowser(Widget):
         
         # Set up the table
         table = self.query_one("#log-table", DataTable)
-        table.add_column("ID", width=25)
-        table.add_column("Status", width=8)
-        table.add_column("Title", width=35)
+        table.add_column("#", width=6)
+        table.add_column("Title", width=45)
         
         # Focus the table
         table.focus()
@@ -201,10 +200,12 @@ class LogBrowser(Widget):
                     'failed': '❌'
                 }.get(execution.status, '❓')
                 
+                # Combine ID and status in a compact format
+                id_with_status = f"{status_icon}{execution.id}"
+                
                 table.add_row(
-                    execution.id,
-                    status_icon,
-                    execution.doc_title[:30] + "..." if len(execution.doc_title) > 30 else execution.doc_title
+                    id_with_status,
+                    execution.doc_title[:40] + "..." if len(execution.doc_title) > 40 else execution.doc_title
                 )
                 
             self.update_status(f"📋 {len(self.executions)} executions | j/k=navigate | s=select | q=back")

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -171,9 +171,9 @@ class LogBrowser(Widget):
         
         # Set up the table
         table = self.query_one("#log-table", DataTable)
-        table.add_column("#", width=4)
-        table.add_column("Status", width=3)
-        table.add_column("Document", width=40)
+        table.add_column("ID", width=4)
+        table.add_column("Status", width=8)
+        table.add_column("Title", width=40)
         
         # Focus the table
         table.focus()


### PR DESCRIPTION
## Summary
- Fixed log browser crashes and improved UI layout
- Implemented cleaner, more compact column design
- Added execution metadata panel with better information display
- Improved overall user experience for viewing execution logs

## Changes Made

### Bug Fixes
1. Added missing `Vertical` import from textual.containers
2. Removed unsupported `can_focus` parameter from RichLog widget
3. Fixed column headers (ID/Status/Title instead of #/Status/Document)
4. Removed truncated "Started" time column

### Layout Improvements
1. Implemented 50/50 horizontal split for consistency
2. Created 2/3-1/3 vertical split in left sidebar (table + metadata)
3. Optimized column widths for better space usage
4. Combined status emoji and title for cleaner display

### UI Enhancements
1. Status shown as emoji only (🔄/✅/❌) in narrow column
2. Title format: "#ID - Title" for clear identification
3. Execution metadata panel shows build info, worktree, timestamps
4. Improved readability and visual hierarchy

## Test Plan
- [x] Run `emdx gui` and press 'l' to open log browser
- [x] Verify no crashes occur
- [x] Check 50/50 split layout
- [x] Confirm metadata panel displays correctly
- [x] Test navigation with j/k keys
- [x] Verify selection mode (s key) works
- [x] Check status emojis display properly

## Screenshots
The log browser now shows:
- Clean status column with emojis
- Title format: "#74 - New Note - 2025-07-14 20:07"
- Detailed execution metadata in bottom panel
- Better use of available space

🤖 Generated with [Claude Code](https://claude.ai/code)