### PR TITLE
fix(tech-debt): Task #3073 - Raise NotImplementedError in get_pattern_stats (QW-13)

### DIFF
--- a/emdx/services/auto_tagger.py
+++ b/emdx/services/auto_tagger.py
@@ -450,9 +450,11 @@ class AutoTagger:
         Returns:
             Dictionary mapping pattern names to match counts
 
-        Note: Pattern usage tracking is not currently implemented.
-        This would require persistent storage of match history.
+        Raises:
+            NotImplementedError: Pattern usage tracking is not currently implemented.
+                This would require persistent storage of match history.
         """
-        # Pattern usage tracking not yet implemented
-        # Would require database table to store pattern match history and analytics
-        return {}
+        raise NotImplementedError(
+            "Pattern usage tracking is not implemented. "
+            "This would require a database table to store pattern match history."
+        )


### PR DESCRIPTION
## Summary
- Changed `get_pattern_stats()` in `auto_tagger.py` to raise `NotImplementedError` instead of silently returning an empty dict
- This makes it explicit that pattern usage tracking is not yet implemented
- Callers will now get a clear error rather than confusing empty results

## Task Details
- **Task**: QW-13 from tech debt epic #3073
- **Issue**: The method returned `{}` silently, which could confuse callers expecting actual statistics
- **Solution**: Raise `NotImplementedError` with a descriptive message explaining the feature is not implemented

## Test plan
- [x] Verified no existing code calls this method (it was unused)
- [x] All auto_tagger tests pass (17 tests)
- [x] All other tests pass (159 passed, 1 skipped)
  - Note: `test_search_documents_basic` was already failing before this change (pre-existing issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)