### PR TITLE
fix: log browser metadata panel and timezone issues (Issue #774)

### DIFF
--- a/emdx/commands/claude_execute.py
+++ b/emdx/commands/claude_execute.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Any, List, Optional
@@ -547,7 +547,7 @@ def execute_document_smart_background(
         doc_id=doc_id,
         doc_title=doc['title'],
         status="running",
-        started_at=datetime.now(),
+        started_at=datetime.now(timezone.utc),
         log_file=str(log_file),
         working_dir=working_dir
     )
@@ -631,7 +631,7 @@ def execute_document_smart(
         doc_id=doc_id,
         doc_title=doc['title'],
         status="running",
-        started_at=datetime.now(),
+        started_at=datetime.now(timezone.utc),
         log_file=str(log_file),
         working_dir=working_dir
     )
@@ -766,7 +766,7 @@ def monitor_execution_detached(
             doc_id=int(doc_id),
             doc_title=doc_title,
             status="running",
-            started_at=datetime.now(),
+            started_at=datetime.now(timezone.utc),
             log_file=str(log_file),
             working_dir=working_dir
         )
@@ -825,7 +825,7 @@ def monitor_execution(
             doc_id=int(doc_id),
             doc_title=doc_title,
             status="running",
-            started_at=datetime.now(),
+            started_at=datetime.now(timezone.utc),
             log_file=str(log_file),
             working_dir=working_dir
         )
@@ -961,7 +961,7 @@ def execute(
                 doc_id=int(doc_id),
                 doc_title=doc['title'],
                 status="running",
-                started_at=datetime.now(),
+                started_at=datetime.now(timezone.utc),
                 log_file=str(log_file),
                 working_dir=working_dir
             )


### PR DESCRIPTION
## Summary
- Simplified log browser metadata panel to show only essential info
- Fixed timezone handling causing incorrect duration calculations (240+ minutes)
- Improved UI layout for better readability

## Changes Made

### Metadata Panel Simplification
1. Removed unnecessary version, build ID, and execution ID info
2. Show only worktree name instead of full path (e.g., "emdx-exec-700")
3. Show only log filename instead of full path (e.g., "claude-700-1752538120.log")
4. Added execution duration calculation (e.g., "2m 15s")
5. Use time-only format for started/completed (HH:MM:SS)

**Before:**
```
=== EMDX Claude Execution ===
Version: 0.6.0
Build ID: 0.6.0-831ee0d1
Doc ID: 658
Execution ID: 69
Worktree: /Users/alexrockwell/dev/worktrees/emdx-exec-700
Started: 2025-07-14 04:06:24
Log File: /Users/alexrockwell/.config/emdx/logs/claude-700-1752538120.log
```

**After:**
```
Worktree: emdx-exec-700
Log: claude-700-1752538120.log

Started: 20:08:40
Completed: 20:10:55
Duration: 2m 15s
Status: ✅ completed
```

### Timezone Fix
- Added `parse_timestamp()` helper to ensure all timestamps have timezone info
- Use UTC consistently: `datetime.now(timezone.utc)` for creation
- Handle SQLite timestamps which may be naive (no timezone)
- Convert all naive timestamps to UTC to prevent timezone offset errors

This fixes the "240m 5s" duration bug which was caused by comparing timestamps in different timezones.

## Test Plan
- [ ] Run `emdx gui` and open log browser with 'l'
- [ ] Check metadata panel shows simplified info
- [ ] Verify duration calculations are correct (not 240+ minutes)
- [ ] Confirm timestamps display in HH:MM:SS format
- [ ] Test with both running and completed executions

🤖 Generated with [Claude Code](https://claude.ai/code)