### PR TITLE
feat: Add emdx prime and status commands for native Claude usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,45 @@ poetry run emdx tags  # List all tags
 poetry run emdx legend  # View emoji legend and aliases
 ```
 
-## 🎯 Claude Code Integration
+## 🎯 Claude Code Integration - MANDATORY INSTRUCTIONS
 
-This section tells Claude when and how to use EMDX tools. The goal: Claude should automatically leverage EMDX to track work, spawn sub-agents with proper metadata, and choose the right execution method for each task.
+**⚠️ YOU MUST FOLLOW THESE RULES WHEN WORKING IN THIS CODEBASE:**
+
+### Session Start Protocol
+At the start of every session, run `emdx prime` to get current work context. This shows:
+- Ready tasks you can work on immediately
+- In-progress work that may need attention
+- Recent documents for context
+
+```bash
+# Run this first to understand the current state
+emdx prime
+
+# Or for a quick overview
+emdx status
+```
+
+### Mandatory Behaviors
+
+1. **ALWAYS check ready tasks before starting work:**
+   ```bash
+   emdx task ready
+   ```
+
+2. **ALWAYS save significant outputs to emdx:**
+   ```bash
+   echo "analysis results" | emdx save --title "Title" --tags "analysis,active"
+   ```
+
+3. **ALWAYS create tasks for discovered work:**
+   ```bash
+   emdx task create "Title" --description "Details"
+   ```
+
+4. **NEVER end session without:**
+   - Updating task status (complete/in-progress)
+   - Creating tasks for remaining work
+   - Running `emdx prime` to verify state
 
 ### Decision Tree: Which EMDX Command to Use
 

--- a/emdx/commands/prime.py
+++ b/emdx/commands/prime.py
@@ -1,0 +1,261 @@
+"""
+Prime command - Output context for Claude session injection.
+
+This is the key command for making Claude use emdx natively.
+It outputs priming context that should be injected at session start.
+"""
+
+import typer
+from datetime import datetime
+from typing import Optional
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+
+from ..database import db
+from ..utils.git import get_git_project
+
+console = Console()
+
+
+def prime(
+    format: str = typer.Option(
+        "text",
+        "--format", "-f",
+        help="Output format: text (for injection), markdown, or json"
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose", "-v",
+        help="Include additional context (recent docs, cascade status)"
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet", "-q",
+        help="Minimal output - just ready tasks"
+    ),
+):
+    """
+    Output priming context for Claude Code session injection.
+
+    This command outputs context that helps Claude understand the current
+    state of work and use emdx natively. Use it in session hooks or
+    pipe it to Claude's context.
+
+    Examples:
+        # Basic priming
+        emdx prime
+
+        # With full context
+        emdx prime --verbose
+
+        # Minimal (just ready tasks)
+        emdx prime --quiet
+
+        # For session hooks
+        emdx prime >> /tmp/claude-context.md
+    """
+    project = get_git_project()
+
+    if format == "json":
+        _output_json(project, verbose, quiet)
+    else:
+        _output_text(project, verbose, quiet, format == "markdown")
+
+
+def _output_text(project: Optional[str], verbose: bool, quiet: bool, markdown: bool):
+    """Output priming context as text."""
+
+    lines = []
+
+    # Header with imperative instructions
+    if not quiet:
+        lines.append("=" * 60)
+        lines.append("EMDX WORK CONTEXT - READ AND FOLLOW THESE INSTRUCTIONS")
+        lines.append("=" * 60)
+        lines.append("")
+        lines.append("YOU MUST follow these rules when working in this codebase:")
+        lines.append("")
+        lines.append("1. ALWAYS save significant outputs to emdx:")
+        lines.append("   echo \"output\" | emdx save --title \"Title\" --tags \"tag1,tag2\"")
+        lines.append("")
+        lines.append("2. ALWAYS create tasks for discovered work:")
+        lines.append("   emdx task create \"Title\" --description \"Details\"")
+        lines.append("")
+        lines.append("3. ALWAYS check ready tasks before starting work:")
+        lines.append("   emdx task ready")
+        lines.append("")
+        lines.append("4. NEVER end session without updating task status")
+        lines.append("")
+        lines.append("-" * 60)
+        lines.append("")
+
+    # Project context
+    if project:
+        lines.append(f"Project: {project}")
+        lines.append("")
+
+    # Ready tasks (the most important section)
+    ready_tasks = _get_ready_tasks()
+    if ready_tasks:
+        lines.append("READY TASKS (work you can start immediately):")
+        lines.append("")
+        for task in ready_tasks[:10]:  # Limit to top 10
+            priority_label = ["P0-CRITICAL", "P1-HIGH", "P2-MEDIUM", "P3-LOW", "P4-BACKLOG"][min(task['priority'], 4)]
+            lines.append(f"  #{task['id']} [{priority_label}] {task['title']}")
+            if task.get('description') and verbose:
+                desc = task['description'][:100] + "..." if len(task['description']) > 100 else task['description']
+                lines.append(f"      {desc}")
+        lines.append("")
+        lines.append(f"Run 'emdx task show <id>' for details, 'emdx task run <id>' to start work.")
+        lines.append("")
+    else:
+        lines.append("No ready tasks. Create new tasks with 'emdx task create'.")
+        lines.append("")
+
+    # In-progress tasks
+    in_progress = _get_in_progress_tasks()
+    if in_progress:
+        lines.append("IN-PROGRESS TASKS (work already started):")
+        lines.append("")
+        for task in in_progress[:5]:
+            lines.append(f"  #{task['id']} {task['title']}")
+        lines.append("")
+
+    # Verbose additions
+    if verbose and not quiet:
+        # Recent documents
+        recent = _get_recent_docs()
+        if recent:
+            lines.append("RECENT CONTEXT (documents to reference):")
+            lines.append("")
+            for doc in recent[:5]:
+                lines.append(f"  #{doc['id']} {doc['title']}")
+            lines.append("")
+
+        # Cascade status
+        cascade_status = _get_cascade_status()
+        if any(cascade_status.values()):
+            lines.append("CASCADE QUEUE:")
+            lines.append("")
+            for stage, count in cascade_status.items():
+                if count > 0:
+                    lines.append(f"  {stage}: {count} item(s)")
+            lines.append("")
+
+    # Footer reminder
+    if not quiet:
+        lines.append("-" * 60)
+        lines.append("Remember: Track your work. Save outputs. Update tasks.")
+        lines.append("=" * 60)
+
+    # Output
+    print("\n".join(lines))
+
+
+def _output_json(project: Optional[str], verbose: bool, quiet: bool):
+    """Output priming context as JSON."""
+    import json
+
+    data = {
+        "project": project,
+        "timestamp": datetime.now().isoformat(),
+        "ready_tasks": _get_ready_tasks(),
+        "in_progress_tasks": _get_in_progress_tasks(),
+    }
+
+    if verbose:
+        data["recent_docs"] = _get_recent_docs()
+        data["cascade_status"] = _get_cascade_status()
+
+    print(json.dumps(data, indent=2, default=str))
+
+
+def _get_ready_tasks() -> list:
+    """Get tasks that are ready to work on (open + no blockers)."""
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("""
+            SELECT t.id, t.title, t.description, t.priority, t.status
+            FROM tasks t
+            WHERE t.status = 'open'
+            AND NOT EXISTS (
+                SELECT 1 FROM task_deps td
+                JOIN tasks blocker ON td.depends_on = blocker.id
+                WHERE td.task_id = t.id AND blocker.status != 'completed'
+            )
+            ORDER BY t.priority ASC, t.created_at ASC
+            LIMIT 20
+        """)
+        rows = cursor.fetchall()
+        return [
+            {"id": r[0], "title": r[1], "description": r[2], "priority": r[3], "status": r[4]}
+            for r in rows
+        ]
+
+
+def _get_in_progress_tasks() -> list:
+    """Get tasks currently in progress."""
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("""
+            SELECT id, title, description, priority
+            FROM tasks
+            WHERE status = 'in_progress'
+            ORDER BY updated_at DESC
+            LIMIT 10
+        """)
+        rows = cursor.fetchall()
+        return [
+            {"id": r[0], "title": r[1], "description": r[2], "priority": r[3]}
+            for r in rows
+        ]
+
+
+def _get_recent_docs() -> list:
+    """Get recently accessed documents."""
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("""
+            SELECT id, title, project
+            FROM documents
+            WHERE is_deleted = 0
+            ORDER BY last_accessed_at DESC
+            LIMIT 10
+        """)
+        rows = cursor.fetchall()
+        return [
+            {"id": r[0], "title": r[1], "project": r[2]}
+            for r in rows
+        ]
+
+
+def _get_cascade_status() -> dict:
+    """Get cascade queue status by stage."""
+    stages = ["idea", "prompt", "analyzed", "planned", "done"]
+    status = {stage: 0 for stage in stages}
+
+    try:
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT cascade_stage, COUNT(*)
+                FROM documents
+                WHERE cascade_stage IS NOT NULL AND cascade_stage != ''
+                AND is_deleted = 0
+                GROUP BY cascade_stage
+            """)
+            for stage, count in cursor.fetchall():
+                if stage in status:
+                    status[stage] = count
+    except Exception:
+        # cascade_stage column may not exist in older databases
+        pass
+
+    return status
+
+
+# Create typer app for the command
+app = typer.Typer()
+app.command()(prime)

--- a/emdx/commands/status.py
+++ b/emdx/commands/status.py
@@ -1,0 +1,212 @@
+"""
+Status command - Show consolidated project status.
+
+Provides a quick overview of:
+- Ready tasks
+- In-progress work
+- Recent activity
+- Cascade queue
+"""
+
+import typer
+from datetime import datetime, timedelta
+from typing import Optional
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from ..database import db
+from ..utils.git import get_git_project
+
+console = Console()
+
+
+def status(
+    verbose: bool = typer.Option(
+        False,
+        "--verbose", "-v",
+        help="Show additional details"
+    ),
+):
+    """
+    Show consolidated project status.
+
+    Displays ready tasks, in-progress work, recent activity,
+    and cascade queue status in a single view.
+
+    Examples:
+        emdx status
+        emdx status --verbose
+    """
+    project = get_git_project()
+
+    console.print()
+    console.print(Panel(
+        f"[bold cyan]📊 EMDX Status[/bold cyan]" +
+        (f" - [dim]{project}[/dim]" if project else ""),
+        expand=False
+    ))
+    console.print()
+
+    # Ready tasks
+    _show_ready_tasks(verbose)
+
+    # In-progress tasks
+    _show_in_progress_tasks()
+
+    # Recent activity
+    _show_recent_activity(verbose)
+
+    # Cascade status
+    _show_cascade_status()
+
+    # Quick tips
+    console.print()
+    console.print("[dim]Quick commands:[/dim]")
+    console.print("  [cyan]emdx task ready[/cyan]      - Full ready task list")
+    console.print("  [cyan]emdx task run <id>[/cyan]   - Start working on a task")
+    console.print("  [cyan]emdx prime[/cyan]           - Output context for Claude")
+    console.print()
+
+
+def _show_ready_tasks(verbose: bool):
+    """Show ready tasks."""
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("""
+            SELECT t.id, t.title, t.priority
+            FROM tasks t
+            WHERE t.status = 'open'
+            AND NOT EXISTS (
+                SELECT 1 FROM task_deps td
+                JOIN tasks blocker ON td.depends_on = blocker.id
+                WHERE td.task_id = t.id AND blocker.status != 'completed'
+            )
+            ORDER BY t.priority ASC, t.created_at ASC
+            LIMIT 7
+        """)
+        tasks = cursor.fetchall()
+
+        # Count total
+        cursor.execute("""
+            SELECT COUNT(*)
+            FROM tasks t
+            WHERE t.status = 'open'
+            AND NOT EXISTS (
+                SELECT 1 FROM task_deps td
+                JOIN tasks blocker ON td.depends_on = blocker.id
+                WHERE td.task_id = t.id AND blocker.status != 'completed'
+            )
+        """)
+        total = cursor.fetchone()[0]
+
+    if tasks:
+        console.print(f"[bold green]Ready Tasks[/bold green] ({total} total):")
+        for task_id, title, priority in tasks:
+            priority_colors = ["red", "yellow", "blue", "dim", "dim"]
+            priority_labels = ["P0", "P1", "P2", "P3", "P4"]
+            p_idx = min(priority, 4)
+            console.print(f"  [cyan]#{task_id}[/cyan] [{priority_colors[p_idx]}]{priority_labels[p_idx]}[/{priority_colors[p_idx]}] {title[:60]}")
+        if total > 7:
+            console.print(f"  [dim]... and {total - 7} more[/dim]")
+        console.print()
+    else:
+        console.print("[yellow]No ready tasks.[/yellow] Create with [cyan]emdx task create[/cyan]")
+        console.print()
+
+
+def _show_in_progress_tasks():
+    """Show in-progress tasks."""
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("""
+            SELECT id, title, updated_at
+            FROM tasks
+            WHERE status = 'in_progress'
+            ORDER BY updated_at DESC
+            LIMIT 5
+        """)
+        tasks = cursor.fetchall()
+
+    if tasks:
+        console.print("[bold yellow]In Progress:[/bold yellow]")
+        for task_id, title, updated_at in tasks:
+            console.print(f"  [cyan]#{task_id}[/cyan] {title[:60]}")
+        console.print()
+
+
+def _show_recent_activity(verbose: bool):
+    """Show recent document activity."""
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+
+        # Recent documents
+        cursor.execute("""
+            SELECT id, title, created_at
+            FROM documents
+            WHERE is_deleted = 0
+            ORDER BY created_at DESC
+            LIMIT 5
+        """)
+        recent = cursor.fetchall()
+
+    if recent and verbose:
+        console.print("[bold blue]Recent Activity:[/bold blue]")
+        for doc_id, title, created_at in recent:
+            # Format time relative
+            if created_at:
+                try:
+                    dt = datetime.fromisoformat(created_at.replace('Z', '+00:00'))
+                    age = datetime.now() - dt.replace(tzinfo=None)
+                    if age < timedelta(hours=1):
+                        time_str = f"{int(age.seconds / 60)}m ago"
+                    elif age < timedelta(days=1):
+                        time_str = f"{int(age.seconds / 3600)}h ago"
+                    else:
+                        time_str = f"{age.days}d ago"
+                except:
+                    time_str = ""
+            else:
+                time_str = ""
+
+            title_short = title[:50] + "..." if len(title) > 50 else title
+            console.print(f"  [cyan]#{doc_id}[/cyan] {title_short} [dim]{time_str}[/dim]")
+        console.print()
+
+
+def _show_cascade_status():
+    """Show cascade queue status."""
+    stages = ["idea", "prompt", "analyzed", "planned"]
+
+    try:
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT cascade_stage, COUNT(*)
+                FROM documents
+                WHERE cascade_stage IS NOT NULL AND cascade_stage != '' AND cascade_stage != 'done'
+                AND is_deleted = 0
+                GROUP BY cascade_stage
+            """)
+            counts = dict(cursor.fetchall())
+
+        total = sum(counts.values())
+        if total > 0:
+            console.print("[bold magenta]Cascade Queue:[/bold magenta]")
+            parts = []
+            for stage in stages:
+                if counts.get(stage, 0) > 0:
+                    parts.append(f"{stage}: {counts[stage]}")
+            console.print("  " + " → ".join(parts))
+            console.print("  [dim]Run [cyan]emdx cascade process <stage>[/cyan] to advance[/dim]")
+            console.print()
+    except Exception:
+        # cascade_stage column may not exist in older databases
+        pass
+
+
+# Create typer app for the command
+app = typer.Typer()
+app.command()(status)

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -31,6 +31,8 @@ from emdx.commands.groups import app as groups_app
 from emdx.commands.ask import app as ask_app
 from emdx.commands.each import app as each_app
 from emdx.commands.cascade import app as cascade_app
+from emdx.commands.prime import prime as prime_command
+from emdx.commands.status import status as status_command
 from emdx.ui.gui import gui
 from emdx.utils.output import console
 
@@ -110,6 +112,12 @@ app.add_typer(each_app, name="each", help="Create and run reusable parallel comm
 
 # Add cascade command for autonomous document transformation
 app.add_typer(cascade_app, name="cascade", help="Cascade ideas through stages to working code")
+
+# Add the prime command for Claude session priming
+app.command(name="prime")(prime_command)
+
+# Add the status command for consolidated project overview
+app.command(name="status")(status_command)
 
 # Add the gui command
 app.command()(gui)


### PR DESCRIPTION
## Summary
- Add `emdx prime` command for Claude session priming with imperative instructions
- Add `emdx status` command for consolidated project overview
- Update CLAUDE.md with mandatory behaviors for native emdx usage

## What This Implements

This PR implements the "agent priming" pattern from Beads/Gas Town to make Claude automatically track work without being told.

### New Commands

**`emdx prime`** - Session priming for Claude
```bash
# Basic priming
emdx prime

# Full context
emdx prime --verbose

# Just ready tasks
emdx prime --quiet

# JSON output for automation
emdx prime --format json
```

**`emdx status`** - Quick project overview
```bash
emdx status
emdx status --verbose
```

### CLAUDE.md Updates
- Added "MANDATORY INSTRUCTIONS" section
- Session start protocol (run `emdx prime` first)
- Four imperative behaviors for tracking work

## Test plan
- [x] `emdx prime` outputs work context with ready tasks
- [x] `emdx prime --quiet` shows minimal output
- [x] `emdx prime --format json` outputs valid JSON
- [x] `emdx status` shows consolidated view
- [x] Commands handle missing cascade_stage column gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)