### PR TITLE
fix(tech-debt): Replace if-elif chain with dict in get_file_icon() (Issue #56)

### DIFF
--- a/emdx/ui/file_list.py
+++ b/emdx/ui/file_list.py
@@ -14,6 +14,57 @@ from emdx.database import db
 
 logger = logging.getLogger(__name__)
 
+# Icon mappings for file extensions
+EXTENSION_ICONS = {
+    # Code files
+    ".py": "🐍", ".pyw": "🐍",
+    ".js": "📜", ".jsx": "📜", ".ts": "📜", ".tsx": "📜",
+    ".rs": "🦀",
+    ".go": "🐹",
+    ".java": "☕", ".class": "☕", ".jar": "☕",
+    ".c": "⚙️", ".cpp": "⚙️", ".cc": "⚙️", ".h": "⚙️", ".hpp": "⚙️",
+    ".swift": "🦉",
+    ".rb": "💎",
+    # Web files
+    ".html": "🌐", ".htm": "🌐",
+    ".css": "🎨", ".scss": "🎨", ".sass": "🎨",
+    # Data files
+    ".json": "📊", ".yaml": "📊", ".yml": "📊", ".toml": "📊",
+    ".xml": "📋",
+    ".sql": "🗃️", ".db": "🗃️", ".sqlite": "🗃️",
+    # Docs
+    ".md": "📝", ".markdown": "📝",
+    ".txt": "📄", ".text": "📄",
+    ".pdf": "📕",
+    ".doc": "📘", ".docx": "📘",
+    # Images
+    ".png": "🖼️", ".jpg": "🖼️", ".jpeg": "🖼️", ".gif": "🖼️", ".svg": "🖼️", ".ico": "🖼️",
+    # Archives
+    ".zip": "📦", ".tar": "📦", ".gz": "📦", ".bz2": "📦", ".xz": "📦", ".7z": "📦",
+    # Scripts
+    ".sh": "🔨", ".bash": "🔨", ".zsh": "🔨", ".fish": "🔨",
+    ".bat": "🪟",
+}
+
+# Icon mappings for specific filenames
+FILENAME_ICONS = {
+    ".gitignore": "⚙️",
+    ".env": "⚙️",
+    ".editorconfig": "⚙️",
+    "Makefile": "🔧",
+    "Dockerfile": "🐳",
+    "docker-compose.yml": "🐳",
+}
+
+# Icon mappings for special directories
+SPECIAL_DIR_ICONS = {
+    ".git": "🔧",
+    "node_modules": "📦",
+    "__pycache__": "📦",
+    ".venv": "📦",
+    "venv": "📦",
+}
+
 
 class FileList(DataTable):
     """File listing with icons and metadata."""
@@ -142,82 +193,15 @@ class FileList(DataTable):
     def get_file_icon(self, path: Path) -> str:
         """Return emoji icon for file type."""
         if path.is_dir():
-            # Special folders
-            if path.name == ".git":
-                return "🔧"
-            elif path.name in {"node_modules", "__pycache__", ".venv", "venv"}:
-                return "📦"
-            return "📁"
-        
-        # File icons by extension
+            return SPECIAL_DIR_ICONS.get(path.name, "📁")
+
+        # Check specific filenames first
+        if path.name in FILENAME_ICONS:
+            return FILENAME_ICONS[path.name]
+
+        # Check by extension
         ext = path.suffix.lower()
-        
-        # Code files
-        if ext in {".py", ".pyw"}:
-            return "🐍"
-        elif ext in {".js", ".jsx", ".ts", ".tsx"}:
-            return "📜"
-        elif ext in {".rs"}:
-            return "🦀"
-        elif ext in {".go"}:
-            return "🐹"
-        elif ext in {".java", ".class", ".jar"}:
-            return "☕"
-        elif ext in {".c", ".cpp", ".cc", ".h", ".hpp"}:
-            return "⚙️"
-        elif ext in {".swift"}:
-            return "🦉"
-        elif ext in {".rb"}:
-            return "💎"
-        
-        # Web files
-        elif ext in {".html", ".htm"}:
-            return "🌐"
-        elif ext in {".css", ".scss", ".sass"}:
-            return "🎨"
-        
-        # Data files
-        elif ext in {".json", ".yaml", ".yml", ".toml"}:
-            return "📊"
-        elif ext in {".xml"}:
-            return "📋"
-        elif ext in {".sql", ".db", ".sqlite"}:
-            return "🗃️"
-        
-        # Docs
-        elif ext in {".md", ".markdown"}:
-            return "📝"
-        elif ext in {".txt", ".text"}:
-            return "📄"
-        elif ext in {".pdf"}:
-            return "📕"
-        elif ext in {".doc", ".docx"}:
-            return "📘"
-        
-        # Images
-        elif ext in {".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico"}:
-            return "🖼️"
-        
-        # Archives
-        elif ext in {".zip", ".tar", ".gz", ".bz2", ".xz", ".7z"}:
-            return "📦"
-        
-        # Scripts
-        elif ext in {".sh", ".bash", ".zsh", ".fish"}:
-            return "🔨"
-        elif ext == ".bat":
-            return "🪟"
-        
-        # Config files
-        elif path.name in {".gitignore", ".env", ".editorconfig"}:
-            return "⚙️"
-        elif path.name == "Makefile":
-            return "🔧"
-        elif path.name in {"Dockerfile", "docker-compose.yml"}:
-            return "🐳"
-        
-        # Default
-        return "📄"
+        return EXTENSION_ICONS.get(ext, "📄")
     
     def format_size(self, size: int) -> str:
         """Format file size in human readable format."""


### PR DESCRIPTION
## Summary
- Refactored `get_file_icon()` in `emdx/ui/file_list.py` from a 50+ line if-elif chain to clean dictionary lookups
- Created three module-level dictionaries: `EXTENSION_ICONS`, `FILENAME_ICONS`, `SPECIAL_DIR_ICONS`
- Reduced method body from ~78 lines to ~12 lines

## Test plan
- [x] All tests pass (excluding pre-existing failure in test_sqlite_database.py)
- [x] Manual verification that file icons display correctly

## Notes
- Pre-existing test failure in `tests/test_sqlite_database.py::TestSQLiteDatabase::test_search_documents_basic` is unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)