### PR TITLE
fix(tech-debt): Replace get_file_icon() if-elif with dict lookup (Issue #3073)

### DIFF
--- a/emdx/ui/file_list.py
+++ b/emdx/ui/file_list.py
@@ -139,85 +139,69 @@ class FileList(DataTable):
             return selected
         return None
     
+    # File extension to icon mappings
+    _EXT_ICONS: dict[str, str] = {
+        # Code files
+        ".py": "🐍", ".pyw": "🐍",
+        ".js": "📜", ".jsx": "📜", ".ts": "📜", ".tsx": "📜",
+        ".rs": "🦀",
+        ".go": "🐹",
+        ".java": "☕", ".class": "☕", ".jar": "☕",
+        ".c": "⚙️", ".cpp": "⚙️", ".cc": "⚙️", ".h": "⚙️", ".hpp": "⚙️",
+        ".swift": "🦉",
+        ".rb": "💎",
+        # Web files
+        ".html": "🌐", ".htm": "🌐",
+        ".css": "🎨", ".scss": "🎨", ".sass": "🎨",
+        # Data files
+        ".json": "📊", ".yaml": "📊", ".yml": "📊", ".toml": "📊",
+        ".xml": "📋",
+        ".sql": "🗃️", ".db": "🗃️", ".sqlite": "🗃️",
+        # Docs
+        ".md": "📝", ".markdown": "📝",
+        ".txt": "📄", ".text": "📄",
+        ".pdf": "📕",
+        ".doc": "📘", ".docx": "📘",
+        # Images
+        ".png": "🖼️", ".jpg": "🖼️", ".jpeg": "🖼️", ".gif": "🖼️", ".svg": "🖼️", ".ico": "🖼️",
+        # Archives
+        ".zip": "📦", ".tar": "📦", ".gz": "📦", ".bz2": "📦", ".xz": "📦", ".7z": "📦",
+        # Scripts
+        ".sh": "🔨", ".bash": "🔨", ".zsh": "🔨", ".fish": "🔨",
+        ".bat": "🪟",
+    }
+
+    # Special directory name to icon mappings
+    _DIR_ICONS: dict[str, str] = {
+        ".git": "🔧",
+        "node_modules": "📦",
+        "__pycache__": "📦",
+        ".venv": "📦",
+        "venv": "📦",
+    }
+
+    # Special file name to icon mappings
+    _NAME_ICONS: dict[str, str] = {
+        ".gitignore": "⚙️",
+        ".env": "⚙️",
+        ".editorconfig": "⚙️",
+        "Makefile": "🔧",
+        "Dockerfile": "🐳",
+        "docker-compose.yml": "🐳",
+    }
+
     def get_file_icon(self, path: Path) -> str:
         """Return emoji icon for file type."""
         if path.is_dir():
-            # Special folders
-            if path.name == ".git":
-                return "🔧"
-            elif path.name in {"node_modules", "__pycache__", ".venv", "venv"}:
-                return "📦"
-            return "📁"
-        
-        # File icons by extension
+            return self._DIR_ICONS.get(path.name, "📁")
+
+        # Check special file names first
+        if path.name in self._NAME_ICONS:
+            return self._NAME_ICONS[path.name]
+
+        # Check extension
         ext = path.suffix.lower()
-        
-        # Code files
-        if ext in {".py", ".pyw"}:
-            return "🐍"
-        elif ext in {".js", ".jsx", ".ts", ".tsx"}:
-            return "📜"
-        elif ext in {".rs"}:
-            return "🦀"
-        elif ext in {".go"}:
-            return "🐹"
-        elif ext in {".java", ".class", ".jar"}:
-            return "☕"
-        elif ext in {".c", ".cpp", ".cc", ".h", ".hpp"}:
-            return "⚙️"
-        elif ext in {".swift"}:
-            return "🦉"
-        elif ext in {".rb"}:
-            return "💎"
-        
-        # Web files
-        elif ext in {".html", ".htm"}:
-            return "🌐"
-        elif ext in {".css", ".scss", ".sass"}:
-            return "🎨"
-        
-        # Data files
-        elif ext in {".json", ".yaml", ".yml", ".toml"}:
-            return "📊"
-        elif ext in {".xml"}:
-            return "📋"
-        elif ext in {".sql", ".db", ".sqlite"}:
-            return "🗃️"
-        
-        # Docs
-        elif ext in {".md", ".markdown"}:
-            return "📝"
-        elif ext in {".txt", ".text"}:
-            return "📄"
-        elif ext in {".pdf"}:
-            return "📕"
-        elif ext in {".doc", ".docx"}:
-            return "📘"
-        
-        # Images
-        elif ext in {".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico"}:
-            return "🖼️"
-        
-        # Archives
-        elif ext in {".zip", ".tar", ".gz", ".bz2", ".xz", ".7z"}:
-            return "📦"
-        
-        # Scripts
-        elif ext in {".sh", ".bash", ".zsh", ".fish"}:
-            return "🔨"
-        elif ext == ".bat":
-            return "🪟"
-        
-        # Config files
-        elif path.name in {".gitignore", ".env", ".editorconfig"}:
-            return "⚙️"
-        elif path.name == "Makefile":
-            return "🔧"
-        elif path.name in {"Dockerfile", "docker-compose.yml"}:
-            return "🐳"
-        
-        # Default
-        return "📄"
+        return self._EXT_ICONS.get(ext, "📄")
     
     def format_size(self, size: int) -> str:
         """Format file size in human readable format."""


### PR DESCRIPTION
## Summary
- Refactors `FileList.get_file_icon()` to use class-level dict lookups instead of a 70+ line if-elif chain
- Organizes icon mappings into three clear dicts: `_EXT_ICONS`, `_DIR_ICONS`, and `_NAME_ICONS`
- Improves code readability, maintainability, and performance (O(1) lookup vs sequential checks)

## Test plan
- [x] All tests pass (159 passed, 1 skipped - pre-existing failure unrelated to this change)
- [x] File icons should display correctly in the file browser TUI

Fixes task QW-4 from tech debt epic #3073

🤖 Generated with [Claude Code](https://claude.com/claude-code)