### PR TITLE
fix(db): Count only existing documents in group doc count

### DIFF
--- a/emdx/database/groups.py
+++ b/emdx/database/groups.py
@@ -342,6 +342,7 @@ def get_recursive_doc_count(group_id: int) -> int:
     """
     with db_connection.get_connection() as conn:
         # Use recursive CTE to get all descendant groups
+        # Only count documents that actually exist and aren't deleted
         cursor = conn.execute(
             """
             WITH RECURSIVE descendants AS (
@@ -354,7 +355,9 @@ def get_recursive_doc_count(group_id: int) -> int:
             )
             SELECT COUNT(DISTINCT dgm.document_id)
             FROM document_group_members dgm
+            JOIN documents d ON dgm.document_id = d.id
             WHERE dgm.group_id IN (SELECT id FROM descendants)
+              AND d.is_deleted = FALSE
             """,
             (group_id,),
         )


### PR DESCRIPTION
## Summary
- Fix `get_recursive_doc_count` to only count documents that actually exist
- Groups with orphaned document references no longer appear expandable in the activity view

## Problem
The `get_recursive_doc_count` function was counting rows in `document_group_members` without verifying the referenced documents still exist. This caused:
- Groups showing `[5]` badge but expanding to show 0 children
- Confusing UX where groups appeared expandable but had nothing to show

## Solution
Added a JOIN with the `documents` table and filter `is_deleted = FALSE` to only count documents that actually exist.

## Test plan
- [x] Verify groups with orphaned references show `[0]` or no expand arrow
- [x] Verify groups with valid documents still show correct count and expand properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)