### PR TITLE
fix(types): Track C Type Safety - Add GitWorktree type annotation (Issue #Track-3)

### DIFF
--- a/emdx/ui/execution/selection_state.py
+++ b/emdx/ui/execution/selection_state.py
@@ -7,7 +7,10 @@ multi-stage agent execution workflows.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, Any, List, Optional
+from typing import TYPE_CHECKING, Dict, Any, List, Optional
+
+if TYPE_CHECKING:
+    from emdx.utils.git_ops import GitWorktree
 
 
 @dataclass
@@ -31,7 +34,7 @@ class SelectionState:
     worktree_index: Optional[int] = None
 
     # Pre-loaded data for stages
-    project_worktrees: List[Any] = field(default_factory=list)
+    project_worktrees: "List[GitWorktree]" = field(default_factory=list)
 
     # Configuration
     config: Dict[str, Any] = field(default_factory=dict)
@@ -58,7 +61,7 @@ class SelectionState:
         self,
         project_index: int,
         project_path: str,
-        worktrees: Optional[List[Any]] = None,
+        worktrees: "Optional[List[GitWorktree]]" = None,
         data: Optional[Dict[str, Any]] = None
     ) -> None:
         """Set project selection with optional worktrees."""


### PR DESCRIPTION
## Summary

- Replace `List[Any]` with `List[GitWorktree]` in `emdx/ui/execution/selection_state.py` for better type safety
- Use `TYPE_CHECKING` import pattern to avoid circular dependencies at runtime

Part of Track C: Type Safety from the tech debt parallel execution plan.

## Changes

- Added `TYPE_CHECKING` guard for `GitWorktree` import from `emdx/utils/git_ops`
- Updated `project_worktrees` field type from `List[Any]` to `List[GitWorktree]`
- Updated `set_project()` method's `worktrees` parameter type

## Testing

- All overlay tests pass (3/3)
- All auto_tagger tests pass (17/17)
- All workflow execution mode tests pass (52/52)
- Verified import works without circular dependencies
- Verified runtime behavior with actual GitWorktree objects

## Notes

Track C (Type Safety) status:
- C1: ExecutionResult TypedDict - Already completed in services.py ✅
- C2: GitWorktree type annotation - **Completed in this PR** ✅
- C3: SqlParam type alias - Already completed in auto_tagger.py ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)