### PR TITLE
feat: improve document editing UX with unified UI, Tab navigation, and header restoration

### DIFF
--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -201,6 +201,13 @@ class DocumentBrowser(Widget):
         height: 1fr;
         width: 100%;
     }
+    
+    #table-header {
+        background: $boost;
+        padding: 0 1;
+        margin-bottom: 0;
+        text-style: bold;
+    }
     """
     
     # Reactive properties
@@ -235,6 +242,8 @@ class DocumentBrowser(Widget):
                     table_container.styles.height = "66%"
                     table_container.styles.min_height = 10
                     table_container.styles.padding = 0
+                    # Add header label
+                    yield Label("ID   TAGS     TITLE", id="table-header")
                     yield DataTable(id="doc-table")
                 with Vertical(id="details-container", classes="details-section") as details_container:
                     # Apply direct styles - 1/3 of sidebar
@@ -278,7 +287,7 @@ class DocumentBrowser(Widget):
         table.add_column(" ", width=1)  # Padding column
         table.add_column("Title", width=74)
         table.cursor_type = "row"
-        table.show_header = True
+        table.show_header = False  # Hide built-in headers since we have custom header
         table.cell_padding = 0  # Remove cell padding for tight spacing
         
         # Disable focus on non-interactive widgets

--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -202,20 +202,8 @@ class DocumentBrowser(Widget):
         width: 100%;
     }
     
-    #table-header {
-        background: blue;
-        padding: 0 1;
-        margin: 0 0 1 0;
-        height: 1;
-        text-style: bold;
-        color: white;
-        width: 100%;
-        display: block;
-    }
-    
     #doc-table {
         height: 1fr;
-        margin-top: 0;
     }
     """
     
@@ -251,8 +239,6 @@ class DocumentBrowser(Widget):
                     table_container.styles.height = "66%"
                     table_container.styles.min_height = 10
                     table_container.styles.padding = (1, 0, 0, 0)  # Top padding for spacing
-                    # Add header label
-                    yield Static("ID   TAGS     TITLE", id="table-header")
                     yield DataTable(id="doc-table")
                 with Vertical(id="details-container", classes="details-section") as details_container:
                     # Apply direct styles - 1/3 of sidebar
@@ -289,20 +275,6 @@ class DocumentBrowser(Widget):
         logger.info(f"CSS contains 'background: green': {'background: green' in self.DEFAULT_CSS}")
         logger.info(f"First 200 chars of CSS: {self.DEFAULT_CSS[:200]}")
         
-        # Setup header
-        try:
-            header = self.query_one("#table-header", Static)
-            header.styles.background = "blue"
-            header.styles.color = "white"
-            header.styles.padding = (0, 1, 0, 1)  # Equal padding on both sides
-            header.styles.height = 1
-            header.styles.text_style = "bold"
-            header.styles.width = "100%"
-            header.styles.margin = (0, 0, 1, 0)  # Bottom margin for spacing
-            header.styles.display = "block"
-        except Exception as e:
-            logger.error(f"Error styling header: {e}")
-        
         # Setup table
         table = self.query_one("#doc-table", DataTable)
         table.add_column("ID", width=4)
@@ -310,7 +282,7 @@ class DocumentBrowser(Widget):
         table.add_column(" ", width=1)  # Padding column
         table.add_column("Title", width=74)
         table.cursor_type = "row"
-        table.show_header = False  # Hide built-in headers since we have custom header
+        table.show_header = True  # Show built-in headers
         table.cell_padding = 0  # Remove cell padding for tight spacing
         
         # Disable focus on non-interactive widgets

--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -209,7 +209,7 @@ class DocumentBrowser(Widget):
         height: 1;
         text-style: bold;
         color: $text;
-        dock: top;
+        width: 100%;
     }
     
     #doc-table {
@@ -248,7 +248,7 @@ class DocumentBrowser(Widget):
                     # Apply direct styles - 2/3 of sidebar
                     table_container.styles.height = "66%"
                     table_container.styles.min_height = 10
-                    table_container.styles.padding = (1, 0, 0, 0)  # Add top padding for header
+                    table_container.styles.padding = 0  # No padding to let header extend fully
                     # Add header label
                     yield Static("ID   TAGS     TITLE", id="table-header")
                     yield DataTable(id="doc-table")
@@ -292,9 +292,11 @@ class DocumentBrowser(Widget):
             header = self.query_one("#table-header", Static)
             header.styles.background = "blue"
             header.styles.color = "white"
-            header.styles.padding = (0, 1)
+            header.styles.padding = (0, 1, 0, 1)  # Equal padding on both sides
             header.styles.height = 1
             header.styles.text_style = "bold"
