### PR TITLE
fix: Pin Click <8.3.0 to fix CLI startup crash

### DIFF
--- a/emdx/commands/agents.py
+++ b/emdx/commands/agents.py
@@ -416,8 +416,10 @@ def edit_agent(
         help="Update timeout in seconds"),
     output_tags: Optional[List[str]] = typer.Option(None, "--tag",
         help="Update output tags"),
-    requires_confirmation: Optional[bool] = typer.Option(None, "--confirm/--no-confirm",
-        help="Update confirmation requirement")
+    confirm: bool = typer.Option(False, "--confirm",
+        help="Set to require confirmation before running"),
+    no_confirm: bool = typer.Option(False, "--no-confirm",
+        help="Set to not require confirmation before running")
 ):
     """Edit an existing agent."""
     try:
@@ -481,8 +483,14 @@ def edit_agent(
                     emoji_tags.append(tag)
             updates['output_tags'] = emoji_tags
         
-        if requires_confirmation is not None:
-            updates['requires_confirmation'] = requires_confirmation
+        # Handle confirm/no-confirm flags
+        if confirm and no_confirm:
+            console.print("[red]Cannot specify both --confirm and --no-confirm[/red]")
+            raise typer.Exit(1)
+        if confirm:
+            updates['requires_confirmation'] = True
+        elif no_confirm:
+            updates['requires_confirmation'] = False
         
         if not updates:
             console.print("[yellow]No updates specified[/yellow]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.13"
-typer = {extras = ["all"], version = "^0.9.0"}
+typer = {extras = ["all"], version = "^0.15.0"}
+click = ">=8.0.0,<8.3.0"  # Pin click to avoid breaking changes in 8.3.x
 rich = "^13.0.0"
 python-dotenv = "^1.0.0"
 gitpython = "^3.1.0"


### PR DESCRIPTION
## Summary
- Fixes CLI crash on startup with "Secondary flag is not valid for non-boolean flag" error
- Pins Click to <8.3.0 to avoid breaking changes introduced in Click 8.3.0
- Updates Typer to ^0.15.0 for better compatibility

## Test plan
- [x] Verified `emdx --help` works
- [x] Verified `emdx gui --help` works  
- [x] Verified `emdx agent edit --help` shows correct flags
- [x] Verified `emdx list` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)