### PR TITLE
fix(tech-debt): Fix redundant exception tuple in agent_form.py (Issue #3073)

### DIFF
--- a/emdx/ui/agent_form.py
+++ b/emdx/ui/agent_form.py
@@ -323,8 +323,8 @@ class AgentForm(Widget):
                 next_index = (current_index + 1) % len(self.field_order)
                 next_field_id = self.field_order[next_index]
                 self.query_one(f"#{next_field_id}").focus()
-        except (ValueError, Exception):
-            # If current field not found, focus first field
+        except ValueError:
+            # If current field not found in field_order, focus first field
             self.query_one("#agent-name").focus()
     
     def focus_previous_field(self):
@@ -337,8 +337,8 @@ class AgentForm(Widget):
                 prev_index = (current_index - 1) % len(self.field_order)
                 prev_field_id = self.field_order[prev_index]
                 self.query_one(f"#{prev_field_id}").focus()
-        except (ValueError, Exception):
-            # If current field not found, focus last field
+        except ValueError:
+            # If current field not found in field_order, focus last field
             self.query_one("#agent-user-prompt").focus()
     
     def show_validation_error(self, message: str):


### PR DESCRIPTION
## Summary
- Fixed redundant exception tuple `except (ValueError, Exception):` in `emdx/ui/agent_form.py`
- Changed to `except ValueError:` in both `focus_next_field()` and `focus_previous_field()` methods
- The original code was redundant because `Exception` is a parent class of `ValueError`

## Changes
- `emdx/ui/agent_form.py:326`: Changed to catch only `ValueError`
- `emdx/ui/agent_form.py:340`: Changed to catch only `ValueError`

## Rationale
The `.index()` method raises `ValueError` when the item is not found. By catching only `ValueError`:
1. We handle the expected case (field ID not found in `field_order`)
2. Other unexpected exceptions will propagate for debugging instead of being silently handled

## Test plan
- [x] All 159 tests pass (excluding pre-existing failing test in `test_sqlite_database.py`)
- [x] Change is minimal and focused on the specific tech debt item

🤖 Generated with [Claude Code](https://claude.com/claude-code)