### PR TITLE
fix(tech-debt): Remove redundant ValueError from exception tuples (Issue #3073)

### DIFF
--- a/emdx/ui/agent_form.py
+++ b/emdx/ui/agent_form.py
@@ -323,7 +323,7 @@ class AgentForm(Widget):
                 next_index = (current_index + 1) % len(self.field_order)
                 next_field_id = self.field_order[next_index]
                 self.query_one(f"#{next_field_id}").focus()
-        except (ValueError, Exception):
+        except Exception:
             # If current field not found, focus first field
             self.query_one("#agent-name").focus()
     
@@ -337,7 +337,7 @@ class AgentForm(Widget):
                 prev_index = (current_index - 1) % len(self.field_order)
                 prev_field_id = self.field_order[prev_index]
                 self.query_one(f"#{prev_field_id}").focus()
-        except (ValueError, Exception):
+        except Exception:
             # If current field not found, focus last field
             self.query_one("#agent-user-prompt").focus()
     


### PR DESCRIPTION
## Summary
- Fixed redundant exception tuple `except (ValueError, Exception):` in `agent_form.py`
- Changed to `except Exception:` which has the same behavior since `Exception` is a superclass of `ValueError`
- This addresses tech debt task QW-2 from epic #3073

## Test plan
- [x] Run `poetry run pytest -x --tb=short` - passes (except pre-existing flaky test)
- [x] Verified the change is functionally equivalent


🤖 Generated with [Claude Code](https://claude.com/claude-code)