### PR TITLE
fix(tech-debt): Task #3073 - Fix redundant exception tuples

### DIFF
--- a/emdx/commands/maintain.py
+++ b/emdx/commands/maintain.py
@@ -836,7 +836,7 @@ def _cleanup_processes(dry_run: bool, max_runtime_hours: int = 2) -> Optional[st
             except psutil.NoSuchProcess:
                 # Process already gone
                 terminated += 1
-            except (psutil.AccessDenied, Exception):
+            except Exception:
                 failed += 1
             
             progress.update(task, advance=1)
@@ -1054,7 +1054,7 @@ def cleanup_temp_dirs(
                 # Calculate size
                 size = sum(f.stat().st_size for f in dir_path.rglob('*') if f.is_file())
                 total_size += size
-        except (OSError, PermissionError) as e:
+        except OSError as e:
             logger.warning(f"Could not scan directory {dir_path}: {e}")
     
     if not old_dirs:
@@ -1100,7 +1100,7 @@ def cleanup_temp_dirs(
                 shutil.rmtree(dir_path)
                 removed += 1
                 freed_space += size
-            except (OSError, PermissionError) as e:
+            except OSError as e:
                 logger.warning(f"Failed to remove directory {dir_path}: {e}")
                 failed += 1
             progress.update(task, advance=1)


### PR DESCRIPTION
## Summary
- Fixed redundant exception tuple in `agent_form.py` (QW-2): Changed `except (ValueError, Exception):` to `except Exception:`
- Fixed redundant exception tuples in `maintain.py` (QW-3):
  - Changed `except (psutil.AccessDenied, Exception):` to `except Exception:`
  - Changed `except (OSError, PermissionError):` to `except OSError:` (2 occurrences)

These tuples were redundant because:
- `Exception` is a parent class that already catches `ValueError` and `AccessDenied`
- `PermissionError` is a subclass of `OSError`

## Test plan
- [x] Run `poetry run pytest -x --tb=short` - all tests pass (except pre-existing test_sqlite_database failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)