### PR TITLE
feat: Standardize parallelism flag across CLI commands (Issue #5476)

### DIFF
--- a/emdx/commands/each.py
+++ b/emdx/commands/each.py
@@ -115,7 +115,7 @@ def create(
         help="What to do with each {{item}}"
     ),
     parallel: int = typer.Option(
-        3, "-j", "--parallel",
+        3, "-j", "--jobs", "-P", "--parallel",
         help="Max concurrent executions"
     ),
     synthesize: Optional[str] = typer.Option(
@@ -398,7 +398,7 @@ def run_command(
         help="Override discovery command"
     ),
     parallel: int = typer.Option(
-        3, "-j", "--parallel",
+        3, "-j", "--jobs", "-P", "--parallel",
         help="Max concurrent executions"
     ),
     synthesize: Optional[str] = typer.Option(
@@ -433,7 +433,7 @@ def main(
         help="Prompt for one-off execution"
     ),
     parallel: int = typer.Option(
-        3, "-j", "--parallel",
+        3, "-j", "--jobs", "-P", "--parallel",
         help="Max concurrent executions"
     ),
     synthesize: Optional[str] = typer.Option(

--- a/emdx/commands/run.py
+++ b/emdx/commands/run.py
@@ -22,7 +22,7 @@ def run(
         help="Title for this run (shows in Activity)"
     ),
     jobs: int = typer.Option(
-        None, "-j", "--jobs",
+        None, "-j", "--jobs", "-P", "--parallel",
         help="Max parallel tasks (default: auto)"
     ),
     synthesize: bool = typer.Option(

--- a/emdx/commands/workflows.py
+++ b/emdx/commands/workflows.py
@@ -272,8 +272,11 @@ def run_workflow(
     ),
     max_concurrent: Optional[int] = typer.Option(
         None,
-        "--max-concurrent",
         "-j",
+        "--jobs",
+        "-P",
+        "--parallel",
+        "--max-concurrent",
         help="Override max concurrent executions for parallel/dynamic stages",
     ),
 ):


### PR DESCRIPTION
## Summary
- Add `--parallel/-P` as an alias for `-j/--jobs/--max-concurrent` across all parallel execution commands
- `emdx run`, `emdx each`, and `emdx workflow run` now accept both `-j` and `-P/--parallel`
- Maintains backwards compatibility with existing `-j` flag

## Test plan
- [ ] Verify `emdx run -P 3 "task1" "task2"` works
- [ ] Verify `emdx run --parallel 3 "task1" "task2"` works
- [ ] Verify `emdx each create foo --from "cmd" --do "prompt" -P 5` works
- [ ] Verify `emdx workflow run task_parallel -P 2` works
- [ ] Verify existing `-j` flag still works for all commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)