### PR TITLE
feat(cli): Add `emdx agent` command for sub-agent execution (#349)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,41 @@ emdx run -d "git branch -r | grep feature" -t "Review {{task}}"
 emdx run -j 3 "task1" "task2" "task3" "task4"
 ```
 
+## 🤖 Sub-Agent Execution (`emdx agent`)
+
+Run Claude Code sub-agents with automatic EMDX tracking. The agent is instructed to save its output with the specified metadata (tags, title, group).
+
+Works the same whether called by a human or another AI agent.
+
+```bash
+# Basic usage - agent saves output with specified tags
+emdx agent "Analyze the auth module for security issues" --tags analysis,security
+
+# With title and group
+emdx agent "Review error handling in api/" -t refactor -T "API Error Review" -g 456
+
+# Verbose mode to see agent output in real-time
+emdx agent "Deep dive on caching strategy" -t analysis -v
+```
+
+**Options:**
+- `--tags, -t` - Tags to apply to output (comma-separated or multiple flags)
+- `--title, -T` - Title for the output document
+- `--group, -g` - Group ID to add output to
+- `--group-role` - Role in group (default: `exploration`)
+- `--verbose, -v` - Show agent output in real-time
+
+**How it works:**
+1. Takes your prompt and appends instructions telling the agent how to save its output
+2. The agent receives: `echo "OUTPUT" | emdx save --title "..." --tags "..." --group N`
+3. Runs Claude Code and streams output to a log file
+4. Extracts the created document ID and prints `doc_id:123` for easy parsing
+
+**Use cases:**
+- Humans kicking off analysis tasks with proper tracking
+- AI agents spawning sub-agents that need to save results to EMDX
+- Ensuring consistent metadata across human and AI-initiated work
+
 ## 🔁 Reusable Parallel Commands (`emdx each`)
 
 Create saved commands that discover items and process them in parallel. Perfect for repeatable "for each X, do Y" patterns.
@@ -223,14 +258,14 @@ emdx workflow run parallel_fix \
 emdx workflow run parallel_fix -t 5182 -t 5183 -t 5184 --worktree
 ```
 
-### When to Use `emdx run` vs `emdx each` vs `emdx workflow`
+### When to Use `emdx run` vs `emdx agent` vs `emdx each` vs `emdx workflow`
 
-| Use `emdx run` when... | Use `emdx each` when... | Use `emdx workflow` when... |
-|------------------------|-------------------------|----------------------------|
-| Quick, ad-hoc parallel tasks | Reusable discovery+action | Complex multi-stage workflows |
-| Simple task lists | "For each X, do Y" patterns | Need iterative or adversarial modes |
-| One-off execution | Save for future use | Custom stage configurations |
-| Just want tasks done fast | Same operation on many items | Need detailed run monitoring |
+| Use `emdx run` when... | Use `emdx agent` when... | Use `emdx each` when... | Use `emdx workflow` when... |
+|------------------------|--------------------------|-------------------------|----------------------------|
+| Quick parallel tasks | Single sub-agent task | Reusable discovery+action | Complex multi-stage workflows |
+| Simple task lists | Need tracked output | "For each X, do Y" patterns | Need iterative or adversarial modes |
+| One-off execution | Human or AI caller | Save for future use | Custom stage configurations |
+| Just want tasks done fast | Consistent metadata | Same operation on many items | Need detailed run monitoring |
 
 For full workflow documentation, see [docs/workflows.md](docs/workflows.md).
 

--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -951,14 +951,69 @@ emdx run -p fix-conflicts
 | `--discover` | `-d` | Shell command to discover tasks |
 | `--template` | `-t` | Template for discovered tasks (use `{{task}}`) |
 
-### When to Use `emdx run` vs `emdx each` vs `emdx workflow`
+### When to Use `emdx run` vs `emdx agent` vs `emdx each` vs `emdx workflow`
 
-| Use `emdx run` when... | Use `emdx each` when... | Use `emdx workflow` when... |
-|------------------------|-------------------------|----------------------------|
-| Quick, ad-hoc parallel tasks | Reusable discovery+action commands | Complex multi-stage workflows |
-| Simple task lists | Same operation on many items | Need iterative or adversarial modes |
-| One-off execution | Save commands for future use | Custom stage configurations |
-| Just want tasks done fast | "For each X, do Y" patterns | Need detailed run monitoring |
+| Use `emdx run` when... | Use `emdx agent` when... | Use `emdx each` when... | Use `emdx workflow` when... |
+|------------------------|--------------------------|-------------------------|----------------------------|
+| Quick parallel tasks | Single sub-agent task | Reusable discovery+action | Complex multi-stage workflows |
+| Simple task lists | Need tracked output | Same operation on many items | Need iterative or adversarial modes |
+| One-off execution | Human or AI caller | Save commands for future use | Custom stage configurations |
+| Just want tasks done fast | Consistent metadata | "For each X, do Y" patterns | Need detailed run monitoring |
+
+---
+
+## 🤖 Sub-Agent Execution (`emdx agent`)
+
+Run Claude Code sub-agents with automatic EMDX tracking. The agent is instructed to save its output with the specified metadata.
+
+Works the same whether called by a human or another AI agent.
+
+### Basic Usage
+
+```bash
+# Run an agent with tags
+emdx agent "Analyze the auth module for security issues" --tags analysis,security
+
+# With custom title and group
+emdx agent "Review error handling in api/" -t refactor -T "API Error Review" -g 456
+
+# Verbose mode to see output in real-time
+emdx agent "Deep dive on caching strategy" -t analysis -v
+```
+
+### How It Works
+
+1. Takes your prompt and appends instructions telling the agent how to save its output
+2. The agent receives: `echo "OUTPUT" | emdx save --title "..." --tags "..." --group N`
+3. Runs Claude Code and streams output to a log file
+4. Extracts the created document ID and prints `doc_id:123` for easy parsing
+
+### Options Reference
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--tags` | `-t` | Tags to apply (comma-separated or multiple flags) |
+| `--title` | `-T` | Title for the output document |
+| `--group` | `-g` | Group ID to add output to |
+| `--group-role` | | Role in group (default: `exploration`) |
+| `--verbose` | `-v` | Show agent output in real-time |
+
+### Use Cases
+
+- **Humans**: Kick off analysis tasks with proper tagging and grouping
+- **AI agents**: Spawn sub-agents that save results to EMDX with consistent metadata
+- **Workflows**: Ensure outputs from any source are tracked the same way
+
+### Parsing Output
+
+The command prints `doc_id:123` on completion for easy parsing:
+
+```bash
+# Capture the document ID
+output=$(emdx agent "Analyze X" -t analysis)
+doc_id=$(echo "$output" | grep "^doc_id:" | cut -d: -f2)
+echo "Created document: $doc_id"
+```
 
 ---
 

--- a/emdx/commands/agent.py
+++ b/emdx/commands/agent.py
@@ -1,0 +1,190 @@
+"""Run a Claude Code sub-agent with EMDX tracking.
+
+This command bridges the gap between human-initiated and AI-initiated work
+by ensuring all sub-agent outputs are properly tagged and tracked.
+
+Works the same whether called by a human or an AI agent.
+"""
+
+import subprocess
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+from rich.console import Console
+
+from ..models.executions import create_execution, update_execution_status
+from ..workflows.output_parser import extract_output_doc_id, extract_token_usage_detailed
+from ..utils.environment import ensure_claude_in_path
+from ..services.document_executor import DEFAULT_ALLOWED_TOOLS
+from .claude_execute import format_claude_output
+
+console = Console()
+
+
+def _build_output_instruction(
+    title: Optional[str],
+    tags: Optional[List[str]],
+    group_id: Optional[int],
+    group_role: str,
+) -> str:
+    """Build the output instruction with user's metadata injected."""
+    title_str = title or "Agent Output"
+
+    # Build the emdx save command with all options
+    cmd_parts = [f'emdx save --title "{title_str}"']
+
+    if tags:
+        tag_str = ",".join(tags)
+        cmd_parts.append(f'--tags "{tag_str}"')
+
+    if group_id is not None:
+        cmd_parts.append(f'--group {group_id}')
+        if group_role != "member":
+            cmd_parts.append(f'--group-role {group_role}')
+
+    save_cmd = " ".join(cmd_parts)
+
+    return f'''
+
+IMPORTANT: When you complete this task, save your final output/analysis using:
+echo "YOUR OUTPUT HERE" | {save_cmd}
+
+Report the document ID that was created.'''
+
+
+def agent(
+    prompt: str = typer.Argument(..., help="Task for the agent"),
+    tags: Optional[List[str]] = typer.Option(
+        None, "--tags", "-t",
+        help="Tags to apply to output (can be comma-separated or multiple -t flags)"
+    ),
+    title: Optional[str] = typer.Option(
+        None, "--title", "-T",
+        help="Title for the output document"
+    ),
+    group: Optional[int] = typer.Option(
+        None, "--group", "-g",
+        help="Group ID to add output to"
+    ),
+    group_role: str = typer.Option(
+        "exploration", "--group-role",
+        help="Role in group (primary, exploration, synthesis, variant, member)"
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v",
+        help="Show agent output in real-time"
+    ),
+):
+    """Run a Claude Code sub-agent with automatic EMDX tracking.
+
+    This ensures outputs are properly tagged and grouped, whether
+    called by a human or another AI agent. The agent is instructed
+    to save its output with the specified metadata.
+
+    Examples:
+        emdx agent "Analyze the auth module" --tags analysis,security
+        emdx agent "Review error handling" -t refactor -g 123
+        emdx agent "Deep dive on caching" -T "Cache Analysis" -t analysis
+    """
+    ensure_claude_in_path()
+
+    # Flatten tags (handle both comma-separated and multiple -t flags)
+    flat_tags = []
+    if tags:
+        for t in tags:
+            flat_tags.extend(t.split(','))
+
+    # Set up logging
+    log_dir = Path.home() / ".config" / "emdx" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
+    log_file = log_dir / f"agent-{timestamp}.log"
+
+    # Create execution record
+    exec_id = create_execution(
+        doc_id=None,
+        doc_title=title or f"Agent: {prompt[:50]}...",
+        log_file=str(log_file),
+        working_dir=str(Path.cwd()),
+    )
+
+    # Build full prompt with output instruction (metadata injected)
+    output_instruction = _build_output_instruction(title, flat_tags, group, group_role)
+    full_prompt = prompt + output_instruction
+
+    # Build command
+    cmd = [
+        "claude",
+        "--print", full_prompt,
+        "--allowedTools", ",".join(DEFAULT_ALLOWED_TOOLS),
+        "--output-format", "stream-json",
+        "--verbose"
+    ]
+
+    console.print(f"[cyan]Running agent task...[/cyan]")
+    if verbose:
+        console.print(f"[dim]Prompt: {prompt[:100]}{'...' if len(prompt) > 100 else ''}[/dim]")
+
+    start_time = time.time()
+
+    try:
+        # Run Claude
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            cwd=str(Path.cwd()),
+        )
+
+        # Stream output to log (and optionally console)
+        with open(log_file, 'w') as log:
+            for line in process.stdout:
+                formatted = format_claude_output(line, time.time())
+                if formatted:
+                    log.write(formatted + "\n")
+                    log.flush()
+                    if verbose:
+                        console.print(formatted)
+
+        exit_code = process.wait()
+        duration = time.time() - start_time
+
+        # Update execution status
+        status = 'completed' if exit_code == 0 else 'failed'
+        update_execution_status(exec_id, status, exit_code)
+
+        if exit_code != 0:
+            console.print(f"[red]Agent failed (exit code {exit_code})[/red]")
+            console.print(f"[dim]Log: {log_file}[/dim]")
+            raise typer.Exit(1)
+
+        # Extract output document ID from log
+        output_doc_id = extract_output_doc_id(log_file)
+
+        # Get token usage
+        usage = extract_token_usage_detailed(log_file)
+
+        if output_doc_id:
+            console.print(f"[green]✓ Agent completed[/green]")
+            console.print(f"  Output: #{output_doc_id}")
+            if flat_tags:
+                console.print(f"  Tags: {', '.join(flat_tags)}")
+            if group:
+                console.print(f"  Group: #{group} (as {group_role})")
+            console.print(f"  Duration: {duration:.1f}s")
+            console.print(f"  Tokens: {usage.get('total', 0):,}")
+
+            # Print doc ID on its own line for easy parsing by other agents
+            print(f"doc_id:{output_doc_id}")
+        else:
+            console.print(f"[yellow]Agent completed but no output document found[/yellow]")
+            console.print(f"[dim]Log: {log_file}[/dim]")
+
+    except FileNotFoundError:
+        console.print("[red]Error: claude command not found[/red]")
+        console.print("[dim]Make sure Claude Code is installed and in PATH[/dim]")
+        raise typer.Exit(1)

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -27,6 +27,7 @@ from emdx.commands.workflows import app as workflows_app
 from emdx.commands.keybindings import app as keybindings_app
 from emdx.commands.preset import app as preset_app
 from emdx.commands.run import run as run_command
+from emdx.commands.agent import agent as agent_command
 from emdx.commands.groups import app as groups_app
 from emdx.commands.ask import app as ask_app
 from emdx.commands.each import app as each_app
@@ -103,6 +104,9 @@ app.add_typer(ask_app, name="ai", help="AI-powered Q&A and semantic search")
 
 # Add the run command for quick task execution
 app.command(name="run")(run_command)
+
+# Add the agent command for sub-agent execution with EMDX tracking
+app.command(name="agent")(agent_command)
 
 # Add each command for reusable parallel commands
 app.add_typer(each_app, name="each", help="Create and run reusable parallel commands")


### PR DESCRIPTION
## Summary

- Adds `emdx agent` command that runs Claude Code sub-agents with automatic EMDX metadata tracking
- Agent is instructed to save output with specified tags, title, and group
- Works the same whether called by a human or another AI agent

## Features

- `--tags, -t` - Tags to apply to output (comma-separated or multiple flags)
- `--title, -T` - Title for the output document  
- `--group, -g` - Group ID to add output to
- `--group-role` - Role in group (default: `exploration`)
- `--verbose, -v` - Show agent output in real-time
- Prints `doc_id:123` on completion for easy parsing

## How it works

1. Takes user prompt and appends save instructions with metadata
2. Agent receives: `echo "OUTPUT" | emdx save --title "..." --tags "..." --group N`
3. Runs Claude Code and streams to log file
4. Extracts created document ID from log

## Example usage

```bash
# Human usage
emdx agent "Analyze auth module" --tags analysis,security -g 456

# AI agent spawning sub-agent
emdx agent "Review error handling" -t refactor -T "API Review" -g 456
```

## Test plan

- [x] `emdx agent --help` displays correctly
- [x] Output instruction generation works for all option combinations
- [ ] Manual test of full agent execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)