### PR TITLE
fix: Replace cryptic mode icons with clearer symbols (Issue #5476)

### DIFF
--- a/emdx/ui/workflow_browser.py
+++ b/emdx/ui/workflow_browser.py
@@ -45,11 +45,11 @@ except Exception as e:
 
 # Mode icons and colors for visual pipeline display
 MODE_INFO = {
-    "single": {"icon": "1", "color": "dim", "name": "single"},
+    "single": {"icon": "•", "color": "dim", "name": "single"},
     "parallel": {"icon": "||", "color": "cyan", "name": "parallel"},
-    "iterative": {"icon": "→", "color": "yellow", "name": "iterative"},
+    "iterative": {"icon": "⟳", "color": "yellow", "name": "iterative"},
     "adversarial": {"icon": "⚔", "color": "red", "name": "adversarial"},
-    "dynamic": {"icon": "*", "color": "magenta", "name": "dynamic"},
+    "dynamic": {"icon": "◈", "color": "magenta", "name": "dynamic"},
 }
 
 


### PR DESCRIPTION
## Summary
- Replace cryptic mode icons in workflow browser with clearer visual symbols
- **single**: `1` → `•` (bullet point - indicates single item)
- **dynamic**: `*` → `◈` (diamond with dot - indicates dynamic/variable)
- **iterative**: `→` → `⟳` (circular arrow - indicates repetition/looping)

## Test plan
- [ ] Launch `emdx gui` and navigate to workflow browser
- [ ] Verify pipeline display shows new icons correctly
- [ ] Confirm icons render properly in terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)