### PR TITLE
fix(tech-debt): Add missing docstrings to package init files (Issue #107)

### DIFF
--- a/emdx/models/__init__.py
+++ b/emdx/models/__init__.py
@@ -1,0 +1,10 @@
+"""Data models for EMDX entities.
+
+This package defines the core data models and operations for:
+
+- documents: Document model with metadata and content
+- executions: Execution records for tracking agent runs
+- tags: Tag system with emoji aliases and categorization
+- tasks: Task management with dependencies and status tracking
+- task_executions: Linking tasks to their execution history
+"""

--- a/emdx/ui/__init__.py
+++ b/emdx/ui/__init__.py
@@ -1,0 +1,15 @@
+"""UI package for EMDX terminal user interfaces.
+
+This package provides Textual-based TUI components for browsing and managing
+the EMDX knowledge base. Components include:
+
+- Document browsers and viewers
+- Agent management interfaces
+- Git integration (diff browser, worktree picker)
+- Log and file browsers
+- Task and workflow management UIs
+- Vim-style editing and navigation
+
+All UI components are built on the Textual framework for modern terminal
+interfaces with rich styling and responsive layouts.
+"""

--- a/emdx/utils/__init__.py
+++ b/emdx/utils/__init__.py
@@ -1,0 +1,13 @@
+"""Utility modules for EMDX.
+
+This package provides shared utilities used across the EMDX codebase:
+
+- claude_wrapper: Integration with Claude Code for AI-assisted operations
+- emoji_aliases: Text-to-emoji tag conversion system
+- environment: Environment detection and configuration
+- file_size: Human-readable file size formatting
+- git/git_ops: Git repository operations and utilities
+- logging/structured_logger: Logging configuration and structured logging
+- log_migration: Migration utilities for log format changes
+- text_formatting: Text display and formatting helpers
+"""


### PR DESCRIPTION
## Summary
- Added module-level docstrings to three empty `__init__.py` files
- `emdx/ui/__init__.py`: Documents TUI components and Textual framework usage
- `emdx/utils/__init__.py`: Lists utility modules and their purposes  
- `emdx/models/__init__.py`: Describes data model entities

## Test plan
- [x] Verified changes don't break imports
- [x] Ran test suite (pre-existing unrelated test failure in `test_sqlite_database.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)