### PR TITLE
fix: Add logging to silent exception in similarity service (TECH_DEBT Track A)

### DIFF
--- a/emdx/services/similarity.py
+++ b/emdx/services/similarity.py
@@ -523,6 +523,7 @@ def compute_content_similarity(content1: str, content2: str) -> float:
         tfidf_matrix = vectorizer.fit_transform([content1, content2])
         similarity = cosine_similarity(tfidf_matrix[0:1], tfidf_matrix[1:2])[0][0]
         return float(similarity)
-    except Exception:
+    except Exception as e:
         # If vectorization fails (e.g., empty vocabulary), return 0
+        logger.warning("TF-IDF vectorization failed, returning 0 similarity: %s", e)
         return 0.0


### PR DESCRIPTION
## Summary

- Fixed silent exception in `emdx/services/similarity.py` that was swallowing errors without logging
- The `compute_content_similarity` function now logs a warning when TF-IDF vectorization fails

Part of: Code Quality Improvements from W234 Analysis - TECH_DEBT Track A

## Changes

- In `emdx/services/similarity.py:526`: Changed bare `except Exception:` to capture the exception variable
- Added `logger.warning()` before the return statement to provide visibility into vectorization failures
- Maintains existing fallback behavior (returns 0.0) while adding observability

**Note:** The originally specified files (`document_executor.py` and `claude_executor.py`) already have proper logging setup and do not contain any silent exception blocks with `pass` or `continue`. The only silent exception found in the services directory was in `similarity.py`.

## Testing

- ✅ All 22 similarity tests pass
- ✅ Full test suite passes (406 passed, 5 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)