### PR TITLE
fix: Remove duplicate _load_document_variables call in executor.py

### DIFF
--- a/emdx/workflows/executor.py
+++ b/emdx/workflows/executor.py
@@ -159,11 +159,6 @@ class WorkflowExecutor:
             # and load the content into doc_N_content and doc_N_title
             await self._load_document_variables(context)
 
-            # Auto-load document content for doc_N variables
-            # If a variable like doc_1, doc_2, etc. is an integer, treat it as a document ID
-            # and load the content into doc_N_content and doc_N_title
-            await self._load_document_variables(context)
-
             # Execute stages sequentially
             for stage in workflow.stages:
                 wf_db.update_workflow_run(run_id, current_stage=stage.name)


### PR DESCRIPTION
## Summary

- Removed duplicate code block in executor.py (lines 162-165 were exact duplicates of lines 157-160)
- Both blocks called `_load_document_variables(context)`, causing duplicate database queries

Part of: Code Quality Improvements from W234 Analysis

## Changes
- Deleted 4 lines of duplicate code in `execute_workflow()` method
- The `_load_document_variables()` method auto-loads document content for `doc_N` variables
- Having this called twice was wasteful and potentially caused subtle bugs

## Testing
- Ran `poetry run pytest tests/test_workflow_executor.py -v` - all 31 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)