### PR TITLE
chore: Add .beads to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,4 +145,4 @@ cython_debug/
 .DS_Store
 
 # Testing
-test-*.md
+test-*.md.beads/


### PR DESCRIPTION
Exclude beads directory from version control.

No longer using beads for issue tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)