### PR TITLE
fix(cleanup): Track D Dead Code Cleanup

### DIFF
--- a/emdx/services/log_stream.py
+++ b/emdx/services/log_stream.py
@@ -116,9 +116,7 @@ class LogStream:
                     subscriber.on_log_error(e)
                 except Exception as e:
                     # Log subscriber error but continue with others
-                    import logging
-                    logging.debug(f"Subscriber error in log stream: {e}")
-                    pass
+                    logger.debug(f"Subscriber error in log stream: {e}")
     
     def _read_new_content(self) -> str:
         """Read only new content since last position."""


### PR DESCRIPTION
## Summary

Part of: Tech Debt Fixes - Track D: Dead Code Cleanup

This PR addresses the remaining dead code issues from Track D of the tech debt audit.

## Changes

- Removed redundant `pass` statement after `logger.debug()` call in `log_stream.py`
- Removed redundant `import logging` inside exception handler (module-level `logger` already available)

## What was already done

Most Track D tasks were already completed in previous PRs:
- D1 (textual_browser.py stubs): File no longer exists
- D3 (DuplicateDetector db_path): Already removed - class now uses shared db module
- D4 (claude_execute.py legacy comments): Already cleaned up

## Testing

- ✅ Import test: `from emdx.services.log_stream import LogStream` succeeds
- ✅ All similarity tests pass (22 passed)
- ✅ All duplicate detector tests pass (23 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)