### PR TITLE
perf: Lazy imports for faster CLI startup (~4x speedup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,4 @@ test_output.txt
 
 # Misnamed log files
 *.lo
+.venv-path

--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -36,7 +36,6 @@ from emdx.models.tags import (
 from emdx.services.auto_tagger import AutoTagger
 from emdx.ui.formatting import format_tags
 from emdx.utils.emoji_aliases import expand_alias_string
-from emdx.utils.git import get_git_project
 from emdx.utils.text_formatting import truncate_title
 
 app = typer.Typer()
@@ -122,6 +121,9 @@ def detect_project(input_content: InputContent, provided_project: Optional[str])
     """Detect project from git repository"""
     if provided_project:
         return provided_project
+
+    # Lazy import - GitPython is slow to import (~135ms)
+    from emdx.utils.git import get_git_project
 
     # Try to detect from file path if it's a file
     if input_content.source_type == "file" and input_content.source_path:

--- a/emdx/commands/gist.py
+++ b/emdx/commands/gist.py
@@ -6,15 +6,17 @@ import os
 import subprocess
 import webbrowser
 from datetime import datetime
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import typer
-from github import Github, GithubException
 from rich.console import Console
 from rich.table import Table
 
 from emdx.database import db
 from emdx.models.documents import get_document
+
+if TYPE_CHECKING:
+    from github import Github, GithubException
 
 app = typer.Typer()
 console = Console()
@@ -85,6 +87,9 @@ def create_gist_with_api(
     if not token:
         return None
 
+    # Lazy import - PyGithub is slow to import (~300ms)
+    from github import Github, GithubException
+
     try:
         g = Github(token)
         user = g.get_user()
@@ -130,6 +135,9 @@ def update_gist_with_api(
     """Update an existing gist using GitHub API."""
     if not token:
         return False
+
+    # Lazy import - PyGithub is slow to import (~300ms)
+    from github import Github, GithubException
 
     try:
         g = Github(token)

--- a/emdx/commands/maintain.py
+++ b/emdx/commands/maintain.py
@@ -12,10 +12,12 @@ import time
 # Removed CommandDefinition import - using standard typer pattern
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-import psutil
 import typer
+
+if TYPE_CHECKING:
+    import psutil
 from rich import box
 from rich.console import Console
 from rich.panel import Panel
@@ -709,22 +711,25 @@ def _cleanup_branches(dry_run: bool, force: bool = False, older_than_days: int =
 
 def _cleanup_processes(dry_run: bool, max_runtime_hours: int = 2) -> Optional[str]:
     """Clean up zombie and stuck EMDX processes.
-    
+
     Args:
         dry_run: If True, only show what would be done
         max_runtime_hours: Maximum runtime before considering a process stuck
     """
+    # Lazy import - psutil is slow to import (~16ms)
+    import psutil
+
     from ..models.executions import get_running_executions
-    
+
     # Categorize problematic processes
     zombie_procs = []
     stuck_procs = []
     orphaned_procs = []
-    
+
     # Get running executions from database
     running_execs = get_running_executions()
     known_pids = {exec.pid for exec in running_execs if exec.pid}
-    
+
     # Find EMDX-related processes
     for proc in psutil.process_iter(['pid', 'name', 'cmdline', 'status', 'create_time']):
         try:

--- a/emdx/utils/git.py
+++ b/emdx/utils/git.py
@@ -3,9 +3,10 @@ Git utility functions for emdx
 """
 
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-import git
+if TYPE_CHECKING:
+    import git
 
 
 def get_git_project(path: Optional[Path] = None) -> Optional[str]:
@@ -18,6 +19,9 @@ def get_git_project(path: Optional[Path] = None) -> Optional[str]:
     Returns:
         The repository name if in a git repo, None otherwise.
     """
+    # Lazy import - GitPython is slow to import (~135ms)
+    import git
+
     if path is None:
         path = Path.cwd()
 

--- a/justfile
+++ b/justfile
@@ -6,6 +6,7 @@ default:
 install:
     poetry lock
     poetry install
+    poetry env info --path > .venv-path
 
 # Check if dependencies are installed and install if needed
 _ensure-installed:
@@ -30,8 +31,18 @@ dev:
     @echo ""
     @echo "Or run: just run --help"
 
-# Run emdx with arguments
-run *args: _ensure-installed
+# Run emdx with arguments (fast - bypasses poetry run overhead)
+# Uses venv directly for ~4x speedup. Auto-installs on first run if needed.
+run *args:
+    @if [ ! -f .venv-path ] || [ ! -x "$(cat .venv-path)/bin/emdx" ]; then \
+        echo "📦 Setting up emdx..." && \
+        poetry install -q && \
+        poetry env info --path > .venv-path; \
+    fi && \
+    "$(cat .venv-path)/bin/emdx" {{args}}
+
+# Run emdx with dependency check (slower but ensures deps installed)
+run-safe *args: _ensure-installed
     poetry run emdx {{args}}
 
 # Run tests


### PR DESCRIPTION
## Summary
- Move heavy imports (PyGithub, GitPython, psutil) inside functions that use them
- Update `just run` to use venv directly, bypassing `poetry run` overhead
- CLI startup reduced from ~2.2s to ~0.5s

## Changes
- **gist.py**: Lazy import `github` module (~300ms saved)
- **core.py**: Lazy import git utils (~135ms saved)
- **git.py**: Lazy import GitPython inside function
- **maintain.py**: Lazy import psutil (~16ms saved)
- **justfile**: Cache venv path, auto-install on first run

## Performance
| Command | Before | After |
|---------|--------|-------|
| `poetry run emdx --help` | ~2.2s | ~1.5s |
| `just run --help` | ~2.0s | ~0.5s |

## Test plan
- [x] `just run --help` works
- [x] `just run find test` works
- [x] Tests pass (`poetry run pytest tests/test_agents.py`)
- [x] Fresh run (no `.venv-path`) auto-installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)