+            header.styles.width = "100%"
+            header.styles.margin = 0
         except Exception as e:
             logger.error(f"Error styling header: {e}")
         

--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -203,17 +203,19 @@ class DocumentBrowser(Widget):
     }
     
     #table-header {
-        background: $boost;
+        background: blue;
         padding: 0 1;
-        margin: 0;
+        margin: 0 0 1 0;
         height: 1;
         text-style: bold;
-        color: $text;
+        color: white;
         width: 100%;
+        display: block;
     }
     
     #doc-table {
         height: 1fr;
+        margin-top: 0;
     }
     """
     
@@ -248,7 +250,7 @@ class DocumentBrowser(Widget):
                     # Apply direct styles - 2/3 of sidebar
                     table_container.styles.height = "66%"
                     table_container.styles.min_height = 10
-                    table_container.styles.padding = 0  # No padding to let header extend fully
+                    table_container.styles.padding = (1, 0, 0, 0)  # Top padding for spacing
                     # Add header label
                     yield Static("ID   TAGS     TITLE", id="table-header")
                     yield DataTable(id="doc-table")
@@ -296,7 +298,8 @@ class DocumentBrowser(Widget):
             header.styles.height = 1
             header.styles.text_style = "bold"
             header.styles.width = "100%"
-            header.styles.margin = 0
+            header.styles.margin = (0, 0, 1, 0)  # Bottom margin for spacing
+            header.styles.display = "block"
         except Exception as e:
             logger.error(f"Error styling header: {e}")
         

--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -205,8 +205,15 @@ class DocumentBrowser(Widget):
     #table-header {
         background: $boost;
         padding: 0 1;
-        margin-bottom: 0;
+        margin: 0;
+        height: 1;
         text-style: bold;
+        color: $text;
+        dock: top;
+    }
+    
+    #doc-table {
+        height: 1fr;
     }
     """
     
@@ -241,9 +248,9 @@ class DocumentBrowser(Widget):
                     # Apply direct styles - 2/3 of sidebar
                     table_container.styles.height = "66%"
                     table_container.styles.min_height = 10
-                    table_container.styles.padding = 0
+                    table_container.styles.padding = (1, 0, 0, 0)  # Add top padding for header
                     # Add header label
-                    yield Label("ID   TAGS     TITLE", id="table-header")
+                    yield Static("ID   TAGS     TITLE", id="table-header")
                     yield DataTable(id="doc-table")
                 with Vertical(id="details-container", classes="details-section") as details_container:
                     # Apply direct styles - 1/3 of sidebar
@@ -279,6 +286,17 @@ class DocumentBrowser(Widget):
         # Log CSS content to verify it's loaded
         logger.info(f"CSS contains 'background: green': {'background: green' in self.DEFAULT_CSS}")
         logger.info(f"First 200 chars of CSS: {self.DEFAULT_CSS[:200]}")
+        
+        # Setup header
+        try:
+            header = self.query_one("#table-header", Static)
+            header.styles.background = "blue"
+            header.styles.color = "white"
+            header.styles.padding = (0, 1)
+            header.styles.height = 1
+            header.styles.text_style = "bold"
+        except Exception as e:
+            logger.error(f"Error styling header: {e}")
         
         # Setup table
         table = self.query_one("#doc-table", DataTable)


### PR DESCRIPTION
## Summary
- Improved new document experience with Tab navigation between title and content
- Auto-insert unicode box title formatting when creating documents  
- Unified edit/new document UI for consistency
- Fixed vim mode handling (INSERT for new docs, NORMAL for edits)
- Enable bidirectional Tab navigation in edit mode
- Attempted to restore ID TAGS TITLE header (reverted to built-in headers due to layout issues)

## Changes
- Tab navigation between title and content fields in both new and edit modes
- Proper vim mode initialization based on document mode
- Unicode box formatting using markdown headers
- Fixed widget mounting order issues
- Header restoration attempts (ultimately reverted to DataTable built-in headers)

## Test plan
- [x] Create new document - Tab switches between title and content
- [x] Tab to content starts in INSERT mode for new documents  
- [x] Edit existing document uses same UI as new document
- [x] Tab to content starts in NORMAL mode for edit
- [x] Bidirectional Tab navigation works in edit mode
- [x] Vim modes preserved when switching fields
- [x] Unicode box formatting appears correctly
- [x] Ctrl+S saves from both title and content areas
- [x] ESC behavior works correctly (INSERT→NORMAL→exit)
- [x] DataTable headers display properly without overlap

🤖 Generated with [Claude Code](https://claude.ai/code)