### PR TITLE
feat: unified document editing experience with markdown headers (Issue #127)

### DIFF
--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -724,11 +724,13 @@ class DocumentBrowser(Widget):
         await edit_container.mount(title_input)
         await edit_container.mount(vim_editor)
         
-        # Focus on title input first
-        title_input.focus()
+        # Vim editor will start in NORMAL mode by default
+        
+        # Focus on title input first - use call_after_refresh to ensure it's ready
+        self.call_after_refresh(lambda: title_input.focus())
         
         # Update status
-        self._update_vim_status("NEW DOCUMENT | Enter title | Tab=switch to content | ESC=cancel")
+        self._update_vim_status("NEW DOCUMENT | Enter title | Tab=switch to content | Ctrl+S=save | ESC=cancel")
         
     def action_cursor_down(self) -> None:
         """Move cursor down."""

--- a/emdx/ui/inputs.py
+++ b/emdx/ui/inputs.py
@@ -60,22 +60,6 @@ class TitleInput(Input):
         except Exception as e:
             logger.debug(f"Error restoring cursor: {e}")
     
-    def _format_title_with_box(self, title: str) -> str:
-        """Format title with unicode box for content area."""
-        # Calculate box width - make it wider than the title for better appearance
-        box_width = max(len(title) + 4, 80)
-        
-        # Center the title within the box
-        padded_title = title.center(box_width - 2)
-        
-        # Create the unicode box
-        top_line = "╔" + "═" * (box_width - 2) + "╗"
-        title_line = "║" + padded_title + "║"
-        bottom_line = "╚" + "═" * (box_width - 2) + "╝"
-        
-        # Return with extra newlines for spacing
-        return f"{top_line}\n{title_line}\n{bottom_line}\n\n"
-    
     def on_blur(self) -> None:
         """Save cursor position when losing focus."""
         self._saved_cursor_position = self.cursor_position
@@ -99,19 +83,10 @@ class TitleInput(Input):
                 vim_editor = self.app_instance.query_one("#vim-editor-container", VimEditor)
                 vim_editor.focus_editor()
                 
-                # First time tabbing to content? Start in INSERT mode and add formatted title
+                # First time tabbing to content? Start in INSERT mode
                 if not hasattr(vim_editor.text_area, '_has_been_focused'):
                     vim_editor.text_area._has_been_focused = True
                     vim_editor.text_area.vim_mode = "INSERT"
-                    
-                    # Only insert formatted title for NEW documents (not edits)
-                    if hasattr(self.app_instance, 'new_document_mode') and self.app_instance.new_document_mode:
-                        # Insert formatted title if content is empty
-                        if not vim_editor.text_area.text.strip() and self.value.strip():
-                            formatted_title = self._format_title_with_box(self.value.strip())
-                            vim_editor.text_area.insert(formatted_title)
-                            # Position cursor after the formatted title
-                            vim_editor.text_area.move_cursor((len(formatted_title.split('\n')), 0))
                 
                 vim_editor.text_area._update_cursor_style()
                 mode_name = vim_editor.text_area.vim_mode

--- a/emdx/ui/inputs.py
+++ b/emdx/ui/inputs.py
@@ -104,12 +104,14 @@ class TitleInput(Input):
                     vim_editor.text_area._has_been_focused = True
                     vim_editor.text_area.vim_mode = "INSERT"
                     
-                    # Insert formatted title if content is empty
-                    if not vim_editor.text_area.text.strip() and self.value.strip():
-                        formatted_title = self._format_title_with_box(self.value.strip())
-                        vim_editor.text_area.insert(formatted_title)
-                        # Position cursor after the formatted title
-                        vim_editor.text_area.move_cursor((len(formatted_title.split('\n')), 0))
+                    # Only insert formatted title for NEW documents (not edits)
+                    if hasattr(self.app_instance, 'new_document_mode') and self.app_instance.new_document_mode:
+                        # Insert formatted title if content is empty
+                        if not vim_editor.text_area.text.strip() and self.value.strip():
+                            formatted_title = self._format_title_with_box(self.value.strip())
+                            vim_editor.text_area.insert(formatted_title)
+                            # Position cursor after the formatted title
+                            vim_editor.text_area.move_cursor((len(formatted_title.split('\n')), 0))
                 
                 vim_editor.text_area._update_cursor_style()
                 mode_name = vim_editor.text_area.vim_mode

--- a/emdx/ui/inputs.py
+++ b/emdx/ui/inputs.py
@@ -37,28 +37,65 @@ class TitleInput(Input):
     def __init__(self, app_instance, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.app_instance = app_instance
+        self._saved_cursor_position = 0
+    
+    def on_focus(self) -> None:
+        """Handle focus event - restore cursor position."""
+        # Input widget doesn't have on_focus, so don't call super
+        # Just restore our saved cursor position after a refresh
+        self.call_after_refresh(self._restore_cursor_position)
+        # Also use a timer as backup
+        self.set_timer(0.05, self._restore_cursor_position)
+    
+    def _restore_cursor_position(self) -> None:
+        """Restore the saved cursor position without selection."""
+        try:
+            # Move cursor to end which should clear selection
+            self.action_end()
+            # Then restore to saved position if needed
+            if self._saved_cursor_position < len(self.value):
+                # Move back to saved position
+                for _ in range(len(self.value) - self._saved_cursor_position):
+                    self.action_cursor_left()
+        except Exception as e:
+            logger.debug(f"Error restoring cursor: {e}")
+    
+    def on_blur(self) -> None:
+        """Save cursor position when losing focus."""
+        self._saved_cursor_position = self.cursor_position
+        # Input widget might not have on_blur either
     
     def on_key(self, event: events.Key) -> None:
-        """Handle Tab and vim keys to switch to content editor."""
+        """Handle Tab to switch to content editor in new document mode."""
         logger.debug(f"TitleInput.on_key: key={event.key}")
-        # Vim keys that should switch focus to content editor
-        vim_keys = {'j', 'k', 'h', 'l', 'i', 'a', 'o', 'x', 'd', 'y', 'p', 'v', 'g', 'w', 'b', 'e', '0', '$', 'u'}
-        vim_special_keys = {'up', 'down', 'left', 'right', 'enter'}
         
-        char = event.character if hasattr(event, 'character') else None
+        # Handle Ctrl+S to save
+        if event.key == "ctrl+s":
+            self.app_instance.action_save_and_exit_edit()
+            event.stop()
+            event.prevent_default()
+            return
         
-        if event.key == "tab" or event.key == "escape" or char in vim_keys or event.key in vim_special_keys:
-            # Switch focus to content editor for vim keys
+        if event.key == "tab":
+            # Switch focus to vim editor container
             try:
-                from .text_areas import VimEditTextArea
-                edit_area = self.app_instance.query_one("#preview-content", VimEditTextArea)
-                edit_area.focus()
-                # Let the edit area handle this key event
-                edit_area.on_key(event)
+                from .vim_editor import VimEditor
+                vim_editor = self.app_instance.query_one("#vim-editor-container", VimEditor)
+                vim_editor.focus_editor()
+                
+                # First time tabbing to content? Start in INSERT mode
+                if not hasattr(vim_editor.text_area, '_has_been_focused'):
+                    vim_editor.text_area._has_been_focused = True
+                    vim_editor.text_area.vim_mode = "INSERT"
+                
+                vim_editor.text_area._update_cursor_style()
+                mode_name = vim_editor.text_area.vim_mode
+                self.app_instance._update_vim_status(f"{mode_name} | Tab=switch to title | Ctrl+S=save | ESC=exit")
                 event.stop()
                 event.prevent_default()
                 return
-            except:
+            except Exception as e:
+                logger.debug(f"Could not switch to vim editor: {e}")
                 pass  # Editor might not exist
         
         # For other keys (typing), let Input handle normally


### PR DESCRIPTION
## Summary
- Unified the new document and edit document UI to use consistent title input + content area
- Replaced hardcoded unicode box formatting with markdown headers for Rich rendering
- Fixed mounting errors and improved Tab navigation between fields

## Changes

### New Document Creation
- Title input field at top (clean, no formatting)
- Empty content area ready for typing
- Tab switches between title and content, starting in INSERT mode
- Ctrl+S saves with markdown header format: `# Title\n\nContent`

### Document Editing
- Same UI as new documents - title input + content area
- Extracts existing title (removes markdown header or unicode box)
- Shows clean content without header in editor
- Ctrl+S re-adds the markdown header

### Display Improvements
- Rich's markdown renderer automatically adds unicode box around headers
- Consistent rendering in both TUI preview and `emdx view` command
- Handles legacy unicode box formats for backward compatibility

## Technical Details
- Fixed widget mounting order to prevent `MountError`
- Added extraction logic for multiple unicode box styles (╔═╗, ┏━┓, ┌─┐)
- Simplified formatting to use standard markdown instead of custom unicode

## Test Plan
- [x] Create new document - verify clean UI and proper saving
- [x] Edit existing document - verify title extraction and re-formatting
- [x] Tab navigation works in both modes
- [x] Preview displays unicode box correctly after save
- [x] Legacy documents with unicode boxes edit properly

Fixes #127

🤖 Generated with [Claude Code](https://claude.ai/code)