### PR TITLE
fix(types): Track C Type Safety - Add GitWorktree type annotation

### DIFF
--- a/emdx/ui/execution/selection_state.py
+++ b/emdx/ui/execution/selection_state.py
@@ -7,7 +7,10 @@ multi-stage agent execution workflows.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, Any, List, Optional
+from typing import TYPE_CHECKING, Dict, Any, List, Optional
+
+if TYPE_CHECKING:
+    from emdx.utils.git_ops import GitWorktree
 
 
 @dataclass
@@ -31,7 +34,7 @@ class SelectionState:
     worktree_index: Optional[int] = None
 
     # Pre-loaded data for stages
-    project_worktrees: List[Any] = field(default_factory=list)
+    project_worktrees: "List[GitWorktree]" = field(default_factory=list)
 
     # Configuration
     config: Dict[str, Any] = field(default_factory=dict)
@@ -58,7 +61,7 @@ class SelectionState:
         self,
         project_index: int,
         project_path: str,
-        worktrees: Optional[List[Any]] = None,
+        worktrees: "Optional[List[GitWorktree]]" = None,
         data: Optional[Dict[str, Any]] = None
     ) -> None:
         """Set project selection with optional worktrees."""


### PR DESCRIPTION
## Summary

- Add proper type annotation for `project_worktrees` and `worktrees` parameter in `SelectionState` dataclass
- Replace `List[Any]` with `List[GitWorktree]` for improved type safety
- Use `TYPE_CHECKING` conditional import to avoid circular dependencies at runtime

Part of: Tech Debt Fixes (Track C: Type Safety)

## Changes

The tech debt audit identified three type safety improvements (Track C):

1. **C1: Add types to workflow services.py** - ✅ Already completed (ExecutionResult TypedDict exists)
2. **C2: Add GitWorktree type to selection_state.py** - ✅ Fixed in this PR
3. **C3: Fix Any types in auto_tagger.py** - ✅ Already completed (SqlParam type alias exists)

### This PR fixes C2

- `emdx/ui/execution/selection_state.py`:
  - Added `TYPE_CHECKING` conditional import for `GitWorktree` from `emdx.utils.git_ops`
  - Changed `project_worktrees: List[Any]` to `project_worktrees: "List[GitWorktree]"`
  - Changed `worktrees: Optional[List[Any]]` to `worktrees: "Optional[List[GitWorktree]]"`

## Testing

- All 17 auto_tagger tests pass
- All 77 workflow tests pass (1 skipped)
- Module imports verified with `python -c "from emdx.ui.execution.selection_state import SelectionState; print('Import OK')"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)