### PR TITLE
fix(tech-debt): Task #54 - Remove redundant exception tuple (Issue #54)

### DIFF
--- a/emdx/ui/agent_form.py
+++ b/emdx/ui/agent_form.py
@@ -323,7 +323,7 @@ class AgentForm(Widget):
                 next_index = (current_index + 1) % len(self.field_order)
                 next_field_id = self.field_order[next_index]
                 self.query_one(f"#{next_field_id}").focus()
-        except (ValueError, Exception):
+        except Exception:
             # If current field not found, focus first field
             self.query_one("#agent-name").focus()
     
@@ -337,7 +337,7 @@ class AgentForm(Widget):
                 prev_index = (current_index - 1) % len(self.field_order)
                 prev_field_id = self.field_order[prev_index]
                 self.query_one(f"#{prev_field_id}").focus()
-        except (ValueError, Exception):
+        except Exception:
             # If current field not found, focus last field
             self.query_one("#agent-user-prompt").focus()
     


### PR DESCRIPTION
## Summary
- Removed redundant exception tuple `(ValueError, Exception)` in `emdx/ui/agent_form.py`
- Since `Exception` is the base class that already catches `ValueError`, catching both is redundant
- Fixed in both `focus_next_field()` and `focus_previous_field()` methods (lines 326, 340)

## Changes
- Changed `except (ValueError, Exception):` to `except Exception:` in two locations

## Test plan
- [x] All tests pass (excluding pre-existing failing test in test_sqlite_database.py)
- [x] No functional change - behavior is identical

Fixes task #54 from tech debt gameplan #3073

🤖 Generated with [Claude Code](https://claude.com/claude-code)