### PR TITLE
fix(arch): Extract Claude executor to service layer (Issue #94)

### DIFF
--- a/emdx/commands/claude_execute.py
+++ b/emdx/commands/claude_execute.py
@@ -28,6 +28,7 @@ from ..prompts import build_prompt
 from ..config.settings import DEFAULT_CLAUDE_MODEL
 from ..utils.environment import ensure_claude_in_path, validate_execution_environment
 from ..utils.structured_logger import ProcessType, StructuredLogger
+from ..services.claude_executor import execute_claude_detached as _execute_claude_detached
 
 app = typer.Typer(name="claude", help="Execute documents with Claude")
 console = Console()
@@ -371,130 +372,24 @@ def execute_with_claude_detached(
     This function starts Claude and returns immediately without waiting.
     The subprocess continues running independently of the parent process.
 
+    Note: This is a thin wrapper around the service layer implementation.
+    The context parameter is ignored (kept for backwards compatibility).
+
     Returns:
         The process ID of the started subprocess.
     """
     if allowed_tools is None:
         allowed_tools = DEFAULT_ALLOWED_TOOLS
 
-    # Validate environment first
-    is_valid, env_info = validate_execution_environment(verbose=False)
-    if not is_valid:
-        error_msg = "; ".join(env_info.get('errors', ['Unknown error']))
-        console.print(f"[red]Environment validation failed: {error_msg}[/red]")
-        raise RuntimeError(f"Environment validation failed: {error_msg}")
-    
-    # Ensure claude is in PATH
-    ensure_claude_in_path()
-
-    # Expand @filename references
-    expanded_task = parse_task_content(task)
-
-    # Build Claude command
-    cmd = [
-        "claude",
-        "--print", expanded_task,
-        "--allowedTools", ",".join(allowed_tools),
-        "--output-format", "stream-json",
-        "--model", DEFAULT_CLAUDE_MODEL,
-        "--verbose"
-    ]
-
-    # Ensure log directory exists
-    log_file.parent.mkdir(parents=True, exist_ok=True)
-
-    # Initialize structured logger for main process
-    main_logger = StructuredLogger(log_file, ProcessType.MAIN, os.getpid())
-    main_logger.info(f"Preparing to execute document #{doc_id or 'unknown'}", {
-        "doc_id": doc_id,
-        "working_dir": working_dir,
-        "allowed_tools": allowed_tools
-    })
-
-    # Start subprocess in detached mode using wrapper
-    try:
-        # Get the wrapper script path
-        wrapper_path = Path(__file__).parent.parent / "utils" / "claude_wrapper.py"
-
-        # Build wrapper command: wrapper.py exec_id log_file claude_command...
-        # Use the Python interpreter from the current environment
-        # If we're in pipx, use the underlying venv Python
-        python_path = sys.executable
-        if "pipx" in python_path and "venvs" in python_path:
-            # We're running from pipx, use the venv's python directly
-            import sysconfig
-            venv_bin = Path(sysconfig.get_path("scripts"))
-            python_path = str(venv_bin / "python")
-        
-        wrapper_cmd = [
-            python_path,
-            str(wrapper_path),
-            str(execution_id),  # Convert numeric ID to string for command line
-            str(log_file)
-        ] + cmd
-
-        # Use nohup for true detachment
-        nohup_cmd = ["nohup"] + wrapper_cmd
-
-
-        # Open log file for appending
-        log_handle = open(log_file, 'a')
-
-        # Ensure PATH contains the claude binary location
-        env = os.environ.copy()
-        env['PYTHONUNBUFFERED'] = '1'
-        # Make sure PATH is preserved
-        if 'PATH' not in env:
-            env['PATH'] = '/usr/local/bin:/usr/bin:/bin'
-
-        process = subprocess.Popen(
-            nohup_cmd,
-            stdin=subprocess.DEVNULL,  # Critical: no stdin blocking
-            stdout=log_handle,  # Direct to file, no pipe
-            stderr=subprocess.STDOUT,
-            cwd=working_dir,
-            env=env,
-            start_new_session=True,  # Better than preexec_fn
-            close_fds=True  # Don't inherit file descriptors
-        )
-
-        # Close the file handle in parent process
-        log_handle.close()
-
-        # Don't write to log - let wrapper handle all logging
-
-        # Return immediately - don't wait or read from pipes
-        # Note: Don't use console.print here as stdout might be redirected
-        # Print to stderr instead to avoid log pollution
-        print(f"\033[32m✅ Claude started in background (PID: {process.pid})\033[0m", file=sys.stderr)
-        print(f"Monitor with: emdx exec show {execution_id}", file=sys.stderr)
-
-        return process.pid
-
-    except FileNotFoundError as e:
-        # Handle missing nohup
-        if "nohup" in str(e):
-            # Fallback without nohup
-            log_handle = open(log_file, 'a')
-
-            process = subprocess.Popen(
-                wrapper_cmd,  # Use wrapper even without nohup
-                stdin=subprocess.DEVNULL,
-                stdout=log_handle,
-                stderr=subprocess.STDOUT,
-                cwd=working_dir,
-                env=env,  # Use same env as nohup version
-                start_new_session=True,
-                close_fds=True
-            )
-
-            log_handle.close()
-
-            # Print to stderr to avoid log pollution
-            print(f"\033[32m✅ Claude started in background (PID: {process.pid}) [no nohup]\033[0m", file=sys.stderr)
-            return process.pid
-        else:
-            raise
+    # Delegate to service layer
+    return _execute_claude_detached(
+        task=task,
+        execution_id=execution_id,
+        log_file=log_file,
+        allowed_tools=allowed_tools,
+        working_dir=working_dir,
+        doc_id=doc_id,
+    )
 
 
 def execute_with_claude(

--- a/emdx/services/claude_executor.py
+++ b/emdx/services/claude_executor.py
@@ -1,0 +1,204 @@
+"""Claude execution service - handles spawning and managing Claude processes.
+
+This module provides the core execution logic for running Claude Code processes.
+It is used by both:
+- commands/claude_execute.py (CLI interface)
+- services/task_runner.py (programmatic task execution)
+
+This separation breaks the bidirectional dependency between commands and services.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from ..config.settings import DEFAULT_CLAUDE_MODEL
+from ..utils.environment import ensure_claude_in_path, validate_execution_environment
+from ..utils.structured_logger import ProcessType, StructuredLogger
+
+
+# Default allowed tools for Claude
+DEFAULT_ALLOWED_TOOLS = [
+    "Read", "Write", "Edit", "MultiEdit", "Bash",
+    "Glob", "Grep", "LS", "Task", "TodoWrite"
+]
+
+
+def parse_task_content(task: str) -> str:
+    """Parse task string, expanding @filename references.
+
+    Args:
+        task: Task description potentially containing @filename references
+
+    Returns:
+        Expanded task content with file contents included
+    """
+    import re
+
+    # Find all @filename references
+    pattern = r'@([^\s]+)'
+
+    def replace_file_reference(match):
+        filename = match.group(1)
+        filepath = Path(filename)
+
+        if filepath.exists() and filepath.is_file():
+            try:
+                content = filepath.read_text()
+                return f"\n\nHere is the content of {filename}:\n\n```\n{content}\n```"
+            except Exception:
+                return f"[File not found: {filename}]"
+        else:
+            return f"[File not found: {filename}]"
+
+    # Replace all @filename references
+    expanded = re.sub(pattern, replace_file_reference, task)
+    return expanded
+
+
+def execute_claude_detached(
+    task: str,
+    execution_id: int,
+    log_file: Path,
+    allowed_tools: Optional[List[str]] = None,
+    working_dir: Optional[str] = None,
+    doc_id: Optional[str] = None,
+) -> int:
+    """Execute a task with Claude in a fully detached background process.
+
+    This function starts Claude and returns immediately without waiting.
+    The subprocess continues running independently of the parent process.
+
+    Args:
+        task: The task prompt to execute
+        execution_id: Numeric database execution ID
+        log_file: Path to the log file
+        allowed_tools: List of allowed tools (defaults to DEFAULT_ALLOWED_TOOLS)
+        working_dir: Working directory for execution
+        doc_id: Document ID (for logging)
+
+    Returns:
+        The process ID of the started subprocess.
+
+    Raises:
+        RuntimeError: If environment validation fails.
+    """
+    if allowed_tools is None:
+        allowed_tools = DEFAULT_ALLOWED_TOOLS
+
+    # Validate environment first
+    is_valid, env_info = validate_execution_environment(verbose=False)
+    if not is_valid:
+        error_msg = "; ".join(env_info.get('errors', ['Unknown error']))
+        raise RuntimeError(f"Environment validation failed: {error_msg}")
+
+    # Ensure claude is in PATH
+    ensure_claude_in_path()
+
+    # Expand @filename references
+    expanded_task = parse_task_content(task)
+
+    # Build Claude command
+    cmd = [
+        "claude",
+        "--print", expanded_task,
+        "--allowedTools", ",".join(allowed_tools),
+        "--output-format", "stream-json",
+        "--model", DEFAULT_CLAUDE_MODEL,
+        "--verbose"
+    ]
+
+    # Ensure log directory exists
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Initialize structured logger for main process
+    main_logger = StructuredLogger(log_file, ProcessType.MAIN, os.getpid())
+    main_logger.info(f"Preparing to execute document #{doc_id or 'unknown'}", {
+        "doc_id": doc_id,
+        "working_dir": working_dir,
+        "allowed_tools": allowed_tools
+    })
+
+    # Start subprocess in detached mode using wrapper
+    try:
+        # Get the wrapper script path
+        wrapper_path = Path(__file__).parent.parent / "utils" / "claude_wrapper.py"
+
+        # Build wrapper command: wrapper.py exec_id log_file claude_command...
+        # Use the Python interpreter from the current environment
+        # If we're in pipx, use the underlying venv Python
+        python_path = sys.executable
+        if "pipx" in python_path and "venvs" in python_path:
+            # We're running from pipx, use the venv's python directly
+            import sysconfig
+            venv_bin = Path(sysconfig.get_path("scripts"))
+            python_path = str(venv_bin / "python")
+
+        wrapper_cmd = [
+            python_path,
+            str(wrapper_path),
+            str(execution_id),  # Convert numeric ID to string for command line
+            str(log_file)
+        ] + cmd
+
+        # Use nohup for true detachment
+        nohup_cmd = ["nohup"] + wrapper_cmd
+
+        # Open log file for appending
+        log_handle = open(log_file, 'a')
+
+        # Ensure PATH contains the claude binary location
+        env = os.environ.copy()
+        env['PYTHONUNBUFFERED'] = '1'
+        # Make sure PATH is preserved
+        if 'PATH' not in env:
+            env['PATH'] = '/usr/local/bin:/usr/bin:/bin'
+
+        process = subprocess.Popen(
+            nohup_cmd,
+            stdin=subprocess.DEVNULL,  # Critical: no stdin blocking
+            stdout=log_handle,  # Direct to file, no pipe
+            stderr=subprocess.STDOUT,
+            cwd=working_dir,
+            env=env,
+            start_new_session=True,  # Better than preexec_fn
+            close_fds=True  # Don't inherit file descriptors
+        )
+
+        # Close the file handle in parent process
+        log_handle.close()
+
+        # Return immediately - don't wait or read from pipes
+        # Note: Don't use console.print here as stdout might be redirected
+        # Print to stderr instead to avoid log pollution
+        print(f"\033[32m✅ Claude started in background (PID: {process.pid})\033[0m", file=sys.stderr)
+        print(f"Monitor with: emdx exec show {execution_id}", file=sys.stderr)
+
+        return process.pid
+
+    except FileNotFoundError as e:
+        # Handle missing nohup
+        if "nohup" in str(e):
+            # Fallback without nohup
+            log_handle = open(log_file, 'a')
+
+            process = subprocess.Popen(
+                wrapper_cmd,  # Use wrapper even without nohup
+                stdin=subprocess.DEVNULL,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                cwd=working_dir,
+                env=env,  # Use same env as nohup version
+                start_new_session=True,
+                close_fds=True
+            )
+
+            log_handle.close()
+
+            # Print to stderr to avoid log pollution
+            print(f"\033[32m✅ Claude started in background (PID: {process.pid}) [no nohup]\033[0m", file=sys.stderr)
+            return process.pid
+        else:
+            raise

--- a/emdx/services/task_runner.py
+++ b/emdx/services/task_runner.py
@@ -14,7 +14,7 @@ from emdx.models import tasks
 from emdx.models.documents import get_document
 from emdx.models.executions import create_execution
 from emdx.models.task_executions import create_task_execution, complete_task_execution
-from emdx.commands.claude_execute import execute_with_claude_detached
+from emdx.services.claude_executor import execute_claude_detached
 
 
 def build_task_prompt(task_id: int) -> str:
@@ -130,14 +130,13 @@ def _run_task_direct(task_id: int, task: dict) -> int:
     tasks.log_progress(task_id, f"Started direct execution #{exec_id} (task_exec #{task_exec_id})")
 
     # Run Claude
-    execute_with_claude_detached(
+    execute_claude_detached(
         task=prompt,
         execution_id=exec_id,
         log_file=log_file,
         allowed_tools=None,
         working_dir=str(Path.cwd()),
         doc_id=str(task['gameplan_id']) if task['gameplan_id'] else None,
-        context=None,
     )
 
     return task_exec_id


### PR DESCRIPTION
## Summary
- Creates new `emdx/services/claude_executor.py` module with Claude execution logic
- Breaks bidirectional dependency between commands and services layers
- `task_runner.py` now imports from services instead of commands
- `claude_execute.py` delegates to the service layer

This addresses **ARCH-1** from the tech debt gameplan #3073: "Extract shared logic - break bidirectional deps"

## Test plan
- [x] All existing tests pass (17 tests in claude_execute and execution_system modules)
- [x] Import verification: `from emdx.services.claude_executor import execute_claude_detached` works
- [x] Import verification: `from emdx.services.task_runner import run_task` works (no more command imports)
- [x] No services importing from commands anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)