### PR TITLE
feat: add task management system and Control Center TUI

### DIFF
--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -1,0 +1,258 @@
+"""Task CLI commands."""
+
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from emdx.models import tasks
+
+app = typer.Typer(help="Task management")
+console = Console()
+
+ICONS = {'open': '○', 'active': '●', 'blocked': '⚠', 'done': '✓', 'failed': '✗'}
+
+
+@app.command()
+def create(
+    title: str = typer.Argument(..., help="Task title"),
+    gameplan: Optional[int] = typer.Option(None, "-g", "--gameplan", help="Gameplan doc ID"),
+    priority: int = typer.Option(3, "-p", "--priority", help="Priority 1-5"),
+    depends: Optional[str] = typer.Option(None, "-d", "--depends", help="Depends on (comma-sep IDs)"),
+    description: Optional[str] = typer.Option(None, "-D", "--description", help="Task description"),
+    project: Optional[str] = typer.Option(None, "--project", help="Project name"),
+):
+    """Create a task."""
+    deps = [int(x) for x in depends.split(',') if x.strip()] if depends else None
+    task_id = tasks.create_task(
+        title,
+        description=description or "",
+        priority=priority,
+        gameplan_id=gameplan,
+        project=project,
+        depends_on=deps,
+    )
+    console.print(f"[green]✅ Created task #{task_id}[/green]")
+
+
+@app.command("list")
+def list_cmd(
+    status: Optional[str] = typer.Option(None, "-s", "--status", help="Filter by status (comma-sep)"),
+    gameplan: Optional[int] = typer.Option(None, "-g", "--gameplan", help="Filter by gameplan"),
+    project: Optional[str] = typer.Option(None, "--project", help="Filter by project"),
+    limit: int = typer.Option(50, "-n", "--limit"),
+):
+    """List tasks."""
+    status_list = [s.strip() for s in status.split(',')] if status else None
+    task_list = tasks.list_tasks(status=status_list, gameplan_id=gameplan, project=project, limit=limit)
+
+    if not task_list:
+        console.print("[yellow]No tasks[/yellow]")
+        return
+
+    table = Table()
+    table.add_column("", width=2)
+    table.add_column("ID", width=5)
+    table.add_column("Title")
+    table.add_column("P", width=2)
+    table.add_column("GP", width=5)
+
+    for t in task_list:
+        gp = str(t['gameplan_id']) if t['gameplan_id'] else ""
+        table.add_row(
+            ICONS.get(t['status'], '?'),
+            str(t['id']),
+            t['title'][:40],
+            str(t['priority']),
+            gp,
+        )
+
+    console.print(table)
+    console.print(f"\n[dim]{len(task_list)} task(s)[/dim]")
+
+
+@app.command()
+def show(task_id: int = typer.Argument(..., help="Task ID")):
+    """Show task details."""
+    task = tasks.get_task(task_id)
+    if not task:
+        console.print(f"[red]Task #{task_id} not found[/red]")
+        raise typer.Exit(1)
+
+    console.print(f"\n[bold]#{task['id']}[/bold] {ICONS.get(task['status'], '?')} {task['title']}")
+    console.print(f"Status: {task['status']}  Priority: {task['priority']}")
+
+    if task['gameplan_id']:
+        console.print(f"Gameplan: #{task['gameplan_id']}")
+    if task['project']:
+        console.print(f"Project: {task['project']}")
+    if task['current_step']:
+        console.print(f"Current step: {task['current_step']}")
+
+    if task['description']:
+        console.print(f"\n[bold]Description:[/bold]\n{task['description']}")
+
+    deps = tasks.get_dependencies(task_id)
+    if deps:
+        console.print("\n[bold]Depends on:[/bold]")
+        for d in deps:
+            console.print(f"  {ICONS.get(d['status'], '?')} #{d['id']} {d['title']}")
+
+    log = tasks.get_task_log(task_id, limit=10)
+    if log:
+        console.print("\n[bold]Recent log:[/bold]")
+        for entry in reversed(log):
+            console.print(f"  {entry['message']}")
+
+
+@app.command()
+def update(
+    task_id: int = typer.Argument(..., help="Task ID"),
+    status: Optional[str] = typer.Option(None, "-s", "--status", help="New status"),
+    priority: Optional[int] = typer.Option(None, "-p", "--priority", help="New priority"),
+    step: Optional[str] = typer.Option(None, "--step", help="Current step (for resume)"),
+    note: Optional[str] = typer.Option(None, "-n", "--note", help="Add to log"),
+):
+    """Update task."""
+    task = tasks.get_task(task_id)
+    if not task:
+        console.print(f"[red]Task #{task_id} not found[/red]")
+        raise typer.Exit(1)
+
+    kwargs = {}
+    if status:
+        kwargs['status'] = status
+    if priority:
+        kwargs['priority'] = priority
+    if step:
+        kwargs['current_step'] = step
+
+    if kwargs:
+        tasks.update_task(task_id, **kwargs)
+    if note:
+        tasks.log_progress(task_id, note)
+
+    console.print(f"[green]✅ Updated #{task_id}[/green]")
+
+
+@app.command()
+def log(
+    task_id: int = typer.Argument(..., help="Task ID"),
+    message: str = typer.Argument(..., help="Log message"),
+):
+    """Add log entry."""
+    task = tasks.get_task(task_id)
+    if not task:
+        console.print(f"[red]Task #{task_id} not found[/red]")
+        raise typer.Exit(1)
+
+    tasks.log_progress(task_id, message)
+    console.print(f"[green]✅ Logged to #{task_id}[/green]")
+
+
+@app.command()
+def ready(
+    gameplan: Optional[int] = typer.Option(None, "-g", "--gameplan", help="Filter by gameplan"),
+    project: Optional[str] = typer.Option(None, "--project", help="Filter by project"),
+):
+    """Show tasks ready to work (open + deps satisfied)."""
+    ready_tasks = tasks.get_ready_tasks(gameplan_id=gameplan)
+
+    # Filter by project if specified
+    if project:
+        ready_tasks = [t for t in ready_tasks if t.get('project') == project]
+
+    if not ready_tasks:
+        console.print("[yellow]No ready tasks[/yellow]")
+        return
+
+    console.print(f"\n[bold]Ready ({len(ready_tasks)}):[/bold]")
+    for t in ready_tasks:
+        gp = f" [dim]GP#{t['gameplan_id']}[/dim]" if t['gameplan_id'] else ""
+        console.print(f"  ○ #{t['id']} {t['title']} [dim]P{t['priority']}[/dim]{gp}")
+
+
+@app.command()
+def depends(
+    task_id: int = typer.Argument(..., help="Task ID"),
+    on: Optional[int] = typer.Option(None, "--on", help="Add dependency on this task ID"),
+    remove: Optional[int] = typer.Option(None, "--remove", help="Remove dependency on this task ID"),
+):
+    """Manage dependencies."""
+    task = tasks.get_task(task_id)
+    if not task:
+        console.print(f"[red]Task #{task_id} not found[/red]")
+        raise typer.Exit(1)
+
+    if on:
+        if tasks.add_dependency(task_id, on):
+            console.print(f"[green]✅ #{task_id} now depends on #{on}[/green]")
+        else:
+            console.print(f"[red]Cannot add dependency (cycle or invalid)[/red]")
+            raise typer.Exit(1)
+    elif remove:
+        # Remove dependency
+        from emdx.database import db
+        with db.get_connection() as conn:
+            cursor = conn.execute(
+                "DELETE FROM task_deps WHERE task_id = ? AND depends_on = ?",
+                (task_id, remove)
+            )
+            conn.commit()
+            if cursor.rowcount > 0:
+                console.print(f"[green]✅ Removed dependency #{task_id} → #{remove}[/green]")
+            else:
+                console.print(f"[yellow]Dependency not found[/yellow]")
+    else:
+        # Show current dependencies
+        deps = tasks.get_dependencies(task_id)
+        if deps:
+            console.print(f"\n[bold]#{task_id} depends on:[/bold]")
+            for d in deps:
+                console.print(f"  {ICONS.get(d['status'], '?')} #{d['id']} {d['title']}")
+        else:
+            console.print(f"[dim]#{task_id} has no dependencies[/dim]")
+
+
+@app.command()
+def delete(
+    task_id: int = typer.Argument(..., help="Task ID"),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+):
+    """Delete a task."""
+    task = tasks.get_task(task_id)
+    if not task:
+        console.print(f"[red]Task #{task_id} not found[/red]")
+        raise typer.Exit(1)
+
+    if not force:
+        console.print(f"Delete task #{task_id}: {task['title']}?")
+        confirm = typer.confirm("Are you sure?")
+        if not confirm:
+            console.print("[yellow]Cancelled[/yellow]")
+            return
+
+    tasks.delete_task(task_id)
+    console.print(f"[green]✅ Deleted #{task_id}[/green]")
+
+
+@app.command()
+def run(
+    task_id: int = typer.Argument(..., help="Task ID"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show prompt only"),
+):
+    """Run task with Claude."""
+    from emdx.services.task_runner import run_task, build_task_prompt
+
+    if dry_run:
+        console.print(build_task_prompt(task_id))
+        return
+
+    try:
+        exec_id = run_task(task_id)
+        console.print(f"[green]✅ Started task #{task_id}, exec #{exec_id}[/green]")
+        console.print(f"[dim]View: emdx exec logs {exec_id}[/dim]")
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1)

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -19,6 +19,7 @@ from emdx.commands.lifecycle import app as lifecycle_app
 from emdx.commands.maintain import app as maintain_app
 from emdx.commands.agents import app as agents_app
 from emdx.commands.tags import app as tag_app
