### PR TITLE
docs: Clean up documentation after execution systems unification (Issue #5555)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ emdx run -j 3 "task1" "task2" "task3" "task4"
 emdx run --worktree "fix X" "fix Y"
 ```
 
-For the full execution ladder (run → each → workflow → pipeline), see [docs/workflows.md](docs/workflows.md#when-to-use-what).
+For the full execution ladder (run → each → workflow → cascade), see [docs/workflows.md](docs/workflows.md#when-to-use-what).
 
 ## 🤖 Sub-Agent Execution (`emdx agent`)
 

--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -897,7 +897,7 @@ The `emdx run` command is the first rung on EMDX's "execution ladder" - the fast
 | 1 | `emdx run` | Quick one-off or parallel tasks |
 | 2 | `emdx each` | Reusable "for each X, do Y" patterns |
 | 3 | `emdx workflow` | Complex multi-stage workflows |
-| 4 | `emdx pipeline` | Idea refinement through stages |
+| 4 | `emdx cascade` | Ideas → code through stages |
 
 Start with `emdx run`. Graduate down only when you need more power.
 
@@ -929,25 +929,13 @@ Discover tasks at runtime using shell commands:
 
 ```bash
 # Discover from git branches
-emdx run -d "git branch -r | grep feature" -t "Review branch {{task}}"
+emdx run -d "git branch -r | grep feature" -t "Review branch {{item}}"
 
 # Discover from PR list
-emdx run -d "gh pr list --json number -q '.[].number'" -t "Fix PR #{{task}}"
+emdx run -d "gh pr list --json number -q '.[].number'" -t "Fix PR #{{item}}"
 
 # Discover from file patterns
-emdx run -d "fd -e py -d 1 src/" -t "Analyze {{task}}"
-```
-
-### Presets
-
-Save common configurations for reuse:
-
-```bash
-# Use a preset
-emdx run -p fix-conflicts
-
-# Presets can include discovery commands, templates, and synthesis settings
-# Manage presets via: emdx workflow preset
+emdx run -d "fd -e py -d 1 src/" -t "Analyze {{item}}"
 ```
 
 **Tip:** If you find yourself reusing the same discovery + template pattern repeatedly, consider graduating to `emdx each` which saves these patterns as named commands. See the [emdx each](#-reusable-parallel-commands-emdx-each) section below.
@@ -1044,7 +1032,7 @@ Ever find yourself running the same parallel discovery task repeatedly?
 
 ```bash
 # Tedious to retype every time
-emdx run -d "gh pr list --json headRefName,mergeStateStatus | jq -r '.[] | select(.mergeStateStatus==\"DIRTY\") | .headRefName'" -t "Merge main into {{task}}, resolve conflicts"
+emdx run -d "gh pr list --json headRefName,mergeStateStatus | jq -r '.[] | select(.mergeStateStatus==\"DIRTY\") | .headRefName'" -t "Merge main into {{item}}, resolve conflicts"
 ```
 
 Save it once, run it forever:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -84,7 +84,7 @@ EMDX offers three ways to run parallel tasks. Use this flowchart to pick the rig
 │                 (Save discovery + action for reuse)         │
 │                                                             │
 │  NO (Complex/multi-stage) → Use `emdx workflow run`         │
-│     (Iterative, adversarial, presets, stage chaining)       │
+│     (Iterative, adversarial, multi-stage orchestration)     │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -93,14 +93,13 @@ EMDX offers three ways to run parallel tasks. Use this flowchart to pick the rig
 | Scenario | Tool | Example |
 |----------|------|---------|
 | Run 3 analysis tasks right now | `emdx run` | `emdx run "analyze auth" "review tests" "check docs"` |
-| Process all Python files once | `emdx run` | `emdx run -d "fd -e py" -t "Review {{task}}"` |
+| Process all Python files once | `emdx run` | `emdx run -d "fd -e py" -t "Review {{item}}"` |
 | Repeatedly fix merge conflicts | `emdx each` | `emdx each create fix-conflicts --from "..." --do "..."` |
 | For-each pattern you'll reuse | `emdx each` | `emdx each run fix-conflicts` |
 | Multi-perspective code review | `emdx workflow` | `emdx workflow run parallel_analysis -t "review X"` |
 | Progressive refinement (draft→polish) | `emdx workflow` | `emdx workflow run iterative_refine --doc 123` |
 | Debate-style analysis | `emdx workflow` | `emdx workflow run adversarial_review -t "..." ` |
 | Need synthesis of outputs | Both | `emdx run --synthesize` or workflow with synthesis_prompt |
-| Using presets/saved configs | `emdx workflow` | `emdx workflow run X --preset security_audit` |
 | Worktree isolation needed | Both | `emdx workflow run X --worktree` or `emdx each --worktree` |
 
 ### Detailed Comparison
@@ -112,7 +111,7 @@ EMDX offers three ways to run parallel tasks. Use this flowchart to pick the rig
 | **Persistence** | None (one-shot) | Commands saved to DB | Workflows defined in DB |
 | **Execution Modes** | Parallel only | Parallel only | Single, Parallel, Iterative, Adversarial, Dynamic |
 | **Synthesis** | `--synthesize` flag | `--synthesize` flag | `synthesis_prompt` in config |
-| **Variables/Presets** | None | None | Full template system + presets |
+| **Variables** | None | None | Full template system |
 | **Stage Chaining** | No | No | Yes (multi-stage pipelines) |
 | **Worktree Isolation** | Auto when needed | `--worktree` flag | `--worktree` flag |
 | **Best For** | Ad-hoc tasks | Repeated patterns | Production workflows |
@@ -128,7 +127,6 @@ EMDX offers three ways to run parallel tasks. Use this flowchart to pick the rig
 - You need iterative refinement (draft → improve → polish)
 - You want adversarial review (advocate → critic → synthesis)
 - You're chaining multiple stages together
-- You need presets for different configurations
 - You want detailed run tracking in the Activity view
 
 ## Core Concept: Execution Patterns vs Runtime Tasks
@@ -287,14 +285,8 @@ emdx workflow run task_parallel -t "Analyze auth" -t 5185
 # Control concurrency
 emdx workflow run task_parallel -t "task1" -t "task2" -t "task3" -j 2
 
-# Use a preset
-emdx workflow run parallel_analysis --preset security_audit
-
 # Override variables
 emdx workflow run my_workflow --var topic=Security --var depth=deep
-
-# Save this run's config as a preset
-emdx workflow run parallel_analysis -t "task" --save-as my_preset
 
 # Run in isolated worktree
 emdx workflow run my_workflow --worktree --base-branch main
@@ -319,39 +311,6 @@ emdx workflow status <run_id>
 emdx workflow status 42
 ```
 
-### Manage Presets
-```bash
-# List all presets
-emdx workflow presets
-
-# List presets for a specific workflow
-emdx workflow presets parallel_analysis
-
-# Create a preset
-emdx workflow preset create parallel_analysis security_audit \
-  --var topic=Security \
-  --var depth=comprehensive \
-  --desc "Thorough security review"
-
-# Show preset details
-emdx workflow preset show parallel_analysis security_audit
-
-# Update preset variables
-emdx workflow preset update parallel_analysis security_audit --var depth=quick
-
-# Create preset from a successful run
-emdx workflow preset from-run parallel_analysis good_config --run 223
-
-# Delete preset
-emdx workflow preset delete parallel_analysis old_preset
-```
-
-### List Iteration Strategies
-```bash
-emdx workflow strategies
-emdx workflow strategies --category refinement
-```
-
 ## Template System
 
 Workflows use `{{variable}}` syntax for dynamic content.
@@ -368,7 +327,7 @@ Workflows use `{{variable}}` syntax for dynamic content.
 ### Task Variables (from --task flag)
 | Variable | Description |
 |----------|-------------|
-| `{{task}}` | Task content (string or loaded document content) |
+| `{{item}}` | Item content (string or loaded document content) |
 | `{{task_title}}` | Document title (if task was a doc ID) |
 | `{{task_id}}` | Document ID (if task was a doc ID) |
 
@@ -451,7 +410,6 @@ stages:
     agent_id: int             # Optional: specific agent to use
     prompt: string            # Prompt template for this stage
     prompts: [string]         # Per-run prompts (for iterative/parallel)
-    iteration_strategy: string # Named strategy for iterative mode
     synthesis_prompt: string  # Prompt for synthesizing parallel/dynamic outputs
     input: string             # Template reference like "{{prev_stage.output}}"
     timeout_seconds: int      # Stage timeout (default: 3600)
@@ -494,44 +452,6 @@ The `WorktreePool` manages worktree lifecycle:
 - Cleans up on completion (unless `--keep-worktree`)
 - Resets worktrees between uses
 
-## Presets
-
-Presets save commonly-used variable configurations for reuse.
-
-### Preset Benefits
-- **Consistency**: Same configuration across runs
-- **Speed**: No need to type long --var lists
-- **Sharing**: Team can use standardized configurations
-- **History**: Track which presets work well
-
-### Preset Workflow
-```bash
-# 1. Run with variables
-emdx workflow run parallel_analysis \
-  -t "Auth review" \
-  --var depth=comprehensive \
-  --var focus=security
-
-# 2. If successful, save as preset
-emdx workflow run parallel_analysis \
-  -t "Auth review" \
-  --var depth=comprehensive \
-  --var focus=security \
-  --save-as security_deep
-
-# 3. Reuse the preset
-emdx workflow run parallel_analysis -t "New task" --preset security_deep
-
-# Or create from a successful run
-emdx workflow preset from-run parallel_analysis security_deep --run 42
-```
-
-### Variable Precedence
-When running a workflow, variables are merged in this order (later wins):
-1. Workflow default variables
-2. Preset variables (--preset)
-3. Runtime variables (--var)
-
 ## Practical Examples
 
 ### Example 1: Multi-Perspective Code Review
@@ -570,21 +490,6 @@ echo "Analyze API security" | emdx save --title "API Task"
 emdx workflow run task_parallel -t 5182 -t 5183
 ```
 
-### Example 5: Using Presets for Consistency
-```bash
-# Create preset for security audits
-emdx workflow preset create parallel_analysis security_audit \
-  --var focus=security \
-  --var depth=comprehensive \
-  --var output_format=detailed
-
-# Use preset for all security reviews
-emdx workflow run parallel_analysis --preset security_audit \
-  -t "Review user input handling" \
-  -t "Review database queries" \
-  -t "Review file operations"
-```
-
 ## Architecture Notes
 
 ### Execution Flow
@@ -604,10 +509,8 @@ Parallel and dynamic executions create document groups:
 
 ### Database Tables
 - `workflows` - Workflow definitions
-- `workflow_presets` - Saved variable configurations
 - `workflow_runs` - Execution history
 - `workflow_stage_runs` - Stage-level tracking
 - `workflow_individual_runs` - Individual run tracking
-- `iteration_strategies` - Predefined prompt sequences
 
 For schema details, see [Database Design](database-design.md).


### PR DESCRIPTION
## Summary

Final documentation cleanup after the execution systems unification work.

### Wave 1: Terminology fixes
- Replace `{{task}}` with `{{item}}` in all examples (6 occurrences)
- Replace `emdx pipeline` with `emdx cascade` (2 occurrences)

### Wave 2: Remove preset documentation
- Presets were removed in cruft cleanup (PR #355) but docs still referenced them
- Removed ~25 references from docs/workflows.md

### Wave 3: Remove iteration strategy docs
- Removed `iteration_strategy` from schema
- Removed from database tables list

**Result**: 119 lines of stale documentation removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)