### PR TITLE
fix(test): Update max_concurrent test to expect 5 (#339)

### DIFF
--- a/tests/test_workflow_executor.py
+++ b/tests/test_workflow_executor.py
@@ -27,9 +27,9 @@ class TestWorkflowExecutorInit:
     """Test WorkflowExecutor initialization."""
 
     def test_default_max_concurrent(self):
-        """Default max_concurrent is 10."""
+        """Default max_concurrent is 5."""
         executor = WorkflowExecutor()
-        assert executor.max_concurrent == 10
+        assert executor.max_concurrent == 5
 
     def test_custom_max_concurrent(self):
         """Custom max_concurrent is respected."""


### PR DESCRIPTION
## Summary
- Fix failing test `test_default_max_concurrent` which expected 10 but got 5
- The default was changed from 10 to 5 in PR #339 but the test wasn't updated

## Test plan
- [x] Test now passes with updated expectation

🤖 Generated with [Claude Code](https://claude.com/claude-code)