### PR TITLE
fix(tech-debt): Fix global fixture contamination in conftest.py (Issue #101)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,6 @@ from pathlib import Path
 import pytest
 from test_fixtures import DatabaseForTesting
 
-from emdx.models.tags import add_tags_to_document
-
 
 @pytest.fixture
 def temp_db():
@@ -32,7 +30,11 @@ def temp_db_file():
 
 @pytest.fixture
 def sample_documents(temp_db):
-    """Add some sample documents to the database."""
+    """Add some sample documents to the database with tags.
+
+    Tags are added directly via SQL to avoid global state contamination
+    from the emdx.models.tags module which uses the global database connection.
+    """
     docs = [
         {
             "title": "Python Testing Guide",
@@ -55,16 +57,38 @@ def sample_documents(temp_db):
     ]
 
     doc_ids = []
+    conn = temp_db.get_connection()
+
     for doc in docs:
         doc_id = temp_db.save_document(
             title=doc["title"], content=doc["content"], project=doc["project"]
         )
-        import emdx.tags
-
-        original_db = emdx.tags.db
-        emdx.tags.db = temp_db
-        add_tags_to_document(doc_id, doc["tags"])
-        emdx.tags.db = original_db
         doc_ids.append(doc_id)
 
+        # Add tags directly via SQL to avoid global state contamination
+        for tag_name in doc["tags"]:
+            tag_name = tag_name.lower().strip()
+            # Get or create tag
+            cursor = conn.execute("SELECT id FROM tags WHERE name = ?", (tag_name,))
+            result = cursor.fetchone()
+            if result:
+                tag_id = result[0]
+            else:
+                cursor = conn.execute(
+                    "INSERT INTO tags (name, usage_count) VALUES (?, 0)", (tag_name,)
+                )
+                tag_id = cursor.lastrowid
+
+            # Link tag to document
+            conn.execute(
+                "INSERT OR IGNORE INTO document_tags (document_id, tag_id) VALUES (?, ?)",
+                (doc_id, tag_id),
+            )
+            # Update usage count
+            conn.execute(
+                "UPDATE tags SET usage_count = usage_count + 1 WHERE id = ?",
+                (tag_id,),
+            )
+
+    conn.commit()
     return doc_ids


### PR DESCRIPTION
## Summary
- Fixed global state contamination in `sample_documents` fixture in `tests/conftest.py`
- Removed broken global state manipulation that tried to swap `emdx.tags.db` (which doesn't exist)
- Tags are now added directly via SQL to avoid relying on `emdx.models.tags.add_tags_to_document()` which uses the global database connection

## Problem
The previous code incorrectly tried to:
```python
import emdx.tags
original_db = emdx.tags.db
emdx.tags.db = temp_db
add_tags_to_document(doc_id, doc["tags"])
emdx.tags.db = original_db
```

This was broken because:
1. `emdx.tags` module doesn't exist - the correct module is `emdx.models.tags`
2. The `db` object is imported from `emdx.database` in `emdx/models/tags.py`, so swapping it wouldn't affect the `add_tags_to_document()` function

## Solution
Tags are now added directly via SQL within the fixture, using the test database connection. This avoids any global state manipulation.

## Test plan
- [x] All 159 tests pass (excluding pre-existing `test_search_documents_basic` failure)
- [x] No new test failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)