### PR TITLE
fix: Reduce default max concurrent from 10 to 5 (Issue #5476)

### DIFF
--- a/emdx/config/constants.py
+++ b/emdx/config/constants.py
@@ -35,7 +35,7 @@ DEFAULT_REFRESH_INTERVAL_SECONDS = 5  # UI auto-refresh interval
 # CONCURRENCY & POOL SIZES
 # =============================================================================
 
-DEFAULT_MAX_CONCURRENT_WORKFLOWS = 10  # Workflow executor default
+DEFAULT_MAX_CONCURRENT_WORKFLOWS = 5  # Workflow executor default
 DEFAULT_MAX_CONCURRENT_STAGES = 5  # Stage config, worktree pool
 DEFAULT_MAX_AGENT_ITERATIONS = 10  # Max iterations for agent loops
 

--- a/emdx/workflows/executor.py
+++ b/emdx/workflows/executor.py
@@ -25,6 +25,7 @@ from .output_parser import extract_output_doc_id, extract_token_usage_detailed
 from .agent_runner import run_agent
 from .synthesis import synthesize_outputs
 from emdx.database import groups as groups_db
+from emdx.config import DEFAULT_MAX_CONCURRENT_WORKFLOWS
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ class WorkflowExecutor:
     - adversarial: Advocate -> Critic -> Synthesizer pattern
     """
 
-    def __init__(self, max_concurrent: int = 10):
+    def __init__(self, max_concurrent: int = DEFAULT_MAX_CONCURRENT_WORKFLOWS):
         """Initialize executor.
 
         Args:


### PR DESCRIPTION
## Summary
- Reduced `DEFAULT_MAX_CONCURRENT_WORKFLOWS` from 10 to 5 in `emdx/config/constants.py:38`
- Updated `WorkflowExecutor.__init__()` in `emdx/workflows/executor.py:43` to use the constant instead of hardcoded value

The default of 10 concurrent workflows was too aggressive for typical workloads.

## Test plan
- [ ] Verify workflows run with the new default of 5 concurrent executions
- [ ] Test that explicit `-j` flag still overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)