### PR TITLE
feat: increase document title width to 74 characters

### DIFF
--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -268,7 +268,7 @@ class DocumentBrowser(Widget):
         table.add_column("ID", width=4)
         table.add_column("Tags", width=8)  
         table.add_column(" ", width=1)  # Padding column
-        table.add_column("Title", width=38)
+        table.add_column("Title", width=74)
         table.cursor_type = "row"
         table.show_header = True
         table.cell_padding = 0  # Remove cell padding for tight spacing
@@ -347,7 +347,7 @@ class DocumentBrowser(Widget):
         
         for doc in self.filtered_docs:
             # Format row data - ID, Tags, and Title
-            title, was_truncated = truncate_emoji_safe(doc["title"], 40)
+            title, was_truncated = truncate_emoji_safe(doc["title"], 74)
             if was_truncated:
                 title += "..."
             


### PR DESCRIPTION
## Summary
- Increased title column width from 38 to 74 characters in the TUI browser
- Updated truncation logic to match the new width
- Provides significantly more space for viewing longer document titles

## Test plan
- [ ] Run `emdx gui` and verify titles display up to 74 characters
- [ ] Check that long titles are properly truncated with "..." after 74 chars
- [ ] Ensure the layout still looks good with the wider title column

🤖 Generated with [Claude Code](https://claude.ai/code)