### PR TITLE
fix(tech-debt): Standardize logger initialization (Track B)

### DIFF
--- a/emdx/database/documents.py
+++ b/emdx/database/documents.py
@@ -2,10 +2,13 @@
 Document CRUD operations for emdx knowledge base
 """
 
+import logging
 from typing import Any, Optional, Union
 
 from ..utils.datetime import parse_datetime
 from .connection import db_connection
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_doc_datetimes(doc: dict[str, Any], fields: list[str] | None = None) -> dict[str, Any]:
@@ -802,9 +805,7 @@ def record_document_source(
             conn.commit()
             return True
         except Exception as e:
-            from emdx.utils.logging import get_logger
-
-            get_logger(__name__).error(f"Error recording document source: {e}")
+            logger.error(f"Error recording document source: {e}")
             return False
 
 

--- a/emdx/workflows/executor.py
+++ b/emdx/workflows/executor.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 import re
 import time
 from dataclasses import dataclass, field
@@ -10,6 +11,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .services import document_service, execution_service, claude_service
+
+logger = logging.getLogger(__name__)
 from .base import (
     ExecutionMode,
     IterationStrategy,
@@ -1229,14 +1232,10 @@ Report the document ID that was created."""
             return None
         except (OSError, IOError) as e:
             # Log file read errors
-            from emdx.utils.logging import get_logger
-            logger = get_logger(__name__)
             logger.debug(f"Could not read log file {log_file} for output doc ID extraction: {type(e).__name__}: {e}")
             return None
         except Exception as e:
             # Log unexpected errors during parsing
-            from emdx.utils.logging import get_logger
-            logger = get_logger(__name__)
             logger.warning(f"Unexpected error extracting output doc ID from {log_file}: {type(e).__name__}: {e}")
             return None
 
@@ -1298,13 +1297,9 @@ Report the document ID that was created."""
 
             return empty
         except (OSError, IOError) as e:
-            from emdx.utils.logging import get_logger
-            logger = get_logger(__name__)
             logger.debug(f"Could not read log file {log_file} for token extraction: {type(e).__name__}: {e}")
             return empty
         except Exception as e:
-            from emdx.utils.logging import get_logger
-            logger = get_logger(__name__)
             logger.warning(f"Unexpected error extracting tokens from {log_file}: {type(e).__name__}: {e}")
             return empty
 

--- a/emdx/workflows/strategies/base.py
+++ b/emdx/workflows/strategies/base.py
@@ -1,5 +1,6 @@
 """Base class for execution strategies."""
 
+import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -11,6 +12,8 @@ from ..base import StageConfig
 from ..services import document_service, execution_service, claude_service
 from .. import database as wf_db
 from emdx.database.documents import record_document_source
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -299,14 +302,10 @@ Report the document ID that was created."""
             return None
         except (OSError, IOError) as e:
             # Log file read errors
-            from emdx.utils.logging import get_logger
-            logger = get_logger(__name__)
             logger.debug(f"Could not read log file {log_file} for output doc ID extraction: {type(e).__name__}: {e}")
             return None
         except Exception as e:
             # Log unexpected errors during parsing
-            from emdx.utils.logging import get_logger
-            logger = get_logger(__name__)
             logger.warning(f"Unexpected error extracting output doc ID from {log_file}: {type(e).__name__}: {e}")
             return None
 
@@ -381,8 +380,6 @@ Report the document ID that was created."""
                 set_parent(doc_id, synthesis_doc_id, relationship="exploration")
             except Exception as e:
                 # Log but don't fail - hierarchy is nice-to-have
-                from emdx.utils.logging import get_logger
-                logger = get_logger(__name__)
                 logger.debug(
                     f"Could not link output #{doc_id} to synthesis #{synthesis_doc_id}: {e}"
                 )


### PR DESCRIPTION
## Summary

Part of tech debt cleanup - Track B: Code Deduplication

- Replace inline imports of `get_logger()` inside exception handlers with module-level logger
- Add standard `logger = logging.getLogger(__name__)` pattern to 3 files
- Remove 8 inline imports from exception handlers

## Changes

### Files Modified:
- `emdx/workflows/executor.py` - Added module-level logger, removed 4 inline imports
- `emdx/workflows/strategies/base.py` - Added module-level logger, removed 3 inline imports  
- `emdx/database/documents.py` - Added module-level logger, removed 1 inline import

### Context
The tech debt audit (TECH_DEBT_TASKS.md) identified Track B as "Code Deduplication". While investigating:
- B1 (shared Console module) was already implemented at `emdx/utils/output.py`
- B2-B5 (Console import migration) was already completed across commands
- B6 (CLI error handling decorator) was already implemented at `emdx/utils/cli.py`
- B7 (standardize logger initialization) had remaining work: 3 files using inline imports

This PR completes B7 by replacing anti-pattern inline imports with standard module-level loggers.

## Testing

- [x] `poetry run python -m pytest tests/test_database.py tests/test_workflow_executor.py -v` - 45 tests passed
- [x] Import verification successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)