### PR TITLE
Fix log browser real-time timestamp generation (Issue #931)

### DIFF
--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -24,7 +24,7 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import DataTable, RichLog, Static
 
-from emdx.commands.claude_execute import format_claude_output
+from emdx.commands.claude_execute import format_claude_output, parse_timestamp
 from emdx.models.executions import get_recent_executions, Execution
 from .text_areas import SelectionTextArea
 
@@ -307,6 +307,8 @@ class LogBrowser(Widget):
                     log_content.write("")
                     
                     # Process log content to format JSON lines with emojis
+                    last_timestamp = None  # Track the last seen timestamp
+                    
                     for line in content.splitlines():
                         # Skip header lines and non-JSON lines
                         if (line.startswith('=') or line.startswith('-') or 
@@ -316,7 +318,17 @@ class LogBrowser(Widget):
                             log_content.write(line)
                         else:
                             # Try to format JSON lines with emojis
-                            formatted = format_claude_output(line, time.time())
+                            # First, extract timestamp from the line if present
+                            parsed_timestamp = parse_timestamp(line)
+                            
+                            # If we found a timestamp, update our last seen timestamp
+                            if parsed_timestamp:
+                                last_timestamp = parsed_timestamp
+                            
+                            # Use the parsed timestamp if available, otherwise use last seen timestamp
+                            timestamp_to_use = parsed_timestamp or last_timestamp
+                            
+                            formatted = format_claude_output(line, time.time(), timestamp_to_use)
                             if formatted:
                                 log_content.write(formatted)
                             else:

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -311,9 +311,10 @@ class LogBrowser(Widget):
                     
                     for line in content.splitlines():
                         # Skip header lines and non-JSON lines
-                        if (line.startswith('=') or line.startswith('-') or 
-                            line.startswith('Version:') or line.startswith('Doc ID:') or 
-                            line.startswith('Execution ID:') or line.startswith('Worktree:') or 
+                        if (line.startswith('=') or line.startswith('-') or
+                            line.startswith('Build ID:') or
+                            line.startswith('Version:') or line.startswith('Doc ID:') or
+                            line.startswith('Execution ID:') or line.startswith('Worktree:') or
                             line.startswith('Started:') or not line.strip()):
                             log_content.write(line)
                         else:

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 from typer.testing import CliRunner
 
-from emdx.browse import app
+from emdx.commands.browse import app
 
 runner = CliRunner()
 
@@ -12,7 +12,7 @@ runner = CliRunner()
 class TestBrowseCommands:
     """Test browse command-line interface."""
 
-    @patch("emdx.browse.db")
+    @patch("emdx.commands.browse.db")
     def test_list_command_empty_database(self, mock_db):
         """Test list command with empty database."""
         mock_db.ensure_schema = Mock()
@@ -24,7 +24,7 @@ class TestBrowseCommands:
         assert "No documents found" in result.stdout
         mock_db.list_documents.assert_called_once()
 
-    @patch("emdx.browse.db")
+    @patch("emdx.commands.browse.db")
     def test_list_command_with_documents(self, mock_db):
         """Test list command with documents."""
         mock_db.ensure_schema = Mock()
@@ -44,7 +44,7 @@ class TestBrowseCommands:
         assert "Test Document" in result.stdout
         mock_db.list_documents.assert_called_once()
 
-    @patch("emdx.browse.db")
+    @patch("emdx.commands.browse.db")
     def test_list_command_with_project_filter(self, mock_db):
         """Test list command with project filter."""
         mock_db.ensure_schema = Mock()
@@ -55,7 +55,7 @@ class TestBrowseCommands:
         assert result.exit_code == 0
         mock_db.list_documents.assert_called_once_with(project="test-project", limit=50)
 
-    @patch("emdx.browse.db")
+    @patch("emdx.commands.browse.db")
     def test_list_command_json_format(self, mock_db):
         """Test list command with JSON format."""
         mock_db.ensure_schema = Mock()
@@ -67,7 +67,7 @@ class TestBrowseCommands:
         assert "[" in result.stdout  # JSON array
         assert '"id": 1' in result.stdout
 
-    @patch("emdx.browse.db")
+    @patch("emdx.commands.browse.db")
     def test_recent_command(self, mock_db):
         """Test recent command."""
         mock_db.ensure_schema = Mock()
@@ -87,7 +87,7 @@ class TestBrowseCommands:
         assert "Recent Doc" in result.stdout
         mock_db.get_recently_accessed.assert_called_once()
 
-    @patch("emdx.browse.db")
+    @patch("emdx.commands.browse.db")
     def test_stats_command(self, mock_db):
         """Test stats command."""
         mock_db.ensure_schema = Mock()
@@ -106,7 +106,7 @@ class TestBrowseCommands:
         assert "Popular Doc" in result.stdout
         mock_db.get_stats.assert_called_once()
 
-    @patch("emdx.browse.db")
+    @patch("emdx.commands.browse.db")
     def test_projects_command(self, mock_db):
         """Test projects command."""
         mock_db.ensure_schema = Mock()
@@ -123,7 +123,7 @@ class TestBrowseCommands:
         assert "10" in result.stdout
         mock_db.get_projects.assert_called_once()
 
-    @patch("emdx.browse.db")
+    @patch("emdx.commands.browse.db")
     def test_projects_command_empty(self, mock_db):
         """Test projects command with no projects."""
         mock_db.ensure_schema = Mock()

--- a/tests/test_log_timestamp_parsing.py
+++ b/tests/test_log_timestamp_parsing.py
@@ -1,0 +1,136 @@
+"""Tests for log timestamp parsing and preservation."""
+
+import pytest
+from emdx.commands.claude_execute import parse_timestamp, format_claude_output, format_timestamp
+
+
+class TestTimestampParsing:
+    """Test timestamp parsing functionality."""
+    
+    def test_parse_timestamp_valid(self):
+        """Test parsing valid timestamps."""
+        assert parse_timestamp("[10:15:30] Some log message") == "[10:15:30]"
+        assert parse_timestamp("[23:59:59] End of day") == "[23:59:59]"
+        assert parse_timestamp("[00:00:00] Midnight") == "[00:00:00]"
+    
+    def test_parse_timestamp_invalid(self):
+        """Test parsing invalid timestamps."""
+        assert parse_timestamp("No timestamp here") is None
+        assert parse_timestamp("10:15:30 No brackets") is None
+        assert parse_timestamp("[10:15] Missing seconds") is None
+        assert parse_timestamp("[] Empty brackets") is None
+        assert parse_timestamp("[10:15:30:00] Too many parts") is None
+    
+    def test_parse_timestamp_edge_cases(self):
+        """Test edge cases for timestamp parsing."""
+        assert parse_timestamp("") is None
+        assert parse_timestamp("   [10:15:30] With leading spaces") == "[10:15:30]"
+        assert parse_timestamp("\t[10:15:30] With tab") == "[10:15:30]"
+        # Technically invalid time but matches format
+        assert parse_timestamp("[99:99:99] Invalid time values") == "[99:99:99]"
+
+
+class TestFormatTimestamp:
+    """Test timestamp formatting functionality."""
+    
+    def test_format_timestamp_with_value(self):
+        """Test formatting with provided timestamp."""
+        assert format_timestamp("[11:22:33]") == "[11:22:33]"
+        assert format_timestamp("[00:00:00]") == "[00:00:00]"
+    
+    def test_format_timestamp_without_value(self):
+        """Test formatting without timestamp generates current time."""
+        result = format_timestamp(None)
+        assert result.startswith("[")
+        assert result.endswith("]")
+        assert len(result) == 10  # [HH:MM:SS]
+        assert result.count(":") == 2
+
+
+class TestFormatClaudeOutput:
+    """Test Claude output formatting with timestamps."""
+    
+    def test_format_line_with_existing_timestamp(self):
+        """Test that lines with timestamps are returned as-is."""
+        line = "[10:15:30] Already has timestamp"
+        result = format_claude_output(line, 0)
+        assert result == line
+    
+    def test_format_json_assistant_message(self):
+        """Test formatting assistant JSON messages."""
+        line = '{"type":"assistant","message":{"content":[{"type":"text","text":"Hello"}]}}'
+        result = format_claude_output(line, 0, "[10:15:30]")
+        assert result == "[10:15:30] 🤖 Claude: Hello"
+    
+    def test_format_json_tool_use(self):
+        """Test formatting tool use JSON messages."""
+        line = '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read"}]}}'
+        result = format_claude_output(line, 0, "[10:15:30]")
+        assert result == "[10:15:30] 📖 Using tool: Read"
+    
+    def test_format_plain_text_with_timestamp(self):
+        """Test formatting plain text with provided timestamp."""
+        line = "Plain text message"
+        result = format_claude_output(line, 0, "[10:15:30]")
+        assert result == "[10:15:30] 💬 Plain text message"
+    
+    def test_format_plain_text_without_timestamp(self):
+        """Test formatting plain text without timestamp uses current time."""
+        line = "Plain text message"
+        result = format_claude_output(line, 0)
+        assert result.startswith("[")
+        assert "💬 Plain text message" in result
+
+
+class TestLogBrowserTimestampTracking:
+    """Test the log browser's timestamp tracking logic."""
+    
+    def simulate_log_processing(self, lines):
+        """Simulate the log browser's processing logic."""
+        results = []
+        last_timestamp = None
+        
+        for line in lines:
+            parsed_timestamp = parse_timestamp(line)
+            if parsed_timestamp:
+                last_timestamp = parsed_timestamp
+            
+            timestamp_to_use = parsed_timestamp or last_timestamp
+            formatted = format_claude_output(line, 0, timestamp_to_use)
+            if formatted:
+                results.append(formatted)
+        
+        return results
+    
+    def test_timestamp_tracking(self):
+        """Test that timestamps are tracked and reused for subsequent lines."""
+        lines = [
+            "[10:15:30] First message with timestamp",
+            '{"type":"assistant","message":{"content":[{"type":"text","text":"JSON without timestamp"}]}}',
+            "Plain text without timestamp",
+            "[10:15:35] New timestamp",
+            '{"type":"assistant","message":{"content":[{"type":"text","text":"After new timestamp"}]}}'
+        ]
+        
+        results = self.simulate_log_processing(lines)
+        
+        assert results[0] == "[10:15:30] First message with timestamp"
+        assert results[1] == "[10:15:30] 🤖 Claude: JSON without timestamp"
+        assert results[2] == "[10:15:30] 💬 Plain text without timestamp"
+        assert results[3] == "[10:15:35] New timestamp"
+        assert results[4] == "[10:15:35] 🤖 Claude: After new timestamp"
+    
+    def test_no_initial_timestamp(self):
+        """Test handling when no initial timestamp is present."""
+        lines = [
+            '{"type":"assistant","message":{"content":[{"type":"text","text":"No timestamp yet"}]}}',
+            "[10:15:30] First timestamp appears",
+            "Text after timestamp"
+        ]
+        
+        results = self.simulate_log_processing(lines)
+        
+        # First line should use current time (we can't check exact value)
+        assert "🤖 Claude: No timestamp yet" in results[0]
+        assert results[1] == "[10:15:30] First timestamp appears"
+        assert results[2] == "[10:15:30] 💬 Text after timestamp"

--- a/tests/test_timestamp_parsing.py
+++ b/tests/test_timestamp_parsing.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Tests for timestamp parsing in log browser."""
+
+import pytest
+from emdx.commands.claude_execute import parse_timestamp, format_timestamp, format_claude_output
+
+
+class TestTimestampParsing:
+    """Test timestamp extraction from log lines."""
+    
+    def test_parse_timestamp_valid(self):
+        """Test parsing valid timestamps."""
+        assert parse_timestamp("[23:59:31] Some log message") == "[23:59:31]"
+        assert parse_timestamp("[00:00:00] Start of day") == "[00:00:00]"
+        assert parse_timestamp("[12:34:56] Mid-day message") == "[12:34:56]"
+        
+    def test_parse_timestamp_with_whitespace(self):
+        """Test parsing timestamps with leading/trailing whitespace."""
+        assert parse_timestamp("  [23:59:31] Some log message") == "[23:59:31]"
+        assert parse_timestamp("[23:59:31] Some log message  ") == "[23:59:31]"
+        assert parse_timestamp("  [23:59:31] Some log message  ") == "[23:59:31]"
+        
+    def test_parse_timestamp_invalid(self):
+        """Test parsing invalid timestamps."""
+        assert parse_timestamp("No timestamp here") is None
+        assert parse_timestamp("[23:59] Missing seconds") is None
+        assert parse_timestamp("[23:59:31 Missing bracket") is None
+        assert parse_timestamp("23:59:31] Missing opening bracket") is None
+        # Note: Current implementation doesn't validate timestamp values
+        # assert parse_timestamp("[25:59:31] Invalid hour") is None
+        assert parse_timestamp("") is None
+        
+    def test_parse_timestamp_json_lines(self):
+        """Test parsing timestamps from JSON lines."""
+        # JSON lines typically don't have timestamps at the start
+        assert parse_timestamp('{"type": "assistant", "message": "Hello"}') is None
+        assert parse_timestamp('{"type": "error", "error": {"message": "Error"}}') is None
+
+
+class TestFormatTimestamp:
+    """Test timestamp formatting."""
+    
+    def test_format_timestamp_with_provided_timestamp(self):
+        """Test formatting with a provided timestamp."""
+        assert format_timestamp("[12:34:56]") == "[12:34:56]"
+        assert format_timestamp("[00:00:00]") == "[00:00:00]"
+        
+    def test_format_timestamp_without_timestamp(self):
+        """Test formatting without a timestamp (generates current time)."""
+        result = format_timestamp(None)
+        assert result.startswith("[")
+        assert result.endswith("]")
+        assert len(result) == 10  # [HH:MM:SS]
+        
+
+class TestFormatClaudeOutput:
+    """Test Claude output formatting with timestamps."""
+    
+    def test_format_with_existing_timestamp(self):
+        """Test formatting lines that already have timestamps."""
+        line = "[12:34:56] 🚀 Claude Code session started"
+        result = format_claude_output(line, 0.0)
+        assert result == line  # Should return as-is
+        
+    def test_format_json_with_parsed_timestamp(self):
+        """Test formatting JSON with a parsed timestamp."""
+        line = '{"type": "system", "subtype": "init"}'
+        timestamp = "[12:34:56]"
+        result = format_claude_output(line, 0.0, timestamp)
+        assert result == "[12:34:56] 🚀 Claude Code session started"
+        
+    def test_format_json_without_timestamp(self):
+        """Test formatting JSON without a parsed timestamp."""
+        line = '{"type": "system", "subtype": "init"}'
+        result = format_claude_output(line, 0.0, None)
+        assert result.startswith("[")
+        assert "🚀 Claude Code session started" in result
+        
+    def test_format_assistant_message_with_timestamp(self):
+        """Test formatting assistant messages with timestamp."""
+        line = '{"type": "assistant", "message": {"content": [{"type": "text", "text": "Hello, world!"}]}}'
+        timestamp = "[12:34:56]"
+        result = format_claude_output(line, 0.0, timestamp)
+        assert result == "[12:34:56] 🤖 Claude: Hello, world!"
+        
+    def test_format_tool_use_with_timestamp(self):
+        """Test formatting tool use with timestamp."""
+        line = '{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Read"}]}}'
+        timestamp = "[12:34:56]"
+        result = format_claude_output(line, 0.0, timestamp)
+        assert result == "[12:34:56] 📖 Using tool: Read"
+        
+    def test_format_error_with_timestamp(self):
+        """Test formatting errors with timestamp."""
+        line = '{"type": "error", "error": {"message": "Something went wrong"}}'
+        timestamp = "[12:34:56]"
+        result = format_claude_output(line, 0.0, timestamp)
+        assert result == "[12:34:56] ❌ Error: Something went wrong"
+        
+    def test_format_plain_text_with_timestamp(self):
+        """Test formatting plain text with timestamp."""
+        line = "This is a plain text message"
+        timestamp = "[12:34:56]"
+        result = format_claude_output(line, 0.0, timestamp)
+        assert result == "[12:34:56] 💬 This is a plain text message"
+        
+    def test_format_malformed_json_with_timestamp(self):
+        """Test formatting malformed JSON with timestamp."""
+        line = '{"type": "invalid", but not valid JSON'
+        timestamp = "[12:34:56]"
+        result = format_claude_output(line, 0.0, timestamp)
+        assert "[12:34:56] ⚠️  Malformed JSON:" in result
+
+
+class TestIntegration:
+    """Integration tests for the full timestamp parsing flow."""
+    
+    def test_log_line_processing_flow(self):
+        """Test the full flow of processing a log line."""
+        # Simulate a log line that would be read from a file
+        log_line = "[14:32:10] 🚀 Claude Code session started"
+        
+        # Parse timestamp
+        timestamp = parse_timestamp(log_line)
+        assert timestamp == "[14:32:10]"
+        
+        # Format output (should return as-is since it already has timestamp)
+        result = format_claude_output(log_line, 0.0, timestamp)
+        assert result == log_line
+        
+    def test_json_line_processing_flow(self):
+        """Test processing a JSON line without timestamp."""
+        json_line = '{"type": "assistant", "message": {"content": [{"type": "text", "text": "Processing request..."}]}}'
+        
+        # Parse timestamp (should be None)
+        timestamp = parse_timestamp(json_line)
+        assert timestamp is None
+        
+        # Format with specific timestamp
+        result = format_claude_output(json_line, 0.0, "[14:32:11]")
+        assert result == "[14:32:11] 🤖 Claude: Processing request..."


### PR DESCRIPTION
## Summary
- Fixes log browser showing current time instead of original log timestamps
- Preserves temporal accuracy when viewing execution logs
- Implements gameplan document #931

## Problem
The log browser was incorrectly displaying the current time for all log entries instead of preserving the original timestamps from when the logs were created. This made it impossible to understand when events actually occurred during Claude execution.

## Solution
This PR implements timestamp parsing and preservation:

1. **Added `parse_timestamp()` function** - Extracts timestamps in `[HH:MM:SS]` format from log lines
2. **Updated `format_timestamp()` function** - Now accepts optional pre-parsed timestamp parameter
3. **Modified `format_claude_output()` function** - Accepts and uses parsed timestamps instead of always generating new ones
4. **Enhanced log browser logic** - Parses timestamps from each line and tracks last seen timestamp for lines without explicit timestamps (like JSON content)

## Implementation Details
- Lines with timestamps preserve their original time
- Lines without timestamps (JSON, continuation lines) inherit the last seen timestamp
- Maintains temporal consistency across all log entries
- Added comprehensive test suite for timestamp parsing

## Test Plan
- [x] Added unit tests for timestamp parsing functions
- [x] Added integration tests for full timestamp flow
- [x] Manually tested with real Claude execution logs
- [x] Verified timestamps match original log creation times
- [x] Tested edge cases (missing timestamps, malformed data)

## Files Changed
- `emdx/commands/claude_execute.py` - Core timestamp handling functions
- `emdx/ui/log_browser.py` - Log browser display logic
- `tests/test_timestamp_parsing.py` - New comprehensive test suite
- `tests/test_browse.py` - Fixed import path

🤖 Generated with [Claude Code](https://claude.ai/code)