### PR TITLE
fix: Rename Runs column to Uses in workflow browser (Issue #5476)

### DIFF
--- a/emdx/ui/workflow_browser.py
+++ b/emdx/ui/workflow_browser.py
@@ -275,7 +275,7 @@ class WorkflowBrowser(HelpMixin, Widget):
             table.add_column("Pipeline", width=12)
             table.add_column("Name", width=24)
             table.add_column("Task", width=5)
-            table.add_column("Runs", width=5)
+            table.add_column("Uses", width=5)
 
             workflows = workflow_registry.list_workflows(include_inactive=False)
             # Sort by usage


### PR DESCRIPTION
## Summary
- Renamed the "Runs" column header to "Uses" in the workflow browser table
- The column displays `usage_count` data, so "Uses" more accurately describes what the data represents

## Test plan
- [ ] Open workflow browser and verify column is labeled "Uses"
- [ ] Confirm usage counts still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)