### PR TITLE
feat(ui): Add consistent navigation bar across all screens

### DIFF
--- a/emdx/ui/activity_browser.py
+++ b/emdx/ui/activity_browser.py
@@ -19,8 +19,9 @@ class ActivityBrowser(Widget):
     BINDINGS = [
         ("1", "switch_activity", "Activity"),
         ("2", "switch_cascade", "Cascade"),
-        ("3", "switch_documents", "Documents"),
-        ("4", "switch_search", "Search"),
+        ("3", "switch_search", "Search"),
+        ("4", "switch_github", "GitHub"),
+        ("5", "switch_documents", "Documents"),
         ("?", "show_help", "Help"),
     ]
 
@@ -49,7 +50,7 @@ class ActivityBrowser(Widget):
         self.activity_view = ActivityView(id="activity-view")
         yield self.activity_view
         yield Static(
-            "[bold]1[/bold] Activity │ [dim]2[/dim] Cascade │ [dim]3[/dim] Documents │ [dim]4[/dim] Search │ "
+            "[bold]1[/bold] Activity │ [dim]2[/dim] Cascade │ [dim]3[/dim] Search │ [dim]4[/dim] GitHub │ [dim]5[/dim] Docs │ "
             "[dim]j/k[/dim] nav │ [dim]Enter[/dim] expand │ [dim]?[/dim] help",
             id="help-bar",
         )
@@ -88,6 +89,11 @@ class ActivityBrowser(Widget):
         """Switch to search screen."""
         if hasattr(self.app, "switch_browser"):
             await self.app.switch_browser("search")
+
+    async def action_switch_github(self) -> None:
+        """Switch to GitHub browser."""
+        if hasattr(self.app, "switch_browser"):
+            await self.app.switch_browser("github")
 
     def action_show_help(self) -> None:
         """Show help."""

--- a/emdx/ui/browser_container.py
+++ b/emdx/ui/browser_container.py
@@ -367,7 +367,7 @@ class BrowserContainer(App):
             event.stop()
             return
 
-        # Global number keys for screen switching (1=Activity, 2=Cascade, 3=Documents, 4=Search, 5=GitHub)
+        # Global number keys for screen switching (1=Activity, 2=Cascade, 3=Search, 4=GitHub, 5=Documents)
         if key == "1":
             await self.switch_browser("activity")
             event.stop()
@@ -377,15 +377,15 @@ class BrowserContainer(App):
             event.stop()
             return
         elif key == "3":
-            await self.switch_browser("document")
-            event.stop()
-            return
-        elif key == "4":
             await self.switch_browser("search")
             event.stop()
             return
-        elif key == "5":
+        elif key == "4":
             await self.switch_browser("github")
+            event.stop()
+            return
+        elif key == "5":
+            await self.switch_browser("document")
             event.stop()
             return
 

--- a/emdx/ui/cascade_browser.py
+++ b/emdx/ui/cascade_browser.py
@@ -1106,8 +1106,9 @@ class CascadeBrowser(Widget):
     BINDINGS = [
         ("1", "switch_activity", "Activity"),
         ("2", "switch_cascade", "Cascade"),
-        ("3", "switch_documents", "Documents"),
-        ("4", "switch_search", "Search"),
+        ("3", "switch_search", "Search"),
+        ("4", "switch_github", "GitHub"),
+        ("5", "switch_documents", "Documents"),
         ("?", "show_help", "Help"),
     ]
 
@@ -1136,7 +1137,7 @@ class CascadeBrowser(Widget):
         self.cascade_view = CascadeView(id="cascade-view")
         yield self.cascade_view
         yield Static(
-            "[dim]1[/dim] Activity │ [bold]2[/bold] Cascade │ [dim]3[/dim] Documents │ [dim]4[/dim] Search │ "
+            "[dim]1[/dim] Activity │ [bold]2[/bold] Cascade │ [dim]3[/dim] Search │ [dim]4[/dim] GitHub │ [dim]5[/dim] Docs │ "
             "[dim]n[/dim] new idea │ [dim]a[/dim] advance │ [dim]p[/dim] process │ [dim]s[/dim] synthesize",
             id="help-bar",
         )
@@ -1194,6 +1195,11 @@ class CascadeBrowser(Widget):
         """Switch to search screen."""
         if hasattr(self.app, "switch_browser"):
             await self.app.switch_browser("search")
+
+    async def action_switch_github(self) -> None:
+        """Switch to GitHub browser."""
+        if hasattr(self.app, "switch_browser"):
+            await self.app.switch_browser("github")
 
     def action_show_help(self) -> None:
         """Show help."""

--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -148,8 +148,14 @@ class DocumentBrowser(HelpMixin, Widget):
                         wrap=True, highlight=True, markup=True, auto_scroll=False
                     )
         
-        # Status bar at the bottom
+        # Status bar at the bottom (for dynamic messages)
         yield Static("Ready", id="browser-status", classes="browser-status")
