### PR TITLE
fix(tech-debt): Add explicit function scope to test fixtures (Issue #105)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from test_fixtures import DatabaseForTesting
 from emdx.models.tags import add_tags_to_document
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def temp_db():
     """Create a temporary in-memory SQLite database for testing."""
     db = DatabaseForTesting(":memory:")
@@ -17,7 +17,7 @@ def temp_db():
     db.close()
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def temp_db_file():
     """Create a temporary SQLite database file for testing."""
     with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
@@ -30,7 +30,7 @@ def temp_db_file():
     db_path.unlink(missing_ok=True)
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def sample_documents(temp_db):
     """Add some sample documents to the database."""
     docs = [


### PR DESCRIPTION
## Summary
- Added explicit `scope="function"` to all pytest fixtures in `tests/conftest.py`
- Prevents global fixture contamination by making fixture scope intent clear
- Ensures each test gets fresh fixtures and prevents test pollution from shared state

## Changes
- `temp_db` fixture: now explicitly function-scoped
- `temp_db_file` fixture: now explicitly function-scoped
- `sample_documents` fixture: now explicitly function-scoped

## Test plan
- [x] All 159 tests pass (1 pre-existing failure in test_sqlite_database.py unrelated to this change)
- [x] No regressions in fixture behavior (function scope was already the default)

Fixes task #105 from tech debt gameplan #3073

🤖 Generated with [Claude Code](https://claude.com/claude-code)