### PR TITLE
fix: Track B Code Deduplication (Tech Debt)

### DIFF
--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -332,6 +332,24 @@ emdx --version
 - **Tests** for all new functionality
 - **Documentation** updates for significant changes
 
+#### **Logging Standards**
+Use the standard Python logging pattern:
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+This allows callers to configure logging as needed. The `emdx/utils/logging.py` module provides `get_logger()` for cases requiring automatic file handler setup, but standard library usage is preferred for most modules.
+
+#### **Console Output Standards**
+Use the shared console instance for CLI output:
+```python
+from emdx.utils.output import console
+
+console.print("[green]Success![/green]")
+```
+This ensures consistent formatting across the CLI. Use `emdx/utils/cli.py` decorators for standardized error handling.
+
 ### **Commit Message Format**
 ```
 feat: add event-driven log streaming

--- a/emdx/ui/workflow_browser.py
+++ b/emdx/ui/workflow_browser.py
@@ -18,7 +18,6 @@ import re
 import textwrap
 from typing import List, Optional, Tuple
 
-from rich.console import Console, Group
 from rich.panel import Panel
 from rich.text import Text
 from textual.app import ComposeResult


### PR DESCRIPTION
## Summary

This PR completes Track B (Code Deduplication) from the tech debt tasks. Most items were already completed in previous work:

- **B1** ✅ Shared console module exists at `emdx/utils/output.py`
- **B2-B5** ✅ Console imports already migrated across 14+ files  
- **B6** ✅ CLI error handling decorator exists at `emdx/utils/cli.py`
- **B7** ✅ Documented logging and console output standards

## Changes

- Removed unused `Console` and `Group` imports from `emdx/ui/workflow_browser.py`
- Added **Logging Standards** section to `docs/development-setup.md` documenting the pattern:
  ```python
  import logging
  logger = logging.getLogger(__name__)
  ```
- Added **Console Output Standards** section documenting shared console usage:
  ```python
  from emdx.utils.output import console
  ```

## Testing

- All 482 tests pass
- Verified `workflow_browser.py` imports correctly after change

🤖 Generated with [Claude Code](https://claude.com/claude-code)