### PR TITLE
feat: Document hierarchy system with auto-supersede and workflow linking

### DIFF
--- a/emdx/scripts/__init__.py
+++ b/emdx/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Scripts for EMDX maintenance and migration tasks."""

--- a/emdx/scripts/cleanup_hierarchy.py
+++ b/emdx/scripts/cleanup_hierarchy.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""One-time cleanup script to archive garbage docs and establish hierarchy.
+
+This script performs the following cleanup operations:
+1. Archives "Workflow Agent Output" documents (intermediate workflow outputs)
+2. Archives "Synthesis (error)" documents (failed synthesis attempts)
+3. Archives "Test Agent:" documents (test agent runs)
+4. Links workflow individual outputs to their synthesis documents
+5. Links exact-title duplicates (older becomes child of newer with 'supersedes' relationship)
+
+Usage:
+    # Run directly
+    poetry run python emdx/scripts/cleanup_hierarchy.py
+
+    # Or via CLI command
+    poetry run emdx maintain cleanup-hierarchy
+"""
+
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CleanupStats:
+    """Statistics from cleanup operation."""
+
+    workflow_output_archived: int = 0
+    synthesis_error_archived: int = 0
+    test_agent_archived: int = 0
+    duplicates_linked: int = 0
+    workflow_docs_linked: int = 0
+    errors: List[str] = field(default_factory=list)
+
+    def total_archived(self) -> int:
+        """Return total documents archived."""
+        return (
+            self.workflow_output_archived
+            + self.synthesis_error_archived
+            + self.test_agent_archived
+        )
+
+    def total_linked(self) -> int:
+        """Return total documents linked."""
+        return self.duplicates_linked + self.workflow_docs_linked
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "workflow_output_archived": self.workflow_output_archived,
+            "synthesis_error_archived": self.synthesis_error_archived,
+            "test_agent_archived": self.test_agent_archived,
+            "duplicates_linked": self.duplicates_linked,
+            "workflow_docs_linked": self.workflow_docs_linked,
+            "total_archived": self.total_archived(),
+            "total_linked": self.total_linked(),
+            "errors": self.errors,
+        }
+
+
+def get_db_path() -> Path:
+    """Get the database path, respecting EMDX_TEST_DB environment variable."""
+    import os
+
+    test_db = os.environ.get("EMDX_TEST_DB")
+    if test_db:
+        return Path(test_db)
+
+    return Path.home() / ".config" / "emdx" / "knowledge.db"
+
+
+def cleanup(
+    db_path: Optional[Path] = None,
+    dry_run: bool = False,
+) -> CleanupStats:
+    """Run cleanup operations to archive garbage docs and establish hierarchy.
+
+    Args:
+        db_path: Path to database file. If None, uses default location.
+        dry_run: If True, don't actually make changes, just report what would be done.
+
+    Returns:
+        CleanupStats with counts of affected documents.
+    """
+    if db_path is None:
+        db_path = get_db_path()
+
+    if not db_path.exists():
+        logger.error(f"Database not found: {db_path}")
+        return CleanupStats(errors=[f"Database not found: {db_path}"])
+
+    stats = CleanupStats()
+
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+
+        # 1. Archive "Workflow Agent Output" docs
+        stats.workflow_output_archived = _archive_by_title_pattern(
+            cur, "Workflow Agent Output%", dry_run
+        )
+
+        # 2. Archive "Synthesis (error)" docs
+        stats.synthesis_error_archived = _archive_by_title_pattern(
+            cur, "Synthesis (error)%", dry_run
+        )
+
+        # 3. Archive "Test Agent:" docs
+        stats.test_agent_archived = _archive_by_title_pattern(
+            cur, "Test Agent:%", dry_run
+        )
+
+        # 4. Link workflow individual outputs to their synthesis docs
+        stats.workflow_docs_linked = _link_workflow_outputs_to_syntheses(cur, dry_run)
+
+        # 5. Link exact-title duplicates (older becomes child of newer)
+        stats.duplicates_linked = _link_duplicate_titles(cur, dry_run)
+
+        if not dry_run:
+            conn.commit()
+
+        conn.close()
+
+    except sqlite3.Error as e:
+        logger.error(f"Database error during cleanup: {e}")
+        stats.errors.append(f"Database error: {e}")
+    except Exception as e:
+        logger.error(f"Unexpected error during cleanup: {e}")
+        stats.errors.append(f"Unexpected error: {e}")
+
+    return stats
+
+
+def _archive_by_title_pattern(
+    cur: sqlite3.Cursor,
+    pattern: str,
+    dry_run: bool,
+) -> int:
+    """Archive documents matching a title pattern.
+
+    Args:
+        cur: Database cursor
+        pattern: SQL LIKE pattern to match against title
+        dry_run: If True, only count matching docs
+
+    Returns:
+        Number of documents archived (or that would be archived)
+    """
+    if dry_run:
+        cur.execute(
+            """
+            SELECT COUNT(*) as count
+            FROM documents
+            WHERE title LIKE ?
+            AND archived_at IS NULL
+            AND is_deleted = FALSE
+            """,
+            (pattern,),
+        )
+        result = cur.fetchone()
+        return result["count"] if result else 0
+
+    cur.execute(
+        """
+        UPDATE documents
+        SET archived_at = CURRENT_TIMESTAMP
+        WHERE title LIKE ?
+        AND archived_at IS NULL
+        AND is_deleted = FALSE
+        """,
+        (pattern,),
+    )
+    return cur.rowcount
+
+
+def _link_workflow_outputs_to_syntheses(
+    cur: sqlite3.Cursor,
+    dry_run: bool,
+) -> int:
+    """Link workflow individual outputs to their synthesis documents.
+
+    Uses workflow_stage_runs.synthesis_doc_id and workflow_individual_runs.output_doc_id
+    to establish parent-child relationships.
+
+    Args:
+        cur: Database cursor
+        dry_run: If True, only count potential links
+
+    Returns:
+        Number of documents linked
+    """
+    # Check if the tables exist (they may not if workflow feature isn't used)
+    cur.execute(
+        """
+        SELECT name FROM sqlite_master
+        WHERE type='table' AND name='workflow_stage_runs'
+        """
+    )
+    if not cur.fetchone():
+        logger.info("workflow_stage_runs table not found, skipping workflow linking")
+        return 0
+
+    cur.execute(
+        """
+        SELECT name FROM sqlite_master
+        WHERE type='table' AND name='workflow_individual_runs'
+        """
+    )
+    if not cur.fetchone():
+        logger.info("workflow_individual_runs table not found, skipping workflow linking")
+        return 0
+
+    # Find pairs of synthesis_doc_id and output_doc_id
+    cur.execute(
+        """
+        SELECT wsr.synthesis_doc_id, wir.output_doc_id
+        FROM workflow_stage_runs wsr
+        JOIN workflow_individual_runs wir ON wir.stage_run_id = wsr.id
+        WHERE wsr.synthesis_doc_id IS NOT NULL
+        AND wir.output_doc_id IS NOT NULL
+        """
+    )
+
+    rows = cur.fetchall()
+    if not rows:
+        return 0
+
+    linked = 0
+    for row in rows:
+        synthesis_id = row["synthesis_doc_id"]
+        output_id = row["output_doc_id"]
+
+        if dry_run:
+            # Check if this would be a valid link (doc exists and has no parent)
+            cur.execute(
+                """
+                SELECT id FROM documents
+                WHERE id = ? AND parent_id IS NULL AND is_deleted = FALSE
+                """,
+                (output_id,),
+            )
+            if cur.fetchone():
+                linked += 1
+        else:
+            cur.execute(
+                """
+                UPDATE documents
+                SET parent_id = ?, relationship = 'exploration'
+                WHERE id = ? AND parent_id IS NULL AND is_deleted = FALSE
+                """,
+                (synthesis_id, output_id),
+            )
+            if cur.rowcount > 0:
+                linked += 1
+
+    return linked
+
+
+def _link_duplicate_titles(
+    cur: sqlite3.Cursor,
+    dry_run: bool,
+) -> int:
+    """Link documents with duplicate normalized titles.
+
+    For documents with the same normalized title within the same project,
+    older documents become children of newer documents with a 'supersedes'
+    relationship.
+
+    Note: Certain generic titles are excluded from linking to prevent
+    unrelated documents from being chained together (e.g., "Synthesis",
+    "Workflow Output", etc.)
+
+    Args:
+        cur: Database cursor
+        dry_run: If True, only count potential links
+
+    Returns:
+        Number of documents linked
+    """
+    # Import here to avoid circular imports
+    from emdx.utils.title_normalization import normalize_title
+
+    # Normalized titles that are too generic to link
+    # These would incorrectly chain unrelated documents
+    EXCLUDED_NORMALIZED_TITLES = {
+        "synthesis",
+        "synthesis error",
+        "workflow output",
+        "workflow agent output",
+        "test document",
+        "test",
+        "untitled",
+        "note",
+        "notes",
+    }
+
+    # Get all non-deleted, non-archived documents without a parent
+    cur.execute(
+        """
+        SELECT id, title, project, created_at
+        FROM documents
+        WHERE is_deleted = FALSE
+        AND parent_id IS NULL
+        ORDER BY created_at DESC
+        """
+    )
+
+    docs = cur.fetchall()
+
+    # Group by normalized title + project
+    # seen_titles maps (normalized_title, project) -> newest doc id
+    seen_titles: Dict[Tuple[str, Optional[str]], int] = {}
+    links_to_create: List[Tuple[int, int]] = []  # (child_id, parent_id)
+
+    for doc in docs:
+        norm_title = normalize_title(doc["title"])
+        if not norm_title:
+            continue
+
+        # Skip generic titles that shouldn't be linked
+        if norm_title.lower() in EXCLUDED_NORMALIZED_TITLES:
+            continue
+
+        key = (norm_title, doc["project"])
+
+        if key in seen_titles:
+            # This doc is older (we're iterating DESC by created_at),
+            # so it should become a child of the newer one
+            newer_id = seen_titles[key]
+            links_to_create.append((doc["id"], newer_id))
+        else:
+            # This is the newest doc with this title+project
+            seen_titles[key] = doc["id"]
+
+    if dry_run:
+        return len(links_to_create)
+
+    linked = 0
+    for child_id, parent_id in links_to_create:
+        cur.execute(
+            """
+            UPDATE documents
+            SET parent_id = ?, relationship = 'supersedes'
+            WHERE id = ? AND parent_id IS NULL AND is_deleted = FALSE
+            """,
+            (parent_id, child_id),
+        )
+        if cur.rowcount > 0:
+            linked += 1
+
+    return linked
+
+
+def main():
+    """Run cleanup as a standalone script."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Archive garbage documents and establish document hierarchy"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=None,
+        help="Path to database file (default: ~/.config/emdx/knowledge.db)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose output",
+    )
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    if args.dry_run:
+        print("DRY RUN - No changes will be made\n")
+
+    print("Running cleanup migration...")
+    stats = cleanup(db_path=args.db_path, dry_run=args.dry_run)
+
+    action = "Would archive" if args.dry_run else "Archived"
+    link_action = "Would link" if args.dry_run else "Linked"
+
+    print(f"{action} {stats.workflow_output_archived} Workflow Agent Output docs")
+    print(f"{action} {stats.synthesis_error_archived} Synthesis (error) docs")
+    print(f"{action} {stats.test_agent_archived} Test Agent docs")
+    print(f"{link_action} {stats.workflow_docs_linked} workflow outputs to syntheses")
+    print(f"{link_action} {stats.duplicates_linked} duplicate title docs")
+
+    if stats.errors:
+        print("\nErrors encountered:")
+        for error in stats.errors:
+            print(f"  - {error}")
+        return 1
+
+    if args.dry_run:
+        print("\nRun without --dry-run to apply changes")
+    else:
+        print("\nCleanup complete!")
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/emdx/services/similarity.py
+++ b/emdx/services/similarity.py
@@ -406,3 +406,33 @@ class SimilarityService:
         self._doc_projects = []
         self._doc_tags = []
         self._last_built = None
+
+
+def compute_content_similarity(content1: str, content2: str) -> float:
+    """Compute TF-IDF cosine similarity between two pieces of content.
+
+    This is a standalone function for quick pairwise comparison without
+    building the full index.
+
+    Args:
+        content1: First document content
+        content2: Second document content
+
+    Returns:
+        Cosine similarity between 0.0 and 1.0
+    """
+    if not content1 or not content2:
+        return 0.0
+
+    try:
+        vectorizer = TfidfVectorizer(
+            max_features=1000,
+            stop_words="english",
+            ngram_range=(1, 2),
+        )
+        tfidf_matrix = vectorizer.fit_transform([content1, content2])
+        similarity = cosine_similarity(tfidf_matrix[0:1], tfidf_matrix[1:2])[0][0]
+        return float(similarity)
+    except Exception:
+        # If vectorization fails (e.g., empty vocabulary), return 0
+        return 0.0

--- a/emdx/ui/presenters/document_browser_presenter.py
+++ b/emdx/ui/presenters/document_browser_presenter.py
@@ -6,15 +6,21 @@ This presenter handles business logic for document browsing:
 - Search/filter logic
 - Tag operations
 - Document CRUD operations
+- Hierarchy navigation (expand/collapse children)
 
 The presenter transforms raw database records into ViewModels
 suitable for display.
 """
 
 import logging
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 
 from emdx.database import db
