### PR TITLE
fix(tech-debt): Remove duplicate DEFAULT_CLAUDE_MODEL constant (Issue #3073)

### DIFF
--- a/emdx/agents/generic.py
+++ b/emdx/agents/generic.py
@@ -37,8 +37,6 @@ class GenericAgent(Agent):
                 f.write(full_prompt)
             
             # Prepare Claude command using same format as claude_execute.py
-            from emdx.utils.constants import DEFAULT_CLAUDE_MODEL
-
             cmd = [
                 "claude",
                 "--print", full_prompt,

--- a/emdx/commands/claude_execute.py
+++ b/emdx/commands/claude_execute.py
@@ -17,7 +17,6 @@ import typer
 from rich.console import Console
 
 from ..models.documents import get_document
-from ..utils.constants import DEFAULT_CLAUDE_MODEL
 from ..models.executions import (
     Execution,
     create_execution,

--- a/emdx/utils/constants.py
+++ b/emdx/utils/constants.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-"""
-Application constants for EMDX.
-"""
-
-# Default Claude model for agent and execution commands
-DEFAULT_CLAUDE_MODEL = "claude-opus-4-5-20251101"


### PR DESCRIPTION
## Summary
- Remove duplicate `DEFAULT_CLAUDE_MODEL` constant that existed in both `emdx/utils/constants.py` and `emdx/config/settings.py`
- Keep single source of truth in `emdx/config/settings.py`
- Remove duplicate imports in `claude_execute.py` (was importing from both locations) and `generic.py` (had inline import in addition to top-level import)

## Test plan
- [x] All tests pass (159 passed, 1 pre-existing failure in test_sqlite_database.py unrelated to these changes)
- [x] No changes to logic, only removing duplicate code

🤖 Generated with [Claude Code](https://claude.com/claude-code)