### PR TITLE
fix(logging): Add logging to silent exception handlers (Track 1)

### DIFF
--- a/emdx/ui/file_browser/actions.py
+++ b/emdx/ui/file_browser/actions.py
@@ -314,8 +314,8 @@ class FileBrowserActions:
                     try:
                         vim_editor = self.query_one("#edit-preview-container")
                         vim_editor.remove()
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug("Edit preview container not present to remove: %s", e)
 
                     # Just recreate the FilePreview widget to replace the vim editor
                     new_preview = FilePreview(id="file-preview", classes="file-preview-pane")
@@ -500,8 +500,8 @@ class FileBrowserActions:
                 fallback_container = ScrollableContainer(id="file-preview", classes="file-preview-pane")
                 fallback_container.mount(Static(f"Preview of {selected_file.name}"))
                 horizontal_container.mount(fallback_container)
-            except Exception:
-                pass
+            except Exception as e2:
+                logger.debug("Fallback preview mount also failed: %s", e2)
 
     def handle_save_result(self: "FileBrowserView", result: Optional[dict]) -> None:
         """Handle result from save modal."""

--- a/emdx/ui/file_browser/view.py
+++ b/emdx/ui/file_browser/view.py
@@ -230,8 +230,8 @@ class FileBrowserView(FileBrowserNavigation, FileBrowserActions, Container):
             self.refresh_files()
             try:
                 self.query_one("#path-breadcrumb", Static).update(str(new_path))
-            except Exception:
-                pass  # Widget not ready yet
+            except Exception as e:
+                logger.debug("Path breadcrumb widget not ready: %s", e)
             self.selected_index = 0
 
     def watch_selected_index(self, old: int, new: int) -> None:
@@ -241,8 +241,8 @@ class FileBrowserView(FileBrowserNavigation, FileBrowserActions, Container):
                 file_list = self.query_one("#file-list", FileList)
                 file_list.selected_index = new
                 self.update_preview()
-            except Exception:
-                pass  # Widget not ready yet
+            except Exception as e:
+                logger.debug("File list widget not ready: %s", e)
 
     def watch_show_hidden(self, old: bool, new: bool) -> None:
         """React to hidden files toggle."""

--- a/emdx/ui/text_areas.py
+++ b/emdx/ui/text_areas.py
@@ -408,8 +408,8 @@ class VimEditTextArea(TextArea):
                     self.app_instance._update_vim_status("EDIT DOCUMENT | Tab=switch fields | Ctrl+S=save | ESC=cancel")
                 event.stop()
                 return
-            except Exception:
-                pass  # Title input might not exist
+            except Exception as e:
+                logger.debug("Title input widget not available for focus: %s", e)
         
         # Don't stop the event - let it bubble up naturally for TextArea to handle
         # Only update line numbers for operations that might change line count

--- a/emdx/ui/vim_editor.py
+++ b/emdx/ui/vim_editor.py
@@ -141,8 +141,8 @@ class VimEditor(Vertical):
             if hasattr(self.text_area, 'selection'):
                 try:
                     self.text_area.selection = None
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("Could not clear selection: %s", e)
                     
             # Note: scroll_to, scroll_offset, scroll_x/y methods disabled due to
             # first-line visibility issues in Textual TextArea
@@ -160,8 +160,8 @@ class VimEditor(Vertical):
             if hasattr(self.text_area, 'move_cursor'):
                 try:
                     self.text_area.move_cursor((0, 0))
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("Could not move cursor via move_cursor: %s", e)
                     
             # Focus the text area AFTER positioning
             self.text_area.focus()

--- a/emdx/workflows/executor.py
+++ b/emdx/workflows/executor.py
@@ -2,12 +2,15 @@
 
 import asyncio
 import json
+import logging
 import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 from .services import document_service, execution_service, claude_service
 from .base import (
@@ -538,8 +541,8 @@ class WorkflowExecutor:
                             groups_db.add_document_to_group(
                                 group_id, doc_id, role="exploration", added_by="workflow"
                             )
-                        except Exception:
-                            pass  # Don't fail on group membership issues
+                        except Exception as e:
+                            logger.debug("Failed to add doc %s to group %s: %s", doc_id, group_id, e)
                 total_tokens += result.get('tokens_used', 0)
             else:
                 errors.append(result.get('error_message', 'Unknown error'))
@@ -565,8 +568,8 @@ class WorkflowExecutor:
                 groups_db.add_document_to_group(
                     group_id, synthesis_doc_id, role="primary", added_by="workflow"
                 )
-            except Exception:
-                pass  # Don't fail on group membership issues
+            except Exception as e:
+                logger.debug("Failed to add synthesis doc %s to group %s: %s", synthesis_doc_id, group_id, e)
 
         return StageResult(
             success=True,
@@ -948,8 +951,8 @@ class WorkflowExecutor:
                                 groups_db.add_document_to_group(
                                     group_id, doc_id, role="exploration", added_by="workflow"
                                 )
-                            except Exception:
-                                pass
+                            except Exception as e:
+                                logger.debug("Failed to add doc %s to group %s: %s", doc_id, group_id, e)
                     total_tokens += result.get('tokens_used', 0)
                 else:
                     error_msg = f"Item '{result.get('item')}' failed: {result.get('error_message', 'Unknown error')}"
@@ -978,8 +981,8 @@ class WorkflowExecutor:
                         groups_db.add_document_to_group(
                             group_id, synthesis_doc_id, role="primary", added_by="workflow"
                         )
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug("Failed to add synthesis doc %s to group %s: %s", synthesis_doc_id, group_id, e)
 
             # Determine overall success
             if not stage.continue_on_failure and errors:

--- a/emdx/workflows/worktree_pool.py
+++ b/emdx/workflows/worktree_pool.py
@@ -1,6 +1,7 @@
 """Worktree pool for managing parallel git worktrees in dynamic workflows."""
 
 import asyncio
+import logging
 import os
 import random
 import subprocess
@@ -9,6 +10,8 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Set
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -97,8 +100,8 @@ class Worktree:
                 capture_output=True,
                 check=False,
             )
-        except Exception:
-            pass  # Best effort cleanup
+        except Exception as e:
+            logger.debug("Best effort worktree cleanup failed for %s: %s", self.path, e)
 
 
 class WorktreePool:


### PR DESCRIPTION
## Summary

This PR addresses Track A (Track 1) from the tech debt audit by replacing silent `except: pass` blocks with debug logging to improve debuggability while maintaining existing error handling behavior.

Part of: Tech Debt Fixes

## Changes

- **workflows/executor.py**: Add logging to group membership failures during parallel/dynamic stage execution
- **workflows/worktree_pool.py**: Add logging to worktree cleanup failures
- **ui/file_browser/actions.py**: Add logging to widget removal and fallback mount failures  
- **ui/file_browser/view.py**: Add logging to widget-not-ready conditions
- **ui/vim_editor.py**: Add logging to cursor positioning fallback failures
- **ui/text_areas.py**: Add logging to title input focus failures

All changes use `logger.debug()` to avoid noise during normal operation while providing visibility into edge cases during troubleshooting.

## Testing

- [x] All imports verified successful (no syntax errors)
- [x] Workflow tests pass (79 workflow-related tests)
- [x] Full test suite verified passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)