### PR TITLE
fix(cleanup): Track D - Dead Code Cleanup (Issue #Track4)

### DIFF
--- a/emdx/ui/file_browser/view.py
+++ b/emdx/ui/file_browser/view.py
@@ -271,7 +271,7 @@ class FileBrowserView(FileBrowserNavigation, FileBrowserActions, Container):
             self.query_one("#file-status-bar", Static).update(status)
         except Exception as e:
             logger.error(f"🗂️ Error in refresh_files: {e}")
-            pass  # Widgets not ready yet
+            # Widgets not ready yet
 
     def update_preview(self) -> None:
         """Update the preview pane."""
@@ -293,7 +293,7 @@ class FileBrowserView(FileBrowserNavigation, FileBrowserActions, Container):
                 logger.info("🗂️ No file selected for preview")
         except Exception as e:
             logger.error(f"🗂️ Error in update_preview: {e}")
-            pass  # Widgets not ready yet
+            # Widgets not ready yet
 
     def on_key(self, event: events.Key) -> None:
         """Handle key events, especially ESC for mode switching."""

--- a/emdx/ui/inputs.py
+++ b/emdx/ui/inputs.py
@@ -81,7 +81,7 @@ class TitleInput(Input):
                 return
             except Exception as e:
                 logger.debug(f"Could not switch to vim editor: {e}")
-                pass  # Editor might not exist
+                # Editor might not exist
         
         # For other keys (typing), let Input handle normally
         # Input widget doesn't have on_key method, so don't call super()

--- a/emdx/ui/text_areas.py
+++ b/emdx/ui/text_areas.py
@@ -382,7 +382,7 @@ class VimEditTextArea(TextArea):
                 return
             except Exception as e:
                 logger.debug(f"Error switching to title: {e}")
-                pass  # Title input might not exist
+                # Title input might not exist
         
         # Clear pending command if not handled
         if char not in ["g", "d", "y"]:


### PR DESCRIPTION
## Summary

Track D (Dead Code Cleanup) from the tech debt parallel execution plan.

- **D2**: Removed 4 redundant `pass` statements that followed logger calls in exception handlers

## Context

Tasks D1, D3, D4 were found to already be completed in previous work:
- **D1**: `textual_browser.py` file was already removed (no deprecated browser stubs to clean)
- **D3**: `db_path` parameter was already removed from `DuplicateDetector`
- **D4**: Legacy comments were already cleaned up from `claude_execute.py`

## Changes

Removed redundant `pass` statements from:
- `emdx/ui/text_areas.py` (line 385)
- `emdx/ui/inputs.py` (line 84)
- `emdx/ui/file_browser/view.py` (lines 274, 296)

When an exception handler contains a logger call, the `pass` statement is unnecessary since the logger call is already a valid statement.

## Testing

- All 482 tests pass
- No regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)