### PR TITLE
fix: Add logging to silent exception handlers (Track A tech debt)

### DIFF
--- a/emdx/commands/export_profiles.py
+++ b/emdx/commands/export_profiles.py
@@ -131,6 +131,7 @@ def create_profile(
         console.print(f"[green]✓ Created export profile '{name}' (ID: {profile_id})[/green]")
 
     except Exception as e:
+        logger.warning("Failed to create export profile: %s", e, exc_info=True)
         console.print(f"[red]Error creating profile: {e}[/red]")
         raise typer.Exit(1)
 
@@ -338,6 +339,7 @@ def edit_profile(
         console.print(f"[red]Invalid JSON: {e}[/red]")
         raise typer.Exit(1)
     except Exception as e:
+        logger.warning("Failed to update export profile: %s", e, exc_info=True)
         console.print(f"[red]Error updating profile: {e}[/red]")
         raise typer.Exit(1)
     finally:
@@ -485,6 +487,7 @@ def import_profile_json(
         console.print(f"[green]✓ Imported profile '{data['name']}' (ID: {profile_id})[/green]")
 
     except Exception as e:
+        logger.warning("Failed to import export profile: %s", e, exc_info=True)
         console.print(f"[red]Error importing profile: {e}[/red]")
         raise typer.Exit(1)
 

--- a/emdx/commands/gdoc.py
+++ b/emdx/commands/gdoc.py
@@ -462,6 +462,7 @@ def create_google_doc(title: str, markdown_content: str) -> Optional[dict]:
         }
 
     except Exception as e:
+        logger.warning("Failed to create Google Doc: %s", e, exc_info=True)
         console.print(f"[red]Error creating Google Doc: {e}[/red]")
         return None
 
@@ -512,6 +513,7 @@ def move_to_folder(doc_id: str, folder_name: str) -> bool:
         return True
 
     except Exception as e:
+        logger.warning("Failed to move Google Doc to folder: %s", e)
         console.print(f"[yellow]Warning: Could not move to folder: {e}[/yellow]")
         return False
 

--- a/emdx/commands/maintain.py
+++ b/emdx/commands/maintain.py
@@ -961,8 +961,9 @@ def _cleanup_executions(dry_run: bool, timeout_minutes: int = 30, check_heartbea
                 update_execution_status(exec.id, "failed", exit_code)
                 updated += 1
             except Exception as e:
+                logger.warning("Failed to update execution %s status: %s", exec.id, e)
                 failed_updates += 1
-                
+
             progress.update(task, advance=1)
     
     # Report results

--- a/emdx/services/document_executor.py
+++ b/emdx/services/document_executor.py
@@ -250,6 +250,7 @@ def execute_document_background(
             'context': context,
         }
     except Exception as e:
+        logger.warning("Failed to execute document %s: %s", doc_id, e, exc_info=True)
         return {
             'success': False,
             'execution_id': execution_id,


### PR DESCRIPTION
## Summary

- Add logging before silent exception handlers to improve debugging
- Adds `logger.warning()` calls with context before returning/continuing
- Four files updated: document_executor.py, maintain.py, export_profiles.py, gdoc.py

Part of: Tech Debt Fixes (Track A - Exception Handling)

## Changes

- **emdx/services/document_executor.py**: Log failed document execution with exc_info
- **emdx/commands/maintain.py**: Log failed execution status updates with execution ID
- **emdx/commands/export_profiles.py**: Log failed profile create/update/import operations with exc_info
- **emdx/commands/gdoc.py**: Log failed Google Doc creation and folder move operations

## Testing

- All 341 tests pass (5 skipped)
- pytest tests/ -v --tb=short completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)