### PR TITLE
fix(tech-debt): Remove redundant exception tuple (Issue #3073)

### DIFF
--- a/emdx/ui/agent_form.py
+++ b/emdx/ui/agent_form.py
@@ -323,7 +323,7 @@ class AgentForm(Widget):
                 next_index = (current_index + 1) % len(self.field_order)
                 next_field_id = self.field_order[next_index]
                 self.query_one(f"#{next_field_id}").focus()
-        except (ValueError, Exception):
+        except Exception:
             # If current field not found, focus first field
             self.query_one("#agent-name").focus()
     
@@ -337,7 +337,7 @@ class AgentForm(Widget):
                 prev_index = (current_index - 1) % len(self.field_order)
                 prev_field_id = self.field_order[prev_index]
                 self.query_one(f"#{prev_field_id}").focus()
-        except (ValueError, Exception):
+        except Exception:
             # If current field not found, focus last field
             self.query_one("#agent-user-prompt").focus()
     


### PR DESCRIPTION
## Summary
- Remove redundant `ValueError` from `(ValueError, Exception)` exception tuples in `agent_form.py`
- Affects `focus_next_field()` and `focus_previous_field()` methods
- Since `Exception` is the base class for `ValueError`, catching `Exception` alone is sufficient

## Task Reference
Fixes QW-2 from tech debt gameplan #3073

## Files Changed
- `emdx/ui/agent_form.py`: Simplified exception handlers from `(ValueError, Exception)` to `Exception`

## Test plan
- [x] Verified tests pass (excluding pre-existing failing test in `test_sqlite_database.py`)
- [x] No functional change - purely code cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)