### PR TITLE
feat: Add --worktree flag to emdx run command (Issue #5476)

### DIFF
--- a/emdx/commands/run.py
+++ b/emdx/commands/run.py
@@ -8,6 +8,7 @@ import typer
 from rich.console import Console
 
 from ..workflows.executor import workflow_executor
+from .workflows import create_worktree_for_workflow, cleanup_worktree
 
 console = Console()
 
@@ -40,6 +41,21 @@ def run(
     template: str = typer.Option(
         None, "-t", "--template",
         help="Template for discovered tasks (use {{task}})"
+    ),
+    worktree: bool = typer.Option(
+        False,
+        "--worktree", "-w",
+        help="Create isolated git worktree for execution (recommended for parallel runs)",
+    ),
+    base_branch: str = typer.Option(
+        "main",
+        "--base-branch",
+        help="Base branch for worktree (only used with --worktree)",
+    ),
+    keep_worktree: bool = typer.Option(
+        False,
+        "--keep-worktree",
+        help="Don't cleanup worktree after completion (for debugging)",
     ),
 ):
     """Run tasks in parallel with worktree isolation.
@@ -93,13 +109,34 @@ def run(
     if template:
         task_list = [template.replace("{{task}}", t) for t in task_list]
 
+    # Create worktree if requested
+    worktree_path = None
+    working_dir = None
+
+    if worktree:
+        try:
+            worktree_path, worktree_branch = create_worktree_for_workflow(base_branch)
+            working_dir = worktree_path
+            console.print(f"[cyan]Created worktree:[/cyan] {worktree_path}")
+            console.print(f"  Branch: {worktree_branch}")
+        except subprocess.CalledProcessError as e:
+            console.print(f"[red]Failed to create worktree: {e.stderr}[/red]")
+            raise typer.Exit(1)
+
     # Execute
-    asyncio.run(_execute_run(
-        tasks=task_list,
-        title=title,
-        jobs=jobs,
-        synthesize=synthesize,
-    ))
+    try:
+        asyncio.run(_execute_run(
+            tasks=task_list,
+            title=title,
+            jobs=jobs,
+            synthesize=synthesize,
+            working_dir=working_dir,
+        ))
+    finally:
+        # Cleanup worktree unless told to keep it
+        if worktree_path and not keep_worktree:
+            console.print(f"[dim]Cleaning up worktree: {worktree_path}[/dim]")
+            cleanup_worktree(worktree_path)
 
 
 def _run_discovery(command: str) -> List[str]:
@@ -133,6 +170,7 @@ async def _execute_run(
     title: Optional[str],
     jobs: Optional[int],
     synthesize: bool,
+    working_dir: Optional[str] = None,
 ):
     """Execute the run using workflow executor."""
     # Prepare variables
@@ -149,11 +187,14 @@ async def _execute_run(
 
     # Execute
     console.print(f"[cyan]Running {len(tasks)} task(s)...[/cyan]")
+    if working_dir:
+        console.print(f"  Working dir: {working_dir}")
 
     try:
         result = await workflow_executor.execute_workflow(
             workflow_name_or_id=workflow_name,
             input_variables=variables,
+            working_dir=working_dir,
         )
 
         if result.status == "completed":


### PR DESCRIPTION
## Summary
- Add `--worktree/-w` flag to `emdx run` command for isolated git worktree execution
- Add `--base-branch` option to specify the base branch for the worktree (default: main)
- Add `--keep-worktree` flag to preserve worktree after completion for debugging

This replicates the worktree isolation pattern from `emdx workflow run` to the simpler `emdx run` command, allowing parallel task execution without git conflicts.

## Test plan
- [ ] Verify `emdx run --help` shows the new flags
- [ ] Test `emdx run -w "task"` creates and cleans up worktree
- [ ] Test `emdx run -w --keep-worktree "task"` preserves worktree
- [ ] Test `emdx run -w --base-branch develop "task"` uses correct base branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)