### PR TITLE
feat: Add --pattern flag to emdx run for workflow selection (Issue #5555)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,9 +144,12 @@ poetry run emdx untag 123 blocked
 
 ## 🚀 Quick Task Execution (`emdx run`)
 
-The fastest way to run parallel tasks:
+The fastest way to run parallel tasks. This is the first rung on EMDX's "execution ladder" - start here and graduate to `emdx each` or `emdx workflow` only when you need more power.
 
 ```bash
+# Run a single task
+emdx run "analyze the auth module"
+
 # Run multiple tasks in parallel
 emdx run "analyze auth" "review tests" "check docs"
 
@@ -158,7 +161,17 @@ emdx run -d "git branch -r | grep feature" -t "Review {{task}}"
 
 # Control concurrency
 emdx run -j 3 "task1" "task2" "task3" "task4"
+
+# Use a saved preset
+emdx run -p security-audit
+
+# Use workflow patterns (shortcuts with auto-settings)
+emdx run "fix X" "fix Y" --pattern fix       # Auto-enables worktree
+emdx run "analyze X" -P analyze              # Auto-enables synthesis
+emdx run --list-patterns                     # Show available patterns
 ```
+
+For the full execution ladder (run → each → workflow → pipeline), see [docs/workflows.md](docs/workflows.md#when-to-use-what).
 
 ## 🤖 Sub-Agent Execution (`emdx agent`)
 

--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -889,7 +889,17 @@ emdx find --tags "gameplan" --project "myproject"
 
 ## 🚀 Quick Task Execution
 
-The `emdx run` command provides a streamlined interface for running tasks in parallel. It's syntactic sugar for the `task_parallel` workflow.
+The `emdx run` command is the first rung on EMDX's "execution ladder" - the fastest way to run tasks.
+
+**The Execution Ladder:**
+| Level | Command | Use When |
+|-------|---------|----------|
+| 1 | `emdx run` | Quick one-off or parallel tasks |
+| 2 | `emdx each` | Reusable "for each X, do Y" patterns |
+| 3 | `emdx workflow` | Complex multi-stage workflows |
+| 4 | `emdx pipeline` | Idea refinement through stages |
+
+Start with `emdx run`. Graduate down only when you need more power.
 
 ### Basic Usage
 
@@ -940,16 +950,43 @@ emdx run -p fix-conflicts
 # Manage presets via: emdx workflow preset
 ```
 
+**Tip:** If you find yourself reusing the same discovery + template pattern repeatedly, consider graduating to `emdx each` which saves these patterns as named commands. See the [emdx each](#-reusable-parallel-commands-emdx-each) section below.
+
+### Workflow Patterns
+
+Patterns are shortcuts that select a workflow with sensible auto-settings:
+
+```bash
+# Use the fix pattern (auto-enables worktree)
+emdx run "fix auth bug" "fix api bug" --pattern fix
+
+# Use the analyze pattern (auto-enables synthesis)
+emdx run "analyze X" "analyze Y" -P analyze
+
+# List available patterns
+emdx run --list-patterns
+```
+
+| Pattern | Workflow | Auto-Settings | Description |
+|---------|----------|---------------|-------------|
+| `parallel` | task_parallel | - | Default parallel execution |
+| `fix` | parallel_fix | worktree | Code fixes with branch isolation |
+| `analyze` | parallel_analysis | synthesize | Analysis with combined output |
+
+Unknown pattern names are treated as direct workflow names, so `--pattern deep_analysis` uses the `deep_analysis` workflow.
+
 ### Options Reference
 
 | Option | Short | Description |
 |--------|-------|-------------|
 | `--title` | `-T` | Title for this run (shows in Activity) |
+| `--pattern` | `-P` | Workflow pattern: parallel, fix, analyze (or workflow name) |
 | `--jobs` | `-j` | Max parallel tasks (default: auto) |
 | `--synthesize` | `-s` | Combine outputs with synthesis stage |
 | `--preset` | `-p` | Use a saved preset |
 | `--discover` | `-d` | Shell command to discover tasks |
 | `--template` | `-t` | Template for discovered tasks (use `{{task}}`) |
+| `--list-patterns` | | Show available patterns and exit |
 
 ### When to Use `emdx run` vs `emdx agent` vs `emdx each` vs `emdx workflow`
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -2,6 +2,29 @@
 
 The EMDX workflow system provides powerful orchestration for multi-agent executions. Workflows are **execution patterns** that define *how* to process tasks, while tasks are provided at runtime.
 
+## When to Use What
+
+EMDX has multiple ways to execute tasks, forming a "complexity ladder":
+
+| Command | Use When | Example |
+|---------|----------|---------|
+| `emdx run "task"` | Single quick task | `emdx run "analyze auth module"` |
+| `emdx run "t1" "t2"` | Multiple parallel tasks | `emdx run "fix X" "fix Y" -j 3` |
+| `emdx each run <name>` | Reusable "for each X, do Y" | `emdx each run fix-conflicts` |
+| `emdx workflow run <wf>` | Complex multi-stage workflows | `emdx workflow run deep_analysis` |
+| `emdx pipeline` | Idea refinement through stages | `emdx pipeline add "idea"` |
+
+### The Execution Ladder
+
+Think of these tools as rungs on a ladder, from simplest to most powerful:
+
+1. **`emdx run`** - The fastest path. Just describe what you want done. Great for one-off tasks.
+2. **`emdx each`** - When you have a reusable pattern: "for each X from this command, do Y."
+3. **`emdx workflow`** - When you need multi-stage processing, iteration, or adversarial modes.
+4. **`emdx pipeline`** - When refining ideas through structured stages over time.
+
+Start at the top. Graduate down only when you need more power.
+
 ## Recommended Workflows
 
 These are the core dynamic workflows designed for reuse with `--task` flags:

--- a/emdx/commands/patterns.py
+++ b/emdx/commands/patterns.py
@@ -1,0 +1,58 @@
+"""Pattern configurations for emdx run command.
+
+Patterns are aliases for workflow configurations that enable quick access
+to different workflow modes with sensible defaults.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass
+class PatternConfig:
+    """Configuration for a workflow pattern."""
+
+    workflow_name: str
+    description: str
+    auto_worktree: bool = False
+    auto_synthesize: bool = False
+
+
+# Pattern aliases mapping pattern names to their configurations
+PATTERN_ALIASES: Dict[str, PatternConfig] = {
+    "parallel": PatternConfig(
+        workflow_name="task_parallel",
+        description="Run tasks in parallel (default)",
+    ),
+    "fix": PatternConfig(
+        workflow_name="parallel_fix",
+        description="Run fix tasks with worktree isolation",
+        auto_worktree=True,
+    ),
+    "analyze": PatternConfig(
+        workflow_name="parallel_analysis",
+        description="Run analysis tasks with synthesis",
+        auto_synthesize=True,
+    ),
+}
+
+
+def get_pattern(name: str) -> Optional[PatternConfig]:
+    """Get a pattern configuration by name.
+
+    Args:
+        name: Pattern name (case-insensitive)
+
+    Returns:
+        PatternConfig if found, None otherwise
+    """
+    return PATTERN_ALIASES.get(name.lower())
+
+
+def list_patterns() -> Dict[str, PatternConfig]:
+    """Get all available pattern configurations.
+
+    Returns:
+        Dictionary of pattern name to PatternConfig
+    """
+    return PATTERN_ALIASES.copy()


### PR DESCRIPTION
## Summary
- Add `--pattern` / `-P` flag to `emdx run` that allows users to choose different workflow patterns
- Add `--list-patterns` flag to show available patterns
- Create `emdx/commands/patterns.py` with `PatternConfig` dataclass and `PATTERN_ALIASES`
- **Add "When to Use What" execution ladder section to docs/workflows.md**
- **Update CLAUDE.md with execution ladder context and pattern examples**
- **Add workflow patterns documentation to docs/cli-api.md**

## The Execution Ladder

The documentation now presents EMDX's execution tools as a "complexity ladder":

| Level | Command | Use When |
|-------|---------|----------|
| 1 | `emdx run` | Quick one-off or parallel tasks |
| 2 | `emdx each` | Reusable "for each X, do Y" patterns |
| 3 | `emdx workflow` | Complex multi-stage workflows |
| 4 | `emdx pipeline` | Idea refinement through stages |

Users are encouraged to start at the top and only "graduate down" when they need more power.

## Workflow Patterns

| Pattern | Workflow | Auto-Settings | Description |
|---------|----------|---------------|-------------|
| `parallel` | task_parallel | - | Default parallel execution |
| `fix` | parallel_fix | worktree | Code fixes with branch isolation |
| `analyze` | parallel_analysis | synthesize | Analysis with combined output |

Unknown pattern names are treated as direct workflow names, so `--pattern deep_analysis` uses the `deep_analysis` workflow.

## Examples

```bash
# These are equivalent (uses default parallel pattern):
emdx run "task1" "task2"
emdx run "task1" "task2" --pattern parallel

# Use fix pattern (auto-worktree enabled):
emdx run "fix auth" "fix api" --pattern fix

# Use analyze pattern (auto-synthesize enabled):
emdx run "analyze X" "analyze Y" -P analyze

# List available patterns:
emdx run --list-patterns

# Use a workflow directly by name:
emdx run "task" --pattern some_custom_workflow
```

## Test plan
- [x] `emdx run --help` shows new `--pattern` and `--list-patterns` flags
- [x] `emdx run --list-patterns` displays available patterns in a table
- [x] Pattern auto-settings apply correctly (worktree for fix, synthesize for analyze)
- [x] Unknown pattern names fall through to workflow names
- [x] docs/workflows.md has "When to Use What" section at the top
- [x] CLAUDE.md mentions the execution ladder and pattern examples
- [x] docs/cli-api.md has the patterns documentation and updated options table

🤖 Generated with [Claude Code](https://claude.com/claude-code)