### PR TITLE
fix(tech-debt): Task #43 - Fix N+1 query pattern in find command (Issue #43)

### DIFF
--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -322,23 +322,27 @@ def find(
                     console.print("[yellow]No results found matching the date filters[/yellow]")
                 return
         
+        # Batch fetch tags for all results to avoid N+1 queries
+        doc_ids = [result["id"] for result in results]
+        all_tags_map = get_tags_for_documents(doc_ids)
+
         # Filter out documents with excluded tags if --no-tags is specified
         if no_tags:
             expanded_no_tags = expand_alias_string(no_tags)
             no_tag_list = [t.strip() for t in expanded_no_tags.split(",") if t.strip()]
-            
+
             if no_tag_list:
                 # Filter results to exclude documents with any of the no_tags
                 filtered_results = []
                 for result in results:
-                    doc_tags = get_document_tags(result["id"])
+                    doc_tags = all_tags_map.get(result["id"], [])
                     # Check if document has any excluded tags
                     has_excluded_tag = any(tag in doc_tags for tag in no_tag_list)
                     if not has_excluded_tag:
                         filtered_results.append(result)
-                
+
                 results = filtered_results
-                
+
                 if not results:
                     console.print(
                         f"[yellow]No results found after excluding tags: {', '.join(no_tag_list)}[/yellow]"
@@ -356,9 +360,9 @@ def find(
             # Output as JSON with all metadata
             output_results = []
             for result in results:
-                # Get tags for each document
-                doc_tags = get_document_tags(result["id"])
-                
+                # Use batch-fetched tags
+                doc_tags = all_tags_map.get(result["id"], [])
+
                 # Build clean result object
                 output_result = {
                     "id": result["id"],
@@ -428,8 +432,8 @@ def find(
 
             console.print(" • ".join(metadata))
 
-            # Display tags
-            doc_tags = get_document_tags(result["id"])
+            # Display tags (using batch-fetched tags)
+            doc_tags = all_tags_map.get(result["id"], [])
             if doc_tags:
                 console.print(f"[dim]Tags: {format_tags(doc_tags)}[/dim]")
 


### PR DESCRIPTION
## Summary

- Fixed N+1 query pattern in `commands/core.py` find command
- The find command was calling `get_document_tags()` inside multiple loops (no-tags filter, JSON output, display loop), causing O(N) database queries for N results
- Now uses `get_tags_for_documents()` to batch-fetch all tags in a single query before processing
- Performance improvement: reduces tag fetching from O(N) queries to O(1)

## Test plan

- [x] Ran `poetry run pytest -x --tb=short` - all tests pass (except pre-existing failure in `test_search_documents_basic`)
- [x] Ran `poetry run pytest -k "find or tag"` - 77 tag/find-related tests pass
- [x] Verified the batch fetch function `get_tags_for_documents()` already exists in `models/tags.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)