+from emdx.database.documents import (
+    count_documents,
+    get_children_count,
+    list_documents as db_list_documents,
+)
 from emdx.models.documents import (
     delete_document,
     get_document,
@@ -60,6 +66,10 @@ class DocumentBrowserPresenter:
         self._has_more: bool = False
         self._loading_more: bool = False
 
+        # Hierarchy state
+        self._expanded_docs: Set[int] = set()  # Set of expanded parent doc IDs
+        self._include_archived: bool = False  # Whether to show archived docs
+
         # Cache for tags (loaded in batch with documents)
         self._tags_cache: Dict[int, List[str]] = {}
 
@@ -70,10 +80,15 @@ class DocumentBrowserPresenter:
     def _create_list_vm(self) -> DocumentListVM:
         """Create current list ViewModel."""
         # Generate status text
+        doc_count = len(self._filtered_documents)
+        archived_indicator = " [+archived]" if self._include_archived else ""
         if self._has_more:
-            status_text = f"{len(self._filtered_documents)}/{self._total_count} docs (scroll for more)"
+            status_text = (
+                f"{doc_count}/{self._total_count} docs{archived_indicator} "
+                "(scroll for more)"
+            )
         else:
-            status_text = f"{len(self._filtered_documents)}/{self._total_count} docs"
+            status_text = f"{doc_count}/{self._total_count} docs{archived_indicator}"
 
         return DocumentListVM(
             documents=self._documents,
@@ -86,10 +101,58 @@ class DocumentBrowserPresenter:
             status_text=status_text,
         )
 
+    def _raw_doc_to_view_model(
+        self,
+        doc: Dict[str, Any],
+        tags: List[str],
+        has_children: bool,
+        depth: int = 0,
+    ) -> DocumentListItem:
+        """Convert a raw document dict to a DocumentListItem.
+
+        Args:
+            doc: Raw document dictionary from database
+            tags: List of tags for this document
+            has_children: Whether this document has children
+            depth: Hierarchy depth (0 = top level)
+
+        Returns:
+            DocumentListItem view model
+        """
+        tags_display = " ".join(tags[:3]).ljust(8)
+
+        # Calculate available title width based on depth
+        # Base width is 74, reduce by 2 chars per depth level for tree indent
+        title_width = max(40, 74 - (depth * 2))
+
+        # Truncate title for display
+        title, was_truncated = truncate_emoji_safe(doc["title"], title_width)
+        if was_truncated:
+            title += "..."
+
+        return DocumentListItem(
+            id=doc["id"],
+            title=title,
+            tags=tags,
+            tags_display=tags_display,
+            project=doc["project"] if doc["project"] else "default",
+            access_count=doc["access_count"] or 0,
+            created_at=doc["created_at"],
+            accessed_at=doc.get("accessed_at"),
+            parent_id=doc.get("parent_id"),
+            has_children=has_children,
+            depth=depth,
+            is_archived=doc.get("archived_at") is not None,
+            relationship=doc.get("relationship"),
+        )
+
     async def load_documents(
         self, limit: int = 100, offset: int = 0, append: bool = False
     ) -> None:
         """Load documents from database with pagination.
+
+        Loads only top-level documents initially. Children are loaded
+        on-demand when a parent is expanded.
 
         Args:
             limit: Number of documents to fetch
@@ -97,80 +160,244 @@ class DocumentBrowserPresenter:
             append: If True, append to existing docs instead of replacing
         """
         try:
-            with db.get_connection() as conn:
-                # Get total count for status display
-                if not append:
-                    cursor = conn.execute(
-                        "SELECT COUNT(*) FROM documents WHERE is_deleted = 0"
-                    )
-                    self._total_count = cursor.fetchone()[0]
-
-                # Fetch paginated documents
-                cursor = conn.execute(
-                    """
-                    SELECT id, title, project, created_at, accessed_at, access_count
-                    FROM documents
-                    WHERE is_deleted = 0
-                    ORDER BY id DESC
-                    LIMIT ? OFFSET ?
-                    """,
-                    (limit, offset),
+            # Get total count for status display (top-level only by default)
+            if not append:
+                self._total_count = count_documents(
+                    include_archived=self._include_archived,
+                    parent_id=None,  # Top-level only
                 )
 
-                raw_docs = cursor.fetchall()
+            # Fetch paginated top-level documents
+            raw_docs = db_list_documents(
+                limit=limit,
+                offset=offset,
+                include_archived=self._include_archived,
+                parent_id=None,  # Top-level only
+            )
 
-                # Batch load tags for efficiency
-                doc_ids = [doc["id"] for doc in raw_docs]
-                all_tags = get_tags_for_documents(doc_ids) if doc_ids else {}
-                self._tags_cache.update(all_tags)
+            # Batch load tags for efficiency
+            doc_ids = [doc["id"] for doc in raw_docs]
+            all_tags = get_tags_for_documents(doc_ids) if doc_ids else {}
+            self._tags_cache.update(all_tags)
 
-                # Convert to ViewModels
-                new_items = []
-                for doc in raw_docs:
-                    doc_tags = all_tags.get(doc["id"], [])
-                    tags_display = " ".join(doc_tags[:3]).ljust(8)
+            # Batch check for children
+            children_counts = get_children_count(
+                doc_ids, include_archived=self._include_archived
+            )
 
-                    # Truncate title for display
-                    title, was_truncated = truncate_emoji_safe(doc["title"], 74)
-                    if was_truncated:
-                        title += "..."
+            # Convert to ViewModels
+            new_items = []
+            for doc in raw_docs:
+                doc_tags = all_tags.get(doc["id"], [])
+                has_children = children_counts.get(doc["id"], 0) > 0
 
-                    new_items.append(
-                        DocumentListItem(
-                            id=doc["id"],
-                            title=title,
-                            tags=doc_tags,
-                            tags_display=tags_display,
-                            project=doc["project"] if doc["project"] else "default",
-                            access_count=doc["access_count"] or 0,
-                            created_at=doc["created_at"],
-                            accessed_at=doc["accessed_at"],
-                        )
-                    )
-
-                if append:
-                    self._documents = self._documents + new_items
-                else:
-                    self._documents = new_items
-
-                self._filtered_documents = self._documents
-                self._current_offset = offset + len(new_items)
-                self._has_more = len(new_items) == limit
-
-                logger.info(
-                    f"Loaded {len(new_items)} documents "
-                    f"(total loaded: {len(self._documents)}, "
-                    f"total available: {self._total_count})"
+                item = self._raw_doc_to_view_model(
+                    doc=doc,
+                    tags=doc_tags,
+                    has_children=has_children,
+                    depth=0,
                 )
+                new_items.append(item)
 
-                # Notify view
-                await self.on_list_update(self._create_list_vm())
+                # If this doc is expanded, load its children
+                if doc["id"] in self._expanded_docs:
+                    children = await self._load_children(doc["id"], depth=1)
+                    new_items.extend(children)
+
+            if append:
+                self._documents = self._documents + new_items
+            else:
+                self._documents = new_items
+
+            self._filtered_documents = self._documents
+            self._current_offset = offset + len(raw_docs)
+            self._has_more = len(raw_docs) == limit
+
+            logger.info(
+                f"Loaded {len(new_items)} documents "
+                f"(total loaded: {len(self._documents)}, "
+                f"total available: {self._total_count})"
+            )
+
+            # Notify view
+            await self.on_list_update(self._create_list_vm())
 
         except Exception as e:
             logger.error(f"Error loading documents: {e}")
             import traceback
 
             logger.error(traceback.format_exc())
+
+    async def _load_children(
+        self, parent_id: int, depth: int, max_depth: int = 10
+    ) -> List[DocumentListItem]:
+        """Load children of a document recursively.
+
+        Args:
+            parent_id: Parent document ID
+            depth: Current depth level
+            max_depth: Maximum depth to prevent infinite recursion
+
+        Returns:
+            List of child DocumentListItem objects
+        """
+        if depth > max_depth:
+            return []
+
+        # Load children from database
+        raw_children = db_list_documents(
+            parent_id=parent_id,
+            include_archived=self._include_archived,
+            limit=100,  # Children are typically limited
+        )
+
+        # Batch load tags
+        child_ids = [doc["id"] for doc in raw_children]
+        if child_ids:
+            child_tags = get_tags_for_documents(child_ids)
+            self._tags_cache.update(child_tags)
+            children_counts = get_children_count(
+                child_ids, include_archived=self._include_archived
+            )
+        else:
+            child_tags = {}
+            children_counts = {}
+
+        items = []
+        for doc in raw_children:
+            doc_tags = child_tags.get(doc["id"], [])
+            has_children = children_counts.get(doc["id"], 0) > 0
+
+            item = self._raw_doc_to_view_model(
+                doc=doc,
+                tags=doc_tags,
+                has_children=has_children,
+                depth=depth,
+            )
+            items.append(item)
+
+            # Recursively load if this child is also expanded
+            if doc["id"] in self._expanded_docs:
+                grandchildren = await self._load_children(
+                    doc["id"], depth + 1, max_depth
+                )
+                items.extend(grandchildren)
+
+        return items
+
+    async def expand_document(self, doc_id: int) -> bool:
+        """Expand a document to show its children.
+
+        Args:
+            doc_id: Document ID to expand
+
+        Returns:
+            True if expansion was successful (doc had children)
+        """
+        # Find the document in our list
+        doc_item = None
+        for item in self._documents:
+            if item.id == doc_id:
+                doc_item = item
+                break
+
+        if doc_item is None or not doc_item.has_children:
+            return False
+
+        if doc_id in self._expanded_docs:
+            return True  # Already expanded
+
+        # Mark as expanded and reload
+        self._expanded_docs.add(doc_id)
+        await self.load_documents()
+        return True
+
+    async def collapse_document(self, doc_id: int) -> bool:
+        """Collapse a document to hide its children.
+
+        Args:
+            doc_id: Document ID to collapse
+
+        Returns:
+            True if collapse was successful
+        """
+        if doc_id not in self._expanded_docs:
+            return False
+
+        # Remove from expanded set (and all descendants)
+        self._expanded_docs.discard(doc_id)
+
+        # Also remove any expanded children of this document
+        children_to_remove = set()
+        for expanded_id in self._expanded_docs:
+            # Check if this expanded doc is a descendant
+            for doc in self._documents:
+                if doc.id == expanded_id and self._is_descendant_of(doc, doc_id):
+                    children_to_remove.add(expanded_id)
+
+        self._expanded_docs -= children_to_remove
+
+        # Reload to update the list
+        await self.load_documents()
+        return True
+
+    def _is_descendant_of(self, doc: DocumentListItem, ancestor_id: int) -> bool:
+        """Check if a document is a descendant of another.
+
+        Args:
+            doc: Document to check
+            ancestor_id: Potential ancestor ID
+
+        Returns:
+            True if doc is a descendant of ancestor_id
+        """
+        current_id = doc.parent_id
+        visited = set()
+        while current_id is not None and current_id not in visited:
+            visited.add(current_id)
+            if current_id == ancestor_id:
+                return True
+            # Find parent in our list
+            parent = next((d for d in self._documents if d.id == current_id), None)
+            if parent is None:
+                break
+            current_id = parent.parent_id
+        return False
+
+    async def toggle_expand(self, doc_id: int) -> bool:
+        """Toggle expansion state of a document.
+
+        Args:
+            doc_id: Document ID to toggle
+
+        Returns:
+            True if toggle was successful
+        """
+        if doc_id in self._expanded_docs:
+            return await self.collapse_document(doc_id)
+        else:
+            return await self.expand_document(doc_id)
+
+    async def toggle_archived(self) -> None:
+        """Toggle display of archived documents."""
+        self._include_archived = not self._include_archived
+        await self.load_documents()
+
+    def is_expanded(self, doc_id: int) -> bool:
+        """Check if a document is expanded.
+
+        Args:
+            doc_id: Document ID to check
+
+        Returns:
+            True if the document is expanded
+        """
+        return doc_id in self._expanded_docs
+
+    @property
+    def include_archived(self) -> bool:
+        """Whether archived documents are being shown."""
+        return self._include_archived
 
     async def load_more_documents(self) -> None:
         """Load more documents when user scrolls near the end."""
@@ -321,7 +548,9 @@ class DocumentBrowserPresenter:
         try:
             proj = project or get_git_project() or "default"
             formatted_content = f"# {title}\n\n{content}"
-            doc_id = save_document(title=title, content=formatted_content, project=proj)
+            doc_id = save_document(
+                title=title, content=formatted_content, project=proj
+            )
             logger.info(f"Created new document with ID: {doc_id}")
             return doc_id
         except Exception as e:
@@ -370,6 +599,19 @@ class DocumentBrowserPresenter:
         if 0 <= index < len(self._filtered_documents):
             return self._filtered_documents[index]
         return None
+
+    def get_parent_document(self, doc: DocumentListItem) -> Optional[DocumentListItem]:
+        """Get the parent document of a given document.
+
+        Args:
+            doc: Document to find parent for
+
+        Returns:
+            Parent DocumentListItem or None if no parent
+        """
+        if doc.parent_id is None:
+            return None
+        return next((d for d in self._documents if d.id == doc.parent_id), None)
 
     def should_load_more(self, current_row: int, buffer: int = 20) -> bool:
         """Check if more documents should be loaded.

--- a/emdx/ui/viewmodels/document_list_vm.py
+++ b/emdx/ui/viewmodels/document_list_vm.py
@@ -21,6 +21,12 @@ class DocumentListItem:
     access_count: int
     created_at: Optional[str] = None
     accessed_at: Optional[str] = None
+    # Hierarchy fields
+    parent_id: Optional[int] = None
+    has_children: bool = False
+    depth: int = 0  # 0 = top level, 1 = child, 2 = grandchild, etc.
+    is_archived: bool = False
+    relationship: Optional[str] = None  # 'supersedes', 'exploration', 'variant'
 
 
 @dataclass

--- a/emdx/utils/title_normalization.py
+++ b/emdx/utils/title_normalization.py
@@ -1,0 +1,96 @@
+"""Title normalization for document deduplication.
+
+Normalizes document titles by removing variable parts like dates, timestamps,
+agent numbers, etc. to enable automatic supersede detection.
+"""
+
+import re
+from typing import Optional
+
+
+def normalize_title(title: str) -> str:
+    """Normalize a document title for comparison.
+
+    Removes:
+    - Dates in various formats: (2025-01-10), - 2025-01-10, 2025-01-10T...
+    - Agent numbers: (Agent 1), (Agent 5)
+    - Task/Issue numbers: #123, Task #45
+    - ISO timestamps: - 2026-01-11T00:05:45.123456
+    - Version suffixes: v1, v2, (v1)
+    - Trailing whitespace and extra spaces
+
+    Args:
+        title: The document title to normalize
+
+    Returns:
+        Normalized title suitable for comparison
+    """
+    if not title:
+        return ""
+
+    result = title
+
+    # Remove ISO timestamps with optional timezone: - 2026-01-11T00:05:45.123456+00:00
+    result = re.sub(r'\s*-?\s*\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[+-]\d{2}:?\d{2}|Z)?', '', result)
+
+    # Remove dates in parentheses: (2025-01-10)
+    result = re.sub(r'\s*\(\d{4}-\d{2}-\d{2}\)', '', result)
+
+    # Remove dates after dash: - 2025-01-10
+    result = re.sub(r'\s*-\s*\d{4}-\d{2}-\d{2}', '', result)
+
+    # Remove standalone dates: 2025-01-10
+    result = re.sub(r'\s+\d{4}-\d{2}-\d{2}(?:\s|$)', ' ', result)
+
+    # Remove agent numbers: (Agent 1), (Agent 5)
+    result = re.sub(r'\s*\(Agent\s+\d+\)', '', result, flags=re.IGNORECASE)
+
+    # Remove task/issue numbers: #123, Task #45, Issue #678
+    result = re.sub(r'\s*(?:Task|Issue)?\s*#\d+', '', result, flags=re.IGNORECASE)
+
+    # Remove version suffixes: v1, v2, (v1), (v2)
+    result = re.sub(r'\s*\(?v\d+\)?', '', result, flags=re.IGNORECASE)
+
+    # Remove (error) suffix from synthesis docs
+    result = re.sub(r'\s*\(error\)', '', result, flags=re.IGNORECASE)
+
+    # Normalize whitespace
+    result = re.sub(r'\s+', ' ', result).strip()
+
+    return result
+
+
+def titles_match(title1: str, title2: str) -> bool:
+    """Check if two titles match after normalization.
+
+    Args:
+        title1: First title
+        title2: Second title
+
+    Returns:
+        True if normalized titles are equal
+    """
+    return normalize_title(title1) == normalize_title(title2)
+
+
+def title_similarity(title1: str, title2: str) -> float:
+    """Calculate similarity ratio between two titles.
+
+    Uses SequenceMatcher for fuzzy matching after normalization.
+
+    Args:
+        title1: First title
+        title2: Second title
+
+    Returns:
+        Similarity ratio between 0.0 and 1.0
+    """
+    from difflib import SequenceMatcher
+
+    norm1 = normalize_title(title1).lower()
+    norm2 = normalize_title(title2).lower()
+
+    if not norm1 or not norm2:
+        return 0.0
+
+    return SequenceMatcher(None, norm1, norm2).ratio()

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -57,7 +57,43 @@ class TestBrowseCommands:
         result = runner.invoke(app, ["list", "--project", "test-project"])
 
         assert result.exit_code == 0
-        mock_list_docs.assert_called_once_with(project="test-project", limit=50)
+        mock_list_docs.assert_called_once_with(
+            project="test-project", limit=50, include_archived=False
+        )
+
+    @patch("emdx.commands.browse.db")
+    @patch("emdx.commands.browse.list_documents")
+    def test_list_command_with_archived_flag(self, mock_list_docs, mock_db):
+        """Test list command with --archived flag."""
+        mock_db.ensure_schema = Mock()
+        mock_list_docs.return_value = [
+            {
+                "id": 1,
+                "title": "Active Doc",
+                "project": "test",
+                "created_at": datetime(2024, 1, 1, 12, 0, 0),
+                "access_count": 5,
+                "archived_at": None,
+            },
+            {
+                "id": 2,
+                "title": "Archived Doc",
+                "project": "test",
+                "created_at": datetime(2024, 1, 2, 12, 0, 0),
+                "access_count": 3,
+                "archived_at": datetime(2024, 1, 5, 10, 0, 0),
+            },
+        ]
+
+        result = runner.invoke(app, ["list", "--archived"])
+
+        assert result.exit_code == 0
+        assert "Active Doc" in result.stdout
+        assert "Archived Doc" in result.stdout
+        assert "Archived" in result.stdout  # Status column
+        mock_list_docs.assert_called_once_with(
+            project=None, limit=50, include_archived=True
+        )
 
     @patch("emdx.commands.browse.db")
     @patch("emdx.commands.browse.list_documents")


### PR DESCRIPTION
## Summary

- **Auto-supersede**: New docs automatically supersede older docs with same normalized title, reducing document pollution
- **Workflow priority**: Workflow linking (synthesis → exploration) takes precedence over auto-supersede
- **Archive system**: Hide superseded docs from default views, auto-archive on completion
- **TUI hierarchy view**: Expandable tree with expand/collapse navigation

## Key Changes

### Auto-Supersede by Title
When saving a document, the system checks for existing docs with the same normalized title (removing dates, timestamps, agent numbers, versions). The old doc becomes a child of the new doc with a "supersedes" relationship.

```
✅ Saved as #4622: Hierarchy Test Doc
   ↳ Superseded #4621
   Project: emdx
```

### Workflow Auto-Parenting
Synthesis documents automatically become parents of their exploration outputs. This relationship is established when synthesis completes and **takes precedence** over auto-supersede - documents already linked via workflow won't be re-parented.

### TUI Navigation
- `l` or `→` - Expand children
- `h` or `←` - Collapse children or navigate to parent
- `a` - Toggle archived documents visibility
- Tree visualization shows hierarchy depth

### Database Schema
Migration 018 adds:
- `parent_id` - Reference to parent document
- `relationship` - Type: 'supersedes', 'exploration', 'variant'
- `archived_at` - Timestamp for archived documents

## Test plan
- [x] Auto-supersede works on save command
- [x] Workflow outputs linked to synthesis docs
- [x] Documents with parent_id excluded from supersede candidates
- [x] TUI expand/collapse preserves cursor position
- [x] Archive commands work correctly
- [x] Cleanup script handles existing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)