### PR TITLE
fix: prevent race condition in worktree creation

### DIFF
--- a/emdx/commands/workflows.py
+++ b/emdx/commands/workflows.py
@@ -31,6 +31,9 @@ def create_worktree_for_workflow(base_branch: str = "main") -> tuple[str, str]:
     Returns:
         Tuple of (worktree_path, branch_name)
     """
+    import random
+    import os
+
     # Get the repo root
     result = subprocess.run(
         ["git", "rev-parse", "--show-toplevel"],
@@ -38,10 +41,13 @@ def create_worktree_for_workflow(base_branch: str = "main") -> tuple[str, str]:
     )
     repo_root = result.stdout.strip()
 
-    # Create unique branch and worktree names
+    # Create unique branch and worktree names with timestamp + random + pid
     timestamp = int(time.time())
-    branch_name = f"workflow-{timestamp}"
-    worktree_dir = Path(repo_root).parent / f"emdx-workflow-{timestamp}"
+    random_suffix = random.randint(1000, 9999)
+    pid = os.getpid()
+    unique_id = f"{timestamp}-{pid}-{random_suffix}"
+    branch_name = f"workflow-{unique_id}"
+    worktree_dir = Path(repo_root).parent / f"emdx-workflow-{unique_id}"
 
     # Create the worktree
     subprocess.run(


### PR DESCRIPTION
## Summary
Fix race condition when multiple workflows start simultaneously and try to create worktrees with the same name.

## Problem
When launching multiple `emdx workflow run -w` commands in parallel, they all got the same timestamp resulting in branch name collisions:
```
fatal: cannot lock ref 'refs/heads/workflow-1767856051': reference already exists
```

## Solution
Add PID and random suffix to worktree/branch names:
- Before: `workflow-{timestamp}` 
- After: `workflow-{timestamp}-{pid}-{random}`

This ensures uniqueness even when multiple workflows start in the same second.

## Testing
- [x] Launched 6 workflows simultaneously - all created unique worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)