### PR TITLE
fix: correct execute command structure to use emdx CLI

### DIFF
--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -803,15 +803,27 @@ class DocumentBrowser(Widget):
             # Find the wrapper script
             wrapper_path = Path(__file__).parent.parent / "utils" / "claude_wrapper.py"
             
-            # Build the claude command
-            claude_cmd = [
-                sys.executable,
-                "-m", "emdx.commands.claude_execute",
-                "execute",
-                str(doc_id),
-                "--execution-id", str(exec_id),
-                "--background"
-            ]
+            # Build the claude command using emdx CLI
+            # Use the emdx command instead of calling module directly
+            import shutil
+            emdx_path = shutil.which("emdx")
+            if not emdx_path:
+                # Fallback to python module if emdx not in PATH
+                emdx_path = sys.executable
+                claude_cmd = [
+                    emdx_path,
+                    "-m", "emdx",
+                    "claude", "execute",
+                    str(doc_id),
+                    "--background"
+                ]
+            else:
+                claude_cmd = [
+                    emdx_path,
+                    "claude", "execute", 
+                    str(doc_id),
+                    "--background"
+                ]
             
             # Execute with wrapper
             wrapper_cmd = [sys.executable, str(wrapper_path), str(exec_id), str(log_path)] + claude_cmd


### PR DESCRIPTION
## Summary
Fixes the execute command ('x' key) that was broken after the previous PR merge. The command was using an invalid `--execution-id` parameter and incorrect module invocation.

## Problem
When pressing 'x' to execute a document, users see errors:
- `No such option: --execution-id`
- `Got unexpected extra argument (783)`

## Solution
Changed the command structure to use the proper emdx CLI:
- `emdx claude execute <doc_id> --background` (if emdx is in PATH)
- `python -m emdx claude execute <doc_id> --background` (fallback)

Removed the invalid `--execution-id` parameter - the execution ID is already tracked through the wrapper script.

## Test plan
- [x] Press 'x' on any document to execute
- [x] Verify no command parsing errors
- [x] Check that execution starts successfully
- [x] Confirm log file is created and populated

🤖 Generated with [Claude Code](https://claude.ai/code)