### PR TITLE
feat(ai): Add semantic search and RAG Q&A system

### DIFF
--- a/emdx/main.py
+++ b/emdx/main.py
@@ -28,6 +28,7 @@ from emdx.commands.keybindings import app as keybindings_app
 from emdx.commands.preset import app as preset_app
 from emdx.commands.run import run as run_command
 from emdx.commands.groups import app as groups_app
+from emdx.commands.ask import app as ask_app
 from emdx.ui.gui import gui
 from emdx.utils.output import console
 
@@ -95,6 +96,9 @@ app.add_typer(keybindings_app, name="keybindings", help="Manage TUI keybindings"
 
 # Add preset management as a subcommand group
 app.add_typer(preset_app, name="preset", help="Manage run presets")
+
+# Add AI-powered features (ask, semantic search, embeddings)
+app.add_typer(ask_app, name="ai", help="AI-powered Q&A and semantic search")
 
 # Add the run command for quick task execution
 app.command(name="run")(run_command)

--- a/emdx/services/ask_service.py
+++ b/emdx/services/ask_service.py
@@ -1,0 +1,350 @@
+"""
+Q&A service for EMDX - RAG over your knowledge base.
+
+Uses semantic search when available (embeddings indexed),
+falls back to keyword search (FTS) otherwise.
+"""
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import anthropic
+
+from ..database import db
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Answer:
+    """An answer from the knowledge base."""
+
+    text: str
+    sources: List[int]  # Document IDs used
+    method: str  # "semantic" or "keyword"
+    context_size: int  # Characters of context used
+
+
+class AskService:
+    """Answer questions using your knowledge base."""
+
+    DEFAULT_MODEL = "claude-sonnet-4-20250514"
+    MIN_EMBEDDINGS_FOR_SEMANTIC = 50  # Use semantic only if we have enough coverage
+
+    def __init__(self, model: Optional[str] = None):
+        self.model = model or self.DEFAULT_MODEL
+        self._client = None
+        self._embedding_service = None
+
+    def _get_client(self) -> anthropic.Anthropic:
+        """Lazy load Anthropic client."""
+        if self._client is None:
+            self._client = anthropic.Anthropic()
+        return self._client
+
+    def _get_embedding_service(self):
+        """Lazy load embedding service."""
+        if self._embedding_service is None:
+            try:
+                from .embedding_service import EmbeddingService
+
+                self._embedding_service = EmbeddingService()
+            except ImportError:
+                logger.warning("sentence-transformers not installed, semantic search unavailable")
+                return None
+        return self._embedding_service
+
+    def _has_embeddings(self) -> bool:
+        """Check if we have enough embeddings for semantic search."""
+        embedding_service = self._get_embedding_service()
+        if embedding_service is None:
+            return False
+
+        try:
+            stats = embedding_service.stats()
+            return stats.indexed_documents >= self.MIN_EMBEDDINGS_FOR_SEMANTIC
+        except Exception as e:
+            logger.debug(f"Could not check embedding stats: {e}")
+            return False
+
+    def ask(
+        self,
+        question: str,
+        limit: int = 10,
+        project: Optional[str] = None,
+        force_keyword: bool = False,
+    ) -> Answer:
+        """
+        Ask a question about your knowledge base.
+
+        Automatically chooses semantic or keyword search based on
+        whether embeddings are available.
+        """
+        # Choose retrieval method
+        if force_keyword or not self._has_embeddings():
+            docs, method = self._retrieve_keyword(question, limit, project)
+        else:
+            docs, method = self._retrieve_semantic(question, limit, project)
+
+        # Generate answer
+        answer_text, context_size = self._generate_answer(question, docs)
+
+        return Answer(
+            text=answer_text,
+            sources=[d[0] for d in docs],
+            method=method,
+            context_size=context_size,
+        )
+
+    def _retrieve_keyword(
+        self, question: str, limit: int, project: Optional[str] = None
+    ) -> Tuple[List[tuple], str]:
+        """Retrieve documents using FTS keyword search."""
+        docs = []
+        seen = set()
+
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+
+            # 1. Extract and search for explicit references (AUTH-123, #42)
+            ticket_refs = re.findall(r"[A-Z]{2,10}-\d+", question)
+            doc_refs = re.findall(r"#(\d+)", question)
+
+            # Fetch explicitly referenced docs
+            for doc_id in doc_refs:
+                try:
+                    doc_id_int = int(doc_id)
+                    cursor.execute(
+                        "SELECT id, title, content FROM documents WHERE id = ? AND is_deleted = 0",
+                        (doc_id_int,),
+                    )
+                    row = cursor.fetchone()
+                    if row and row[0] not in seen:
+                        docs.append(row)
+                        seen.add(row[0])
+                except ValueError:
+                    pass
+
+            # Search for ticket references in content
+            for ticket in ticket_refs:
+                query = """
+                    SELECT id, title, content FROM documents
+                    WHERE content LIKE ? AND is_deleted = 0
+                """
+                params = [f"%{ticket}%"]
+
+                if project:
+                    query += " AND project = ?"
+                    params.append(project)
+
+                query += " LIMIT 3"
+                cursor.execute(query, params)
+
+                for row in cursor.fetchall():
+                    if row[0] not in seen:
+                        docs.append(row)
+                        seen.add(row[0])
+
+            # 2. FTS search for question terms
+            # Clean question for FTS (remove special chars, keep words)
+            terms = re.sub(r"[^\w\s]", " ", question).strip()
+            if terms and len(docs) < limit:
+                query = """
+                    SELECT id, title, content FROM documents
+                    WHERE documents_fts MATCH ? AND is_deleted = 0
+                """
+                params = [terms]
+
+                if project:
+                    query += " AND project = ?"
+                    params.append(project)
+
+                query += " ORDER BY rank LIMIT ?"
+                params.append(limit - len(docs))
+
+                try:
+                    cursor.execute(query, params)
+                    for row in cursor.fetchall():
+                        if row[0] not in seen:
+                            docs.append(row)
+                            seen.add(row[0])
+                except Exception as e:
+                    # FTS query might fail on complex queries
+                    logger.debug(f"FTS search failed: {e}")
+
+            # 3. Fallback to recent docs if nothing found
+            if not docs:
+                query = """
+                    SELECT id, title, content FROM documents
+                    WHERE is_deleted = 0
+                """
+                params = []
+
+                if project:
+                    query += " AND project = ?"
+                    params.append(project)
+
+                query += " ORDER BY updated_at DESC LIMIT ?"
+                params.append(limit)
+
+                cursor.execute(query, params)
+                docs = cursor.fetchall()
+
+        return docs[:limit], "keyword"
+
+    def _retrieve_semantic(
+        self, question: str, limit: int, project: Optional[str] = None
+    ) -> Tuple[List[tuple], str]:
+        """Retrieve documents using semantic (embedding) search."""
+        embedding_service = self._get_embedding_service()
+        if embedding_service is None:
+            return self._retrieve_keyword(question, limit, project)
+
+        try:
+            matches = embedding_service.search(question, limit=limit * 2)
+
+            # Fetch full content for matches
+            docs = []
+            with db.get_connection() as conn:
+                cursor = conn.cursor()
+                for match in matches:
+                    query = "SELECT id, title, content FROM documents WHERE id = ?"
+                    params = [match.doc_id]
+
+                    if project:
+                        query += " AND project = ?"
+                        params.append(project)
+
+                    cursor.execute(query, params)
+                    row = cursor.fetchone()
+                    if row:
+                        docs.append(row)
+
+                    if len(docs) >= limit:
+                        break
+
+            if docs:
+                return docs, "semantic"
+
+            # Fall back to keyword if semantic returns nothing
+            return self._retrieve_keyword(question, limit, project)
+
+        except Exception as e:
+            logger.warning(f"Semantic search failed, falling back to keyword: {e}")
+            return self._retrieve_keyword(question, limit, project)
+
+    def _generate_answer(
+        self, question: str, docs: List[tuple]
+    ) -> Tuple[str, int]:
+        """Generate answer from retrieved documents using Claude."""
+        if not docs:
+            return (
+                "I couldn't find any relevant documents to answer this question. "
+                "Try rephrasing or check if you have documents on this topic.",
+                0,
+            )
+
+        # Build context from documents
+        context_parts = []
+        for doc_id, title, content in docs:
+            # Truncate very long documents
+            truncated = content[:3000] if len(content) > 3000 else content
+            context_parts.append(f"# Document #{doc_id}: {title}\n\n{truncated}")
+
+        context = "\n\n---\n\n".join(context_parts)
+        context_size = len(context)
+
+        # Generate answer with Claude
+        try:
+            client = self._get_client()
+            response = client.messages.create(
+                model=self.model,
+                max_tokens=1000,
+                system="""You answer questions using the provided knowledge base context.
+
+Rules:
+- Only answer based on the provided documents
+- Cite document IDs when referencing information (e.g., "According to Document #42...")
+- If the context doesn't contain relevant information, say so clearly
+- Be concise but complete
+- If documents contain conflicting information, note the discrepancy""",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": f"Context from my knowledge base:\n\n{context}\n\n---\n\nQuestion: {question}",
+                    }
+                ],
+            )
+
+            return response.content[0].text, context_size
+
+        except anthropic.APIError as e:
+            logger.error(f"Claude API error: {e}")
+            return f"Error generating answer: {e}", context_size
+
+    def ask_with_context(
+        self,
+        question: str,
+        additional_context: str,
+        limit: int = 5,
+        project: Optional[str] = None,
+    ) -> Answer:
+        """
+        Ask a question with additional context (e.g., from external resources).
+
+        The additional_context is prepended to the retrieved documents.
+        """
+        # Retrieve relevant docs
+        if self._has_embeddings():
+            docs, method = self._retrieve_semantic(question, limit, project)
+        else:
+            docs, method = self._retrieve_keyword(question, limit, project)
+
+        # Build combined context
+        context_parts = [additional_context] if additional_context else []
+
+        for doc_id, title, content in docs:
+            truncated = content[:2000] if len(content) > 2000 else content
+            context_parts.append(f"# Document #{doc_id}: {title}\n\n{truncated}")
+
+        context = "\n\n---\n\n".join(context_parts)
+
+        # Generate answer
+        try:
+            client = self._get_client()
+            response = client.messages.create(
+                model=self.model,
+                max_tokens=1000,
+                system="""You answer questions using the provided context which may include:
+1. External resource data (Jira tickets, GitHub issues, etc.)
+2. Documents from the user's knowledge base
+
+Rules:
+- Cite sources clearly (Jira tickets by ID, documents by #ID)
+- If sources conflict, note the discrepancy
+- Be concise but complete""",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": f"Context:\n\n{context}\n\n---\n\nQuestion: {question}",
+                    }
+                ],
+            )
+
+            return Answer(
+                text=response.content[0].text,
+                sources=[d[0] for d in docs],
+                method=method,
+                context_size=len(context),
+            )
+
+        except anthropic.APIError as e:
+            logger.error(f"Claude API error: {e}")
+            return Answer(
+                text=f"Error generating answer: {e}",
+                sources=[d[0] for d in docs],
+                method=method,
+                context_size=len(context),
+            )

