### PR TITLE
fix: workflow variables override defaults instead of vice versa

### DIFF
--- a/emdx/workflows/executor.py
+++ b/emdx/workflows/executor.py
@@ -116,12 +116,12 @@ class WorkflowExecutor:
                     context['input'] = doc.get('content', '')
                     context['input_title'] = doc.get('title', '')
 
-            # Merge with provided variables
+            # Merge workflow default variables first
+            context.update(workflow.variables)
+
+            # Then merge user-provided variables (override defaults)
             if input_variables:
                 context.update(input_variables)
-
-            # Also merge workflow default variables
-            context.update(workflow.variables)
 
             # Execute stages sequentially
             for stage in workflow.stages:


### PR DESCRIPTION
## Summary
Fixed a bug where user-provided workflow variables (`-v key=value`) were being overwritten by workflow default variables.

## The Bug
In `emdx/workflows/executor.py`, the order of variable merging was wrong:
```python
# OLD (buggy):
if input_variables:
    context.update(input_variables)  # User vars
context.update(workflow.variables)   # Defaults OVERWRITE user vars!
```

This meant that custom `task_title`, `task_description`, etc. passed via `-v` were always ignored.

## The Fix
```python
# NEW (correct):
context.update(workflow.variables)   # Defaults first
if input_variables:
    context.update(input_variables)  # User vars OVERRIDE defaults
```

## Testing
- All 161 tests pass
- Manually verified workflow now receives correct variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)