### PR TITLE
fix: resolve psutil dependency sync issue

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,8 +2,9 @@
 default:
     @just --list
 
-# Install dependencies
+# Install dependencies and sync lock file
 install:
+    poetry lock
     poetry install
 
 # Check if dependencies are installed and install if needed


### PR DESCRIPTION
## Summary
- Fixed `emdx gui` failing with ModuleNotFoundError for psutil
- Updated justfile install recipe to run `poetry lock` before `poetry install`

## Test plan
- [x] Verify `poetry run emdx gui` command loads without errors
- [x] Confirm `just install` now syncs lock file properly
- [x] Test that psutil dependency is properly installed

🤖 Generated with [Claude Code](https://claude.ai/code)