--- a/emdx/services/embedding_service.py
+++ b/emdx/services/embedding_service.py
@@ -1,0 +1,335 @@
+"""
+Semantic embedding service for EMDX.
+
+Uses sentence-transformers for local embedding generation,
+enabling semantic search without API costs.
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
+
+import numpy as np
+
+from ..database import db
+
+logger = logging.getLogger(__name__)
+
+# Lazy load - model is ~90MB, loads in ~2 seconds
+_model = None
+
+
+def _get_model():
+    """Lazy load the embedding model."""
+    global _model
+    if _model is None:
+        from sentence_transformers import SentenceTransformer
+
+        # all-MiniLM-L6-v2: Good balance of speed/quality
+        # ~90MB download, ~80ms per doc, 384 dimensions
+        _model = SentenceTransformer("all-MiniLM-L6-v2")
+        logger.info("Loaded embedding model: all-MiniLM-L6-v2")
+    return _model
+
+
+@dataclass
+class SemanticMatch:
+    """A semantically similar document."""
+
+    doc_id: int
+    title: str
+    project: Optional[str]
+    similarity: float
+    snippet: str
+
+
+@dataclass
+class EmbeddingStats:
+    """Statistics about the embedding index."""
+
+    total_documents: int
+    indexed_documents: int
+    coverage_percent: float
+    model_name: str
+    index_size_bytes: int
+
+
+class EmbeddingService:
+    """Manages document embeddings for semantic search."""
+
+    MODEL_NAME = "all-MiniLM-L6-v2"
+    EMBEDDING_DIM = 384
+
+    def embed_text(self, text: str) -> np.ndarray:
+        """Embed arbitrary text."""
+        model = _get_model()
+        return model.encode(text, convert_to_numpy=True, normalize_embeddings=True)
+
+    def embed_document(self, doc_id: int, force: bool = False) -> np.ndarray:
+        """Embed a document (cached in database)."""
+        # Check cache first
+        if not force:
+            cached = self._get_cached_embedding(doc_id)
+            if cached is not None:
+                return cached
+
+        # Fetch document content
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT title, content FROM documents WHERE id = ? AND is_deleted = 0",
+                (doc_id,),
+            )
+            row = cursor.fetchone()
+            if not row:
+                raise ValueError(f"Document {doc_id} not found")
+
+            title, content = row
+
+        # Combine title and content for richer embedding
+        text = f"{title}\n\n{content}"
+        embedding = self.embed_text(text)
+
+        # Cache it
+        self._save_embedding(doc_id, embedding)
+
+        return embedding
+
+    def _get_cached_embedding(self, doc_id: int) -> Optional[np.ndarray]:
+        """Get cached embedding from database."""
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT embedding FROM document_embeddings WHERE document_id = ? AND model_name = ?",
+                (doc_id, self.MODEL_NAME),
+            )
+            row = cursor.fetchone()
+            if row:
+                return np.frombuffer(row[0], dtype=np.float32)
+        return None
+
+    def _save_embedding(self, doc_id: int, embedding: np.ndarray) -> None:
+        """Cache embedding to database."""
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT OR REPLACE INTO document_embeddings
+                (document_id, model_name, embedding, dimension, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+            """,
+                (
+                    doc_id,
+                    self.MODEL_NAME,
+                    embedding.tobytes(),
+                    self.EMBEDDING_DIM,
+                    datetime.utcnow().isoformat(),
+                ),
+            )
+            conn.commit()
+
+    def index_all(self, force: bool = False, batch_size: int = 50) -> int:
+        """Index all unembedded documents. Returns count of newly indexed docs."""
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+
+            if force:
+                # Get all documents
+                cursor.execute(
+                    "SELECT id, title, content FROM documents WHERE is_deleted = 0"
+                )
+            else:
+                # Only get documents without embeddings
+                cursor.execute(
+                    """
+                    SELECT d.id, d.title, d.content
+                    FROM documents d
+                    LEFT JOIN document_embeddings e
+                        ON d.id = e.document_id AND e.model_name = ?
+                    WHERE d.is_deleted = 0 AND e.id IS NULL
+                """,
+                    (self.MODEL_NAME,),
+                )
+
+            docs = cursor.fetchall()
+
+        if not docs:
+            return 0
+
+        model = _get_model()
+        count = 0
+
+        # Process in batches for efficiency
+        for i in range(0, len(docs), batch_size):
+            batch = docs[i : i + batch_size]
+            texts = [f"{title}\n\n{content}" for _, title, content in batch]
+
+            # Batch encode
+            embeddings = model.encode(
+                texts,
+                convert_to_numpy=True,
+                normalize_embeddings=True,
+                show_progress_bar=False,
+            )
+
+            # Save all embeddings in batch
+            with db.get_connection() as conn:
+                cursor = conn.cursor()
+                for (doc_id, _, _), embedding in zip(batch, embeddings):
+                    cursor.execute(
+                        """
+                        INSERT OR REPLACE INTO document_embeddings
+                        (document_id, model_name, embedding, dimension, updated_at)
+                        VALUES (?, ?, ?, ?, ?)
+                    """,
+                        (
+                            doc_id,
+                            self.MODEL_NAME,
+                            embedding.tobytes(),
+                            self.EMBEDDING_DIM,
+                            datetime.utcnow().isoformat(),
+                        ),
+                    )
+                conn.commit()
+
+            count += len(batch)
+            logger.info(f"Indexed {count}/{len(docs)} documents")
+
+        return count
+
+    def search(
+        self, query: str, limit: int = 10, threshold: float = 0.3
+    ) -> List[SemanticMatch]:
+        """Semantic search across all documents."""
+        query_embedding = self.embed_text(query)
+
+        # Load all embeddings from database
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT e.document_id, e.embedding, d.title, d.project,
+                       SUBSTR(d.content, 1, 200) as snippet
+                FROM document_embeddings e
+                JOIN documents d ON e.document_id = d.id
+                WHERE e.model_name = ? AND d.is_deleted = 0
+            """,
+                (self.MODEL_NAME,),
+            )
+            rows = cursor.fetchall()
+
+        if not rows:
+            return []
+
+        # Compute similarities
+        results = []
+        for doc_id, emb_bytes, title, project, snippet in rows:
+            doc_embedding = np.frombuffer(emb_bytes, dtype=np.float32)
+            # Dot product of normalized vectors = cosine similarity
+            similarity = float(np.dot(query_embedding, doc_embedding))
+
+            if similarity >= threshold:
+                results.append(
+                    SemanticMatch(
+                        doc_id=doc_id,
+                        title=title,
+                        project=project,
+                        similarity=similarity,
+                        snippet=snippet.replace("\n", " ")[:150] + "..."
+                        if snippet
+                        else "",
+                    )
+                )
+
+        # Sort by similarity descending
+        results.sort(key=lambda x: x.similarity, reverse=True)
+        return results[:limit]
+
+    def find_similar(self, doc_id: int, limit: int = 5) -> List[SemanticMatch]:
+        """Find documents similar to a given document."""
+        doc_embedding = self.embed_document(doc_id)
+
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT e.document_id, e.embedding, d.title, d.project,
+                       SUBSTR(d.content, 1, 200) as snippet
+                FROM document_embeddings e
+                JOIN documents d ON e.document_id = d.id
+                WHERE e.model_name = ? AND d.is_deleted = 0 AND e.document_id != ?
+            """,
+                (self.MODEL_NAME, doc_id),
+            )
+            rows = cursor.fetchall()
+
+        results = []
+        for other_id, emb_bytes, title, project, snippet in rows:
+            other_embedding = np.frombuffer(emb_bytes, dtype=np.float32)
+            similarity = float(np.dot(doc_embedding, other_embedding))
+
+            results.append(
+                SemanticMatch(
+                    doc_id=other_id,
+                    title=title,
+                    project=project,
+                    similarity=similarity,
+                    snippet=snippet.replace("\n", " ")[:150] + "..." if snippet else "",
+                )
+            )
+
+        results.sort(key=lambda x: x.similarity, reverse=True)
+        return results[:limit]
+
+    def stats(self) -> EmbeddingStats:
+        """Get embedding index statistics."""
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+
+            # Total documents
+            cursor.execute("SELECT COUNT(*) FROM documents WHERE is_deleted = 0")
+            total = cursor.fetchone()[0]
+
+            # Indexed documents
+            cursor.execute(
+                "SELECT COUNT(*) FROM document_embeddings WHERE model_name = ?",
+                (self.MODEL_NAME,),
+            )
+            indexed = cursor.fetchone()[0]
+
+            # Index size
+            cursor.execute(
+                "SELECT SUM(LENGTH(embedding)) FROM document_embeddings WHERE model_name = ?",
+                (self.MODEL_NAME,),
+            )
+            size = cursor.fetchone()[0] or 0
+
+        coverage = (indexed / total * 100) if total > 0 else 0
+
+        return EmbeddingStats(
+            total_documents=total,
+            indexed_documents=indexed,
+            coverage_percent=round(coverage, 1),
+            model_name=self.MODEL_NAME,
+            index_size_bytes=size,
+        )
+
+    def delete_embedding(self, doc_id: int) -> bool:
+        """Delete embedding for a document."""
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM document_embeddings WHERE document_id = ?", (doc_id,)
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def clear_index(self) -> int:
+        """Clear all embeddings. Returns count deleted."""
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM document_embeddings")
+            count = cursor.rowcount
+            conn.commit()
+            return count

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ google-auth-httplib2 = "^0.2.0"
 google-auth-oauthlib = "^1.2.0"
 scikit-learn = "^1.6.0"  # TF-IDF similarity
 datasketch = "^1.6.0"  # MinHash/LSH for O(n) duplicate detection
+sentence-transformers = "^3.0.0"  # Local embeddings for semantic search
+anthropic = "^0.40.0"  # Claude API for RAG Q&A
+numpy = "^1.26.0"  # Vector operations for embeddings
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"


### PR DESCRIPTION
Add AI-powered features for knowledge base Q&A:

- EmbeddingService: Local embeddings using sentence-transformers
  (all-MiniLM-L6-v2) for semantic search without API costs
- AskService: RAG implementation that retrieves relevant docs
  and generates answers using Claude API
- CLI commands under `emdx ai`:
  - `ask`: Question-answering over knowledge base
  - `index`: Build/update embedding index
  - `search`: Semantic search across documents
  - `similar`: Find similar documents
  - `stats`: Index statistics
  - `clear`: Clear embedding index

The system automatically falls back to keyword search (FTS)
when embeddings aren't indexed, making it work out of the box.

Dependencies added:
- sentence-transformers ^3.0.0 (local embeddings)
- anthropic ^0.40.0 (Claude API)
- numpy ^1.26.0 (vector operations)