+from emdx.commands.tasks import app as tasks_app
 from emdx.ui.gui import gui
 
 console = Console()
@@ -65,6 +66,9 @@ app.add_typer(lifecycle_app, name="lifecycle", help="Track document lifecycles")
 
 # Add agents as a subcommand group
 app.add_typer(agents_app, name="agent", help="Manage and run AI agents")
+
+# Add tasks as a subcommand group
+app.add_typer(tasks_app, name="task", help="Task management")
 
 # Add the gui command
 app.command()(gui)

--- a/emdx/models/tasks.py
+++ b/emdx/models/tasks.py
@@ -1,0 +1,216 @@
+"""Task operations for emdx."""
+
+from typing import Any, Optional
+
+from emdx.database import db
+
+# Valid status values
+STATUSES = ('open', 'active', 'blocked', 'done', 'failed')
+
+
+def create_task(
+    title: str,
+    description: str = "",
+    priority: int = 3,
+    gameplan_id: Optional[int] = None,
+    project: Optional[str] = None,
+    depends_on: Optional[list[int]] = None,
+) -> int:
+    """Create task and return its ID."""
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("""
+            INSERT INTO tasks (title, description, priority, gameplan_id, project)
+            VALUES (?, ?, ?, ?, ?)
+        """, (title, description, priority, gameplan_id, project))
+        task_id = cursor.lastrowid
+
+        if depends_on:
+            for dep_id in depends_on:
+                cursor.execute(
+                    "INSERT INTO task_deps (task_id, depends_on) VALUES (?, ?)",
+                    (task_id, dep_id)
+                )
+        conn.commit()
+        return task_id
+
+
+def get_task(task_id: int) -> Optional[dict[str, Any]]:
+    """Get task by ID."""
+    with db.get_connection() as conn:
+        cursor = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,))
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+
+def list_tasks(
+    status: Optional[list[str]] = None,
+    gameplan_id: Optional[int] = None,
+    project: Optional[str] = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """List tasks with filters."""
+    conditions, params = ["1=1"], []
+
+    if status:
+        conditions.append(f"status IN ({','.join('?' * len(status))})")
+        params.extend(status)
+    if gameplan_id:
+        conditions.append("gameplan_id = ?")
+        params.append(gameplan_id)
+    if project:
+        conditions.append("project = ?")
+        params.append(project)
+
+    params.append(limit)
+
+    with db.get_connection() as conn:
+        cursor = conn.execute(f"""
+            SELECT * FROM tasks WHERE {' AND '.join(conditions)}
+            ORDER BY priority, created_at DESC LIMIT ?
+        """, params)
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def update_task(task_id: int, **kwargs) -> bool:
+    """Update task fields."""
+    if not kwargs:
+        return False
+
+    sets = []
+    params = []
+
+    for key, value in kwargs.items():
+        sets.append(f"{key} = ?")
+        params.append(value)
+        # Set completed_at when status becomes done
+        if key == 'status' and value == 'done':
+            sets.append("completed_at = CURRENT_TIMESTAMP")
+
+    sets.append("updated_at = CURRENT_TIMESTAMP")
+    params.append(task_id)
+
+    with db.get_connection() as conn:
+        cursor = conn.execute(
+            f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", params
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
+def delete_task(task_id: int) -> bool:
+    """Delete task."""
+    with db.get_connection() as conn:
+        cursor = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+        conn.commit()
+        return cursor.rowcount > 0
+
+
+def get_dependencies(task_id: int) -> list[dict[str, Any]]:
+    """Get tasks this task depends on."""
+    with db.get_connection() as conn:
+        cursor = conn.execute("""
+            SELECT t.* FROM tasks t
+            JOIN task_deps d ON t.id = d.depends_on
+            WHERE d.task_id = ?
+        """, (task_id,))
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def get_ready_tasks(gameplan_id: Optional[int] = None) -> list[dict[str, Any]]:
+    """Get tasks ready to work (open + all deps done)."""
+    conditions = ["t.status = 'open'"]
+    params = []
+
+    if gameplan_id:
+        conditions.append("t.gameplan_id = ?")
+        params.append(gameplan_id)
+
+    with db.get_connection() as conn:
+        cursor = conn.execute(f"""
+            SELECT t.* FROM tasks t
+            WHERE {' AND '.join(conditions)}
+            AND NOT EXISTS (
+                SELECT 1 FROM task_deps d
+                JOIN tasks dep ON d.depends_on = dep.id
+                WHERE d.task_id = t.id AND dep.status != 'done'
+            )
+            ORDER BY t.priority, t.created_at
+        """, params)
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def add_dependency(task_id: int, depends_on: int) -> bool:
+    """Add dependency. Returns False if would create cycle."""
+    if task_id == depends_on:
+        return False
+    if _would_cycle(task_id, depends_on):
+        return False
+
+    with db.get_connection() as conn:
+        try:
+            conn.execute(
+                "INSERT INTO task_deps (task_id, depends_on) VALUES (?, ?)",
+                (task_id, depends_on)
+            )
+            conn.commit()
+            return True
+        except Exception:
+            return False
+
+
+def _would_cycle(task_id: int, new_dep: int) -> bool:
+    """Check if adding dep would create cycle (DFS)."""
+    visited, stack = set(), [new_dep]
+    with db.get_connection() as conn:
+        while stack:
+            current = stack.pop()
+            if current == task_id:
+                return True
+            if current in visited:
+                continue
+            visited.add(current)
+            cursor = conn.execute(
+                "SELECT depends_on FROM task_deps WHERE task_id = ?", (current,)
+            )
+            stack.extend(row[0] for row in cursor.fetchall())
+    return False
+
+
+def log_progress(task_id: int, message: str) -> int:
+    """Add entry to task log."""
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO task_log (task_id, message) VALUES (?, ?)",
+            (task_id, message)
+        )
+        conn.execute(
+            "UPDATE tasks SET updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (task_id,)
+        )
+        conn.commit()
+        return cursor.lastrowid
+
+
+def get_task_log(task_id: int, limit: int = 20) -> list[dict[str, Any]]:
+    """Get task log entries."""
+    with db.get_connection() as conn:
+        cursor = conn.execute("""
+            SELECT * FROM task_log WHERE task_id = ?
+            ORDER BY created_at DESC LIMIT ?
+        """, (task_id, limit))
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def get_gameplan_stats(gameplan_id: int) -> dict[str, Any]:
+    """Get task stats for a gameplan."""
+    with db.get_connection() as conn:
+        cursor = conn.execute("""
+            SELECT status, COUNT(*) as count FROM tasks
+            WHERE gameplan_id = ? GROUP BY status
+        """, (gameplan_id,))
+        by_status = {row['status']: row['count'] for row in cursor.fetchall()}
+        total = sum(by_status.values())
+        done = by_status.get('done', 0)
+        return {'total': total, 'done': done, 'by_status': by_status}

--- a/emdx/services/task_runner.py
+++ b/emdx/services/task_runner.py
@@ -1,0 +1,104 @@
+"""Task runner - spawns Claude for tasks."""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from emdx.models import tasks
+from emdx.models.documents import get_document
+from emdx.models.executions import create_execution
+from emdx.commands.claude_execute import execute_with_claude_detached
+
+
+def build_task_prompt(task_id: int) -> str:
+    """Build prompt for task execution."""
+    task = tasks.get_task(task_id)
+    if not task:
+        raise ValueError(f"Task {task_id} not found")
+
+    lines = [f"# Task #{task['id']}: {task['title']}", ""]
+
+    # Gameplan context
+    if task['gameplan_id']:
+        doc = get_document(str(task['gameplan_id']))
+        if doc:
+            content = doc['content']
+            if len(content) > 2000:
+                content = content[:2000] + "\n\n[... truncated ...]"
+            lines.extend(["## Context from Gameplan", content, ""])
+
+    if task['description']:
+        lines.extend(["## Description", task['description'], ""])
+
+    if task['current_step']:
+        lines.extend(["## Resume from", f"> {task['current_step']}", ""])
+
+    # Dependencies
+    deps = tasks.get_dependencies(task_id)
+    if deps:
+        lines.append("## Dependencies")
+        for d in deps:
+            icon = '✓' if d['status'] == 'done' else '○'
+            lines.append(f"- {icon} #{d['id']} {d['title']}")
+        lines.append("")
+
+    # Instructions
+    lines.extend([
+        "## Instructions",
+        "1. Complete the task described above",
+        f"2. Log progress: emdx task log {task_id} \"message\"",
+        f"3. When done: emdx task update {task_id} -s done -n \"summary\"",
+        f"4. If blocked: emdx task update {task_id} -s blocked -n \"reason\"",
+    ])
+
+    return "\n".join(lines)
+
+
+def run_task(task_id: int, background: bool = True) -> int:
+    """Run task with Claude. Returns execution ID."""
+    task = tasks.get_task(task_id)
+    if not task:
+        raise ValueError(f"Task {task_id} not found")
+
+    if task['status'] not in ('open', 'blocked'):
+        raise ValueError(f"Task status is '{task['status']}', expected 'open' or 'blocked'")
+
+    # Check deps
+    deps = tasks.get_dependencies(task_id)
+    unsatisfied = [d for d in deps if d['status'] != 'done']
+    if unsatisfied:
+        raise ValueError(f"Unsatisfied deps: {[d['id'] for d in unsatisfied]}")
+
+    # Setup log file
+    log_dir = Path.home() / ".config" / "emdx" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / f"task-{task_id}-{datetime.now().strftime('%Y%m%d%H%M%S')}.log"
+
+    prompt = build_task_prompt(task_id)
+
+    # Create execution record
+    # create_execution(doc_id: int, doc_title: str, log_file: str, working_dir, pid)
+    exec_id = create_execution(
+        doc_id=task['gameplan_id'] or 0,
+        doc_title=f"Task #{task_id}: {task['title']}",
+        log_file=str(log_file),
+        working_dir=str(Path.cwd()),
+    )
+
+    # Update task
+    tasks.update_task(task_id, status='active')
+    tasks.log_progress(task_id, f"Started execution #{exec_id}")
+
+    # Run Claude
+    # execute_with_claude_detached(task, execution_id, log_file: Path, ...)
+    execute_with_claude_detached(
+        task=prompt,
+        execution_id=exec_id,
+        log_file=log_file,  # Path object
+        allowed_tools=None,
+        working_dir=str(Path.cwd()),
+        doc_id=str(task['gameplan_id']) if task['gameplan_id'] else None,
+        context=None,
+    )
+
+    return exec_id

--- a/emdx/ui/browser_container.py
+++ b/emdx/ui/browser_container.py
@@ -154,6 +154,9 @@ class BrowserContainer(App):
                     from textual.widgets import Static
                     self.browsers[browser_type] = Static(f"Agent browser failed to load:\n{str(e)}\n\nCheck logs for details.")
                     logger.error(f"AgentBrowser creation failed, showing error message")
+            elif browser_type == "control":
+                from .control_center import ControlCenterBrowser
+                self.browsers[browser_type] = ControlCenterBrowser()
             else:
                 # Fallback to document
                 browser_type = "document"
@@ -214,7 +217,11 @@ class BrowserContainer(App):
             await self.switch_browser("agent")
             event.stop()
             return
-        elif key == "q" and self.current_browser in ["file", "git", "log", "agent"]:
+        elif key == "c" and self.current_browser == "document":
+            await self.switch_browser("control")
+            event.stop()
+            return
+        elif key == "q" and self.current_browser in ["file", "git", "log", "agent", "control"]:
             await self.switch_browser("document")
             event.stop()
             return

--- a/emdx/ui/control_center.py
+++ b/emdx/ui/control_center.py
@@ -1,0 +1,270 @@
+"""Control center browser - task and gameplan view."""
+
+import logging
+from typing import Optional
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.widget import Widget
+from textual.widgets import DataTable, Static
+
+from emdx.models import tasks
+from emdx.models.tags import search_by_tags
+
+logger = logging.getLogger(__name__)
+
+ICONS = {'open': '○', 'active': '●', 'blocked': '⚠', 'done': '✓', 'failed': '✗'}
+
+
+class ControlCenterBrowser(Widget):
+    """Task and gameplan browser."""
+
+    BINDINGS = [
+        Binding("j", "cursor_down", "Down"),
+        Binding("k", "cursor_up", "Up"),
+        Binding("tab", "switch_panel", "Switch"),
+        Binding("enter", "select", "Select"),
+        Binding("n", "new_task", "New Task"),
+        Binding("a", "toggle_active", "Active Only"),
+        Binding("r", "refresh", "Refresh"),
+    ]
+
+    DEFAULT_CSS = """
+    ControlCenterBrowser {
+        layout: vertical;
+        height: 100%;
+    }
+
+    #cc-main {
+        height: 1fr;
+    }
+
+    #cc-left {
+        width: 50%;
+        border-right: solid $primary;
+    }
+
+    #cc-right {
+        width: 50%;
+    }
+
+    .cc-header {
+        height: 1;
+        background: $boost;
+        padding: 0 1;
+        text-style: bold;
+    }
+
+    .cc-subheader {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+    }
+
+    #cc-status {
+        dock: bottom;
+        height: 1;
+        background: $surface;
+        padding: 0 1;
+    }
+
+    DataTable {
+        height: 1fr;
+    }
+
+    .empty-message {
+        padding: 1 2;
+        color: $text-muted;
+    }
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.gameplans = []
+        self.task_list = []
+        self.selected_gameplan = None
+        self.focus_left = True
+        self.active_only = True  # Default to showing only active gameplans
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(id="cc-main"):
+            with Vertical(id="cc-left"):
+                yield Static("🎯 Gameplans (active)", id="gp-header", classes="cc-header")
+                yield DataTable(id="gp-table", cursor_type="row")
+            with Vertical(id="cc-right"):
+                yield Static("📋 Tasks", id="task-header", classes="cc-header")
+                yield Static("Select a gameplan to see tasks", classes="cc-subheader", id="task-subheader")
+                yield DataTable(id="task-table", cursor_type="row")
+        yield Static("", id="cc-status")
+
+    def on_mount(self) -> None:
+        # Setup gameplan table
+        gp_table = self.query_one("#gp-table", DataTable)
+        gp_table.add_column("", width=2)  # Status icon
+        gp_table.add_column("ID", width=5)
+        gp_table.add_column("Title", width=35)
+        gp_table.add_column("Progress", width=8)
+
+        # Setup task table
+        task_table = self.query_one("#task-table", DataTable)
+        task_table.add_column("", width=2)  # Status icon
+        task_table.add_column("ID", width=5)
+        task_table.add_column("Title", width=40)
+        task_table.add_column("P", width=2)
+
+        self._load_gameplans()
+        self._update_status()
+
+        gp_table.focus()
+
+    def _load_gameplans(self) -> None:
+        """Load docs tagged with 🎯, optionally filtered by 🚀 (active)."""
+        table = self.query_one("#gp-table", DataTable)
+        table.clear()
+
+        try:
+            if self.active_only:
+                # Only show gameplans tagged with both 🎯 AND 🚀
+                self.gameplans = search_by_tags(["🎯", "🚀"], mode="all", limit=50)
+                header = self.query_one("#gp-header", Static)
+                header.update("🎯 Gameplans (🚀 active)")
+            else:
+                # Show all gameplans
+                self.gameplans = search_by_tags(["🎯"], mode="any", limit=50)
+                header = self.query_one("#gp-header", Static)
+                header.update("🎯 Gameplans (all)")
+
+            if not self.gameplans:
+                table.add_row("", "", "[dim]No gameplans found[/dim]", "")
+                return
+
+            for doc in self.gameplans:
+                stats = tasks.get_gameplan_stats(doc['id'])
+                total = stats['total']
+                done = stats['done']
+
+                # Progress indicator
+                if total == 0:
+                    progress = "[dim]—[/dim]"
+                    icon = "📝"
+                elif done == total:
+                    progress = f"[green]{done}/{total}[/green]"
+                    icon = "✅"
+                else:
+                    progress = f"{done}/{total}"
+                    icon = "🚀" if "🚀" in doc.get('tags', []) else "📝"
+
+                title = doc['title'][:35] if len(doc['title']) > 35 else doc['title']
+                table.add_row(icon, str(doc['id']), title, progress)
+
+        except Exception as e:
+            logger.error(f"Load gameplans error: {e}", exc_info=True)
+
+    def _load_tasks(self, gameplan_id: Optional[int] = None) -> None:
+        """Load tasks for selected gameplan."""
+        table = self.query_one("#task-table", DataTable)
+        table.clear()
+
+        # Update subheader
+        subheader = self.query_one("#task-subheader", Static)
+
+        try:
+            if gameplan_id is None:
+                subheader.update("Select a gameplan to see tasks")
+                return
+
+            self.task_list = tasks.list_tasks(gameplan_id=gameplan_id, limit=50)
+
+            if not self.task_list:
+                subheader.update(f"GP #{gameplan_id} - No tasks yet (press 'n' to create)")
+                table.add_row("", "", "[dim]No tasks for this gameplan[/dim]", "")
+                return
+
+            # Count by status
+            by_status = {}
+            for t in self.task_list:
+                by_status[t['status']] = by_status.get(t['status'], 0) + 1
+
+            status_summary = " | ".join(f"{ICONS.get(s, '?')}{c}" for s, c in by_status.items())
+            subheader.update(f"GP #{gameplan_id} - {status_summary}")
+
+            for t in self.task_list:
+                icon = ICONS.get(t['status'], '?')
+                title = t['title'][:40] if len(t['title']) > 40 else t['title']
+
+                # Color based on status
+                if t['status'] == 'done':
+                    title = f"[dim]{title}[/dim]"
+                elif t['status'] == 'blocked':
+                    title = f"[yellow]{title}[/yellow]"
+                elif t['status'] == 'active':
+                    title = f"[green]{title}[/green]"
+
+                table.add_row(icon, str(t['id']), title, str(t['priority']))
+
+        except Exception as e:
+            logger.error(f"Load tasks error: {e}", exc_info=True)
+
+    def _update_status(self) -> None:
+        status = self.query_one("#cc-status", Static)
+        gp_text = f"GP #{self.selected_gameplan}" if self.selected_gameplan else "No selection"
+
+        try:
+            ready_count = len(tasks.get_ready_tasks(gameplan_id=self.selected_gameplan))
+            ready_text = f"{ready_count} ready" if ready_count else "0 ready"
+        except:
+            ready_text = ""
+
+        filter_text = "active" if self.active_only else "all"
+        status.update(f"{gp_text} | {ready_text} | [a] {filter_text} | [n] new | [Tab] switch | [q] back")
+
+    def action_cursor_down(self) -> None:
+        table_id = "#gp-table" if self.focus_left else "#task-table"
+        self.query_one(table_id, DataTable).action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        table_id = "#gp-table" if self.focus_left else "#task-table"
+        self.query_one(table_id, DataTable).action_cursor_up()
+
+    def action_switch_panel(self) -> None:
+        self.focus_left = not self.focus_left
+        table_id = "#gp-table" if self.focus_left else "#task-table"
+        self.query_one(table_id, DataTable).focus()
+
+    def action_select(self) -> None:
+        if self.focus_left:
+            table = self.query_one("#gp-table", DataTable)
+            if table.cursor_row is not None and table.cursor_row < len(self.gameplans):
+                self.selected_gameplan = self.gameplans[table.cursor_row]['id']
+                self._load_tasks(self.selected_gameplan)
+                self._update_status()
+
+    def action_toggle_active(self) -> None:
+        """Toggle between active-only and all gameplans."""
+        self.active_only = not self.active_only
+        self._load_gameplans()
+        self._update_status()
+
+    def action_new_task(self) -> None:
+        """Show command to create a new task."""
+        if self.selected_gameplan:
+            self.notify(f"Run: emdx task create \"Task title\" -g {self.selected_gameplan}")
+        else:
+            self.notify("Run: emdx task create \"Task title\"")
+
+    def action_refresh(self) -> None:
+        """Refresh the view."""
+        self._load_gameplans()
+        if self.selected_gameplan:
+            self._load_tasks(self.selected_gameplan)
+        self._update_status()
+
+    def on_data_table_row_highlighted(self, event) -> None:
+        """Handle row selection."""
+        if self.focus_left and event.data_table.id == "gp-table":
+            if event.cursor_row is not None and event.cursor_row < len(self.gameplans):
+                gp = self.gameplans[event.cursor_row]
+                self.selected_gameplan = gp['id']
+                self._load_tasks(gp['id'])
+                self._update_status()


### PR DESCRIPTION
## Summary

Implements the "Gas Town" vision for Claude-driven task execution:

- **Task tables**: `tasks`, `task_deps`, `task_log` (migration 009)
- **Task model**: CRUD, dependencies with cycle detection, ready tasks query
- **Task CLI**: create, list, show, update, log, ready, depends, delete, run
- **Control Center TUI**: gameplans + tasks dual-pane view with active/all filter
- **Task runner**: direct Claude execution via detached process

### Key Design Decisions

The task system is **independent of workflows by design**. Tasks can be linked to gameplans (docs tagged 🎯) and executed directly or via workflows. The `task_executions` join table (documented in emdx #1846, not yet implemented) will connect tasks to workflow runs.

### New Commands

```bash
emdx task create "Title" -g <gameplan_id> -p <priority>
emdx task list [-s status] [-g gameplan]
emdx task show <id>
emdx task update <id> -s <status> -n "note"
emdx task ready              # show tasks with satisfied dependencies
emdx task depends <id> --on <other_id>
emdx task run <id>           # execute task with Claude
```

### TUI Access

Press `c` in document browser to access Control Center. Press `a` to toggle active-only gameplans.

## Test plan

- [x] Create tasks via CLI
- [x] View tasks in Control Center TUI
- [x] Filter gameplans by active tag
- [x] Task dependencies prevent ready status until satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)