### PR TITLE
fix(ui): Activity View improvements and preview limit increase

### DIFF
--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -993,9 +993,9 @@ class DocumentBrowser(Widget):
 
             try:
                 content = detail_vm.content
-                # Limit preview to first 5000 chars for performance
-                if len(content) > 5000:
-                    content = content[:5000] + "\n\n[dim]... (truncated for preview)[/dim]"
+                # Limit preview to first 50000 chars for performance
+                if len(content) > 50000:
+                    content = content[:50000] + "\n\n[dim]... (truncated for preview)[/dim]"
                 if content.strip():
                     markdown = Markdown(content)
                     preview.write(markdown)
@@ -1003,7 +1003,7 @@ class DocumentBrowser(Widget):
                     preview.write("[dim]Empty document[/dim]")
             except Exception:
                 # Fallback to plain text if markdown fails
-                preview.write(detail_vm.content[:5000])
+                preview.write(detail_vm.content[:50000])
         except Exception:
             # Preview widget not found or not ready - ignore
             pass


### PR DESCRIPTION
## Summary
- Add ID column to Activity View showing document (`#1234`) or workflow (`w123`) IDs for easy reference
- Fix timezone handling for timestamps - detect UTC vs local time dynamically (documents use UTC, workflows use local)
- Fix error count in status bar to only show today's failures instead of all-time count
- Increase preview content limit from 5K to 50K chars in both Activity and Documents views

## Test plan
- [ ] Open Activity View (key 1) and verify ID column shows document/workflow IDs
- [ ] Verify timestamps show correct relative times (not 5h off)
- [ ] Verify error count reflects only today's failures
- [ ] Open a long document and verify preview shows more content without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)