+        # Navigation bar (fixed)
+        yield Static(
+            "[dim]1[/dim] Activity │ [dim]2[/dim] Cascade │ [dim]3[/dim] Search │ [dim]4[/dim] GitHub │ [bold]5[/bold] Docs │ "
+            "[dim]j/k[/dim] nav │ [dim]Enter[/dim] view │ [dim]e[/dim] edit",
+            id="nav-bar", classes="nav-bar"
+        )
                     
     async def on_mount(self) -> None:
         """Initialize the document browser."""

--- a/emdx/ui/document_browser.tcss
+++ b/emdx/ui/document_browser.tcss
@@ -30,6 +30,14 @@ DocumentBrowser {
     layer: base;
 }
 
+.nav-bar {
+    height: 1;
+    background: $surface;
+    color: $text;
+    padding: 0 1;
+    layer: base;
+}
+
 #tag-selector {
     layer: overlay;
     display: none;

--- a/emdx/ui/github/github_view.py
+++ b/emdx/ui/github/github_view.py
@@ -155,6 +155,12 @@ class GitHubView(Widget):
     GitHubView .pr-item-content {
         width: 100%;
     }
+
+    GitHubView #github-footer {
+        height: 1;
+        background: $surface;
+        padding: 0 1;
+    }
     """
 
     class ViewDocument(Message):
@@ -176,6 +182,11 @@ class GitHubView(Widget):
             with Vertical(id="pr-list-container"):
                 yield ListView(id="pr-list")
             yield PRPreview(id="pr-preview")
+        yield Static(
+            "[dim]1[/dim] Activity │ [dim]2[/dim] Cascade │ [dim]3[/dim] Search │ [bold]4[/bold] GitHub │ [dim]5[/dim] Docs │ "
+            "[dim]Enter[/dim] Diff │ [dim]M[/dim] Merge │ [dim]A[/dim] Approve │ [dim]r[/dim] Refresh",
+            id="github-footer"
+        )
 
     async def on_mount(self) -> None:
         """Initialize on mount."""

--- a/emdx/ui/search/search_screen.py
+++ b/emdx/ui/search/search_screen.py
@@ -58,15 +58,16 @@ class SearchScreen(HelpMixin, Widget):
         Binding("question_mark", "show_help", "Help"),
         Binding("1", "switch_activity", "Activity"),
         Binding("2", "switch_cascade", "Cascade"),
-        Binding("3", "switch_documents", "Documents"),
-        Binding("4", "switch_search", "Search"),
+        Binding("3", "switch_search", "Search"),
+        Binding("4", "switch_github", "GitHub"),
+        Binding("5", "switch_documents", "Documents"),
     ]
 
     DEFAULT_CSS = """
     SearchScreen {
         layout: grid;
         grid-size: 1;
-        grid-rows: 3 1fr 1;
+        grid-rows: 3 1fr 1 1;
     }
 
     #search-bar {
@@ -120,6 +121,12 @@ class SearchScreen(HelpMixin, Widget):
         background: $surface-darken-1;
         padding: 0 1;
     }
+
+    #search-nav {
+        height: 1;
+        background: $surface;
+        padding: 0 1;
+    }
     """
 
     # Reactive state
@@ -147,8 +154,14 @@ class SearchScreen(HelpMixin, Widget):
         # Results list (Google-style with rich content)
         yield OptionList(id="results-list")
 
-        # Status bar
-        yield Static("Tab=mode | Enter=view | /=search | ?=help", id="search-status")
+        # Status bar (dynamic)
+        yield Static("Type to search...", id="search-status")
+        # Navigation bar (fixed)
+        yield Static(
+            "[dim]1[/dim] Activity │ [dim]2[/dim] Cascade │ [bold]3[/bold] Search │ [dim]4[/dim] GitHub │ [dim]5[/dim] Docs │ "
+            "[dim]Tab[/dim] mode │ [dim]Enter[/dim] view │ [dim]/[/dim] search",
+            id="search-nav"
+        )
 
     async def on_mount(self) -> None:
         """Initialize the search screen."""
@@ -540,3 +553,8 @@ class SearchScreen(HelpMixin, Widget):
     async def action_switch_search(self) -> None:
         """Already on search, do nothing."""
         pass
+
+    async def action_switch_github(self) -> None:
+        """Switch to GitHub browser."""
+        if hasattr(self.app, "switch_browser"):
+            await self.app.switch_browser("github")


### PR DESCRIPTION
## Summary
- Reorder screen navigation: 1=Activity, 2=Cascade, 3=Search, 4=GitHub, 5=Documents
- Add consistent navigation bar showing on all screens (Activity, Cascade, Search, GitHub, Documents)
- Separate dynamic status bar from fixed navigation bar to prevent overwriting

## Test plan
- [ ] Press 1-5 to switch between screens
- [ ] Verify navigation bar appears at bottom of all screens
- [ ] Verify status messages don't overwrite the navigation bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)