### PR TITLE
feat: Add Cursor CLI support with live log streaming (#370)

### DIFF
--- a/docs/CURSOR_SUPPORT_IMPLEMENTATION_PLAN.md
+++ b/docs/CURSOR_SUPPORT_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,691 @@
+# Cursor CLI Support Implementation Plan
+
+## Executive Summary
+
+This document outlines a comprehensive plan to add Cursor CLI support to EMDX's execution system. The analysis reveals that **adding Cursor support is highly feasible** due to:
+
+1. **Near-identical JSON output formats** between Claude and Cursor CLIs
+2. **Single execution funnel** - all commands converge through `claude_executor.py`
+3. **Well-structured abstractions** already in place (`ExecutionConfig`, `ExecutionResult`)
+4. **Minimal CLI flag differences** requiring only minor adaptations
+
+**Estimated Total Effort**: 1-2 days for production-ready implementation
+
+---
+
+## Key Findings
+
+### CLI Interface Comparison
+
+| Aspect | Claude CLI | Cursor CLI | Compatibility |
+|--------|-----------|------------|---------------|
+| **Command** | `claude` | `cursor agent` | Different binary |
+| **Prompt flag** | `--print <prompt>` | `-p` + positional | Different syntax |
+| **Output format** | `--output-format stream-json` | `--output-format stream-json` | ✅ Identical |
+| **Model flag** | `--model <model>` | `--model <model>` | ✅ Identical |
+| **Tool control** | `--allowedTools X,Y,Z` | `--force` (all tools) | Different approach |
+| **Verbose** | `--verbose` (required for stream-json) | Not required | Claude-specific |
+| **Workspace** | Uses `cwd` | `--workspace <path>` | Optional flag |
+
+### JSON Output Format Compatibility
+
+**Critical Finding**: Both CLIs produce nearly identical NDJSON output!
+
+| Message Type | Claude | Cursor | Notes |
+|--------------|--------|--------|-------|
+| `system/init` | ✅ | ✅ | Cursor adds `apiKeySource`, Claude adds `tools` |
+| `user` | ❌ | ✅ | Cursor echoes user input |
+| `assistant` | ✅ | ✅ | Claude has richer metadata |
+| `result` | ✅ | ✅ | Claude has `total_cost_usd`, Cursor has `request_id` |
+
+**Parser Impact**: A unified parser can handle both with source detection on first message.
+
+### Hardcoded References Inventory
+
+| Location | Reference | Change Required |
+|----------|-----------|-----------------|
+| `services/claude_executor.py:108,250` | `cmd = ["claude", ...]` | Parameterize binary |
+| `utils/environment.py:16` | `REQUIRED_COMMANDS = ["claude", "git"]` | Make configurable |
+| `utils/environment.py:55-63,141-149` | Claude version checks | Add Cursor checks |
+| `config/constants.py:186` | `DEFAULT_CLAUDE_MODEL` | Add Cursor models |
+
+---
+
+## Architecture Design
+
+### Strategy Pattern for CLI Executors
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     USER COMMANDS                               │
+│         (emdx run, agent, each, workflow, cascade)              │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                   UnifiedExecutor                               │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │                  ExecutionConfig                         │   │
+│  │  + cli_tool: Literal["claude", "cursor"] = "claude"     │   │
+│  │  + prompt: str                                           │   │
+│  │  + model: Optional[str]  # None = use default           │   │
+│  │  + allowed_tools: List[str]                              │   │
+│  │  + working_dir: str                                      │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                           │                                     │
+│                           ▼                                     │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │               CliExecutorFactory                         │   │
+│  │  get_executor(cli_tool) -> CliExecutor                  │   │
+│  └─────────────────────────────────────────────────────────┘   │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │
+           ┌───────────────┴───────────────┐
+           ▼                               ▼
+┌─────────────────────┐         ┌─────────────────────┐
+│  ClaudeCliExecutor  │         │  CursorCliExecutor  │
+│  - build_command()  │         │  - build_command()  │
+│  - parse_output()   │         │  - parse_output()   │
+│  - get_models()     │         │  - get_models()     │
+└─────────────────────┘         └─────────────────────┘
+           │                               │
+           ▼                               ▼
+┌─────────────────────┐         ┌─────────────────────┐
+│ claude --print ...  │         │ cursor agent -p ... │
+└─────────────────────┘         └─────────────────────┘
+```
+
+### New File Structure
+
+```
+emdx/
+├── services/
+│   ├── cli_executor/                    # NEW: CLI executor package
+│   │   ├── __init__.py                  # Export factory and base
+│   │   ├── base.py                      # CliExecutor ABC
+│   │   ├── claude.py                    # ClaudeCliExecutor
+│   │   ├── cursor.py                    # CursorCliExecutor
+│   │   └── factory.py                   # CliExecutorFactory
+│   ├── claude_executor.py               # MODIFY: Use factory
+│   └── unified_executor.py              # MODIFY: Add cli_tool field
+├── config/
+│   ├── constants.py                     # MODIFY: Add CLI config
+│   └── cli_config.py                    # NEW: CLI-specific settings
+├── utils/
+│   ├── environment.py                   # MODIFY: Detect both CLIs
+│   └── output_parser.py                 # MODIFY: Unified parsing
+└── workflows/
+    └── output_parser.py                 # MODIFY: Source-aware parsing
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core Abstraction (4-6 hours)
+
+**Goal**: Create CLI executor abstraction without breaking existing functionality.
+
+#### 1.1 Create `cli_config.py`
+
+```python
+# emdx/config/cli_config.py
+from dataclasses import dataclass
+from typing import Literal, Dict, List, Optional
+from enum import Enum
+
+class CliTool(str, Enum):
+    CLAUDE = "claude"
+    CURSOR = "cursor"
+
+@dataclass
+class CliConfig:
+    """Configuration for a CLI tool."""
+    binary: str                          # "claude" or "cursor agent"
+    prompt_flag: str                     # "--print" or "-p"
+    output_format_flag: str              # "--output-format"
+    model_flag: str                      # "--model"
+    requires_verbose: bool               # Claude needs --verbose for stream-json
+    supports_allowed_tools: bool         # Claude has --allowedTools
+    force_flag: Optional[str]            # Cursor uses --force
+    workspace_flag: Optional[str]        # Cursor uses --workspace
+    default_model: str                   # Default model for this CLI
+
+CLI_CONFIGS: Dict[CliTool, CliConfig] = {
+    CliTool.CLAUDE: CliConfig(
+        binary="claude",
+        prompt_flag="--print",
+        output_format_flag="--output-format",
+        model_flag="--model",
+        requires_verbose=True,
+        supports_allowed_tools=True,
+        force_flag=None,
+        workspace_flag=None,
+        default_model="claude-opus-4-5-20251101",
+    ),
+    CliTool.CURSOR: CliConfig(
+        binary="cursor agent",
+        prompt_flag="-p",
+        output_format_flag="--output-format",
+        model_flag="--model",
+        requires_verbose=False,
+        supports_allowed_tools=False,
+        force_flag="--force",
+        workspace_flag="--workspace",
+        default_model="auto",
+    ),
+}
+
+# Model mappings for cross-CLI compatibility
+MODEL_ALIASES = {
+    "opus": {"claude": "claude-opus-4-5-20251101", "cursor": "opus-4.5"},
+    "sonnet": {"claude": "claude-sonnet-4-5-20250929", "cursor": "sonnet-4.5"},
+    "auto": {"claude": "claude-sonnet-4-5-20250929", "cursor": "auto"},
+}
+```
+
+#### 1.2 Create `CliExecutor` Base Class
+
+```python
+# emdx/services/cli_executor/base.py
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Dict, Any
+
+@dataclass
+class CliCommand:
+    """Represents a CLI command to execute."""
+    args: List[str]
+    env: Dict[str, str]
+    cwd: Optional[str]
+
+@dataclass
+class CliResult:
+    """Result from CLI execution."""
+    success: bool
+    output: str
+    error: Optional[str]
+    exit_code: int
+    tokens_used: int
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    duration_ms: int
+
+class CliExecutor(ABC):
+    """Abstract base class for CLI executors."""
+
+    @abstractmethod
+    def build_command(
+        self,
+        prompt: str,
+        model: Optional[str],
+        allowed_tools: Optional[List[str]],
+        output_format: str,
+        working_dir: Optional[str],
+    ) -> CliCommand:
+        """Build the CLI command to execute."""
+        pass
+
+    @abstractmethod
+    def parse_result(self, stdout: str, stderr: str, exit_code: int) -> CliResult:
+        """Parse CLI output into structured result."""
+        pass
+
+    @abstractmethod
+    def get_available_models(self) -> List[str]:
+        """Get list of available models for this CLI."""
+        pass
+
+    @abstractmethod
+    def validate_environment(self) -> tuple[bool, Dict[str, Any]]:
+        """Validate that the CLI is properly installed."""
+        pass
+```
+
+#### 1.3 Implement `ClaudeCliExecutor`
+
+```python
+# emdx/services/cli_executor/claude.py
+from .base import CliExecutor, CliCommand, CliResult
+from ..config.cli_config import CLI_CONFIGS, CliTool
+
+class ClaudeCliExecutor(CliExecutor):
+    def __init__(self):
+        self.config = CLI_CONFIGS[CliTool.CLAUDE]
+
+    def build_command(
+        self,
+        prompt: str,
+        model: Optional[str],
+        allowed_tools: Optional[List[str]],
+        output_format: str = "stream-json",
+        working_dir: Optional[str] = None,
+    ) -> CliCommand:
+        cmd = [
+            self.config.binary,
+            self.config.prompt_flag, prompt,
+            self.config.output_format_flag, output_format,
+            self.config.model_flag, model or self.config.default_model,
+        ]
+
+        if self.config.requires_verbose and output_format == "stream-json":
+            cmd.append("--verbose")
+
+        if allowed_tools and self.config.supports_allowed_tools:
+            cmd.extend(["--allowedTools", ",".join(allowed_tools)])
+
+        return CliCommand(args=cmd, env={}, cwd=working_dir)
+
+    def parse_result(self, stdout: str, stderr: str, exit_code: int) -> CliResult:
+        # Extract from __RAW_RESULT_JSON__ marker (existing logic)
+        # ...existing parsing logic from output_parser.py...
+        pass
+```
+
+#### 1.4 Implement `CursorCliExecutor`
+
+```python
+# emdx/services/cli_executor/cursor.py
+from .base import CliExecutor, CliCommand, CliResult
+from ..config.cli_config import CLI_CONFIGS, CliTool
+
+class CursorCliExecutor(CliExecutor):
+    def __init__(self):
+        self.config = CLI_CONFIGS[CliTool.CURSOR]
+
+    def build_command(
+        self,
+        prompt: str,
+        model: Optional[str],
+        allowed_tools: Optional[List[str]],
+        output_format: str = "stream-json",
+        working_dir: Optional[str] = None,
+    ) -> CliCommand:
+        # cursor agent uses positional prompt with -p flag
+        cmd = ["cursor", "agent"]
+        cmd.append(self.config.prompt_flag)  # -p
+        cmd.extend([self.config.output_format_flag, output_format])
+        cmd.extend([self.config.model_flag, model or self.config.default_model])
+
+        # Cursor doesn't have --allowedTools, use --force for full access
+        if allowed_tools and self.config.force_flag:
+            cmd.append(self.config.force_flag)
+
+        if working_dir and self.config.workspace_flag:
+            cmd.extend([self.config.workspace_flag, working_dir])
+
+        # Add prompt as positional argument at end
+        cmd.append(prompt)
+
+        return CliCommand(args=cmd, env={}, cwd=working_dir)
+
+    def parse_result(self, stdout: str, stderr: str, exit_code: int) -> CliResult:
+        # Parse Cursor's NDJSON output (similar to Claude but without cost)
+        # ...
+        pass
+```
+
+#### 1.5 Create Factory
+
+```python
+# emdx/services/cli_executor/factory.py
+from typing import Optional
+from .base import CliExecutor
+from .claude import ClaudeCliExecutor
+from .cursor import CursorCliExecutor
+from ..config.cli_config import CliTool
+
+_executors = {
+    CliTool.CLAUDE: ClaudeCliExecutor,
+    CliTool.CURSOR: CursorCliExecutor,
+}
+
+def get_cli_executor(cli_tool: Optional[str] = None) -> CliExecutor:
+    """Get the appropriate CLI executor.
+
+    Args:
+        cli_tool: "claude", "cursor", or None (uses default/env var)
+
+    Returns:
+        CliExecutor instance
+    """
+    if cli_tool is None:
+        # Check environment variable, default to Claude
+        import os
+        cli_tool = os.environ.get("EMDX_CLI_TOOL", "claude")
+
+    tool = CliTool(cli_tool)
+    return _executors[tool]()
+```
+
+### Phase 2: Integration (2-4 hours)
+
+**Goal**: Wire up the abstraction to existing code paths.
+
+#### 2.1 Update `ExecutionConfig`
+
+```python
+# emdx/services/unified_executor.py
+@dataclass
+class ExecutionConfig:
+    prompt: str
+    working_dir: str = field(default_factory=os.getcwd)
+    title: str = "CLI Execution"
+    doc_id: Optional[int] = None
+    output_instruction: Optional[str] = None
+    allowed_tools: List[str] = field(default_factory=lambda: DEFAULT_ALLOWED_TOOLS.copy())
+    timeout_seconds: int = 300
+    cli_tool: str = "claude"  # NEW: "claude" or "cursor"
+    model: Optional[str] = None  # NEW: Override default model
+```
+
+#### 2.2 Update `execute_claude_sync`
+
+```python
+# emdx/services/claude_executor.py
+from .cli_executor.factory import get_cli_executor
+
+def execute_cli_sync(
+    task: str,
+    execution_id: int,
+    log_file: Path,
+    cli_tool: str = "claude",
+    model: Optional[str] = None,
+    allowed_tools: Optional[List[str]] = None,
+    working_dir: Optional[str] = None,
+    doc_id: Optional[str] = None,
+    timeout: int = 300,
+) -> dict:
+    """Execute a task with specified CLI tool synchronously."""
+
+    executor = get_cli_executor(cli_tool)
+
+    # Validate environment
+    is_valid, env_info = executor.validate_environment()
+    if not is_valid:
+        return {"success": False, "error": f"Environment validation failed: {env_info}"}
+
+    # Build command
+    cmd_obj = executor.build_command(
+        prompt=task,
+        model=model,
+        allowed_tools=allowed_tools or DEFAULT_ALLOWED_TOOLS,
+        output_format="text",  # sync uses text
+        working_dir=working_dir,
+    )
+
+    # Execute
+    result = subprocess.run(
+        cmd_obj.args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=cmd_obj.cwd,
+        env={**os.environ, **cmd_obj.env},
+    )
+
+    # Parse result
+    cli_result = executor.parse_result(result.stdout, result.stderr, result.returncode)
+
+    return {
+        "success": cli_result.success,
+        "output": cli_result.output,
+        "error": cli_result.error,
+        "exit_code": cli_result.exit_code,
+    }
+
+# Keep backward compatibility
+def execute_claude_sync(*args, **kwargs):
+    """Backward compatible wrapper."""
+    return execute_cli_sync(*args, cli_tool="claude", **kwargs)
+```
+
+#### 2.3 Update `environment.py`
+
+```python
+# emdx/utils/environment.py
+class EnvironmentValidator:
+    def __init__(self, cli_tool: str = "claude"):
+        self.cli_tool = cli_tool
+        self.REQUIRED_COMMANDS = self._get_required_commands()
+
+    def _get_required_commands(self) -> List[str]:
+        base = ["git"]
+        if self.cli_tool == "claude":
+            return base + ["claude"]
+        elif self.cli_tool == "cursor":
+            return base + ["cursor"]
+        return base
+
+    def check_commands(self) -> None:
+        for cmd in self.REQUIRED_COMMANDS:
+            path = shutil.which(cmd)
+            if path:
+                self.info[f"{cmd}_path"] = path
+                self._check_version(cmd)
+            else:
+                self.errors.append(f"Required command '{cmd}' not found in PATH")
+
+    def _check_version(self, cmd: str) -> None:
+        try:
+            if cmd == "claude":
+                result = subprocess.run(["claude", "--version"], ...)
+            elif cmd == "cursor":
+                result = subprocess.run(["cursor", "agent", "--version"], ...)
+            # ...
+        except Exception as e:
+            self.warnings.append(f"Could not get version for {cmd}: {e}")
+```
+
+### Phase 3: User Interface (1-2 hours)
+
+**Goal**: Expose CLI selection to users.
+
+#### 3.1 Add CLI Flag to Commands
+
+```python
+# emdx/commands/run.py
+@app.command()
+def run(
+    tasks: List[str] = typer.Argument(...),
+    cli_tool: str = typer.Option("claude", "--cli", "-C", help="CLI tool: claude or cursor"),
+    model: Optional[str] = typer.Option(None, "--model", "-m", help="Model to use"),
+    # ... existing options
+):
+    """Run tasks with specified CLI tool."""
+    # ...
+```
+
+#### 3.2 Add Environment Variable Support
+
+```python
+# emdx/config/cli_config.py
+import os
+
+def get_default_cli_tool() -> str:
+    """Get default CLI tool from environment or config."""
+    return os.environ.get("EMDX_CLI_TOOL", "claude")
+
+def get_default_model(cli_tool: str) -> str:
+    """Get default model for CLI tool."""
+    env_key = f"EMDX_{cli_tool.upper()}_MODEL"
+    if model := os.environ.get(env_key):
+        return model
+    return CLI_CONFIGS[CliTool(cli_tool)].default_model
+```
+
+#### 3.3 Add Configuration File Support
+
+```yaml
+# ~/.config/emdx/cli.yaml
+default_cli: cursor  # or "claude"
+
+claude:
+  model: claude-opus-4-5-20251101
+  allowed_tools:
+    - Read
+    - Write
+    - Edit
+    - Bash
+
+cursor:
+  model: auto
+  force_mode: true  # Use --force flag
+```
+
+### Phase 4: Testing & Documentation (2-3 hours)
+
+#### 4.1 Unit Tests
+
+```python
+# tests/test_cli_executor.py
+import pytest
+from emdx.services.cli_executor.factory import get_cli_executor
+from emdx.services.cli_executor.claude import ClaudeCliExecutor
+from emdx.services.cli_executor.cursor import CursorCliExecutor
+
+def test_factory_returns_claude_by_default():
+    executor = get_cli_executor()
+    assert isinstance(executor, ClaudeCliExecutor)
+
+def test_factory_returns_cursor():
+    executor = get_cli_executor("cursor")
+    assert isinstance(executor, CursorCliExecutor)
+
+def test_claude_command_building():
+    executor = ClaudeCliExecutor()
+    cmd = executor.build_command(
+        prompt="test prompt",
+        model="claude-sonnet-4-5-20250929",
+        allowed_tools=["Read", "Write"],
+        output_format="stream-json",
+    )
+    assert "claude" in cmd.args
+    assert "--print" in cmd.args
+    assert "--verbose" in cmd.args
+    assert "--allowedTools" in cmd.args
+
+def test_cursor_command_building():
+    executor = CursorCliExecutor()
+    cmd = executor.build_command(
+        prompt="test prompt",
+        model="auto",
+        allowed_tools=["Read", "Write"],
+        output_format="stream-json",
+    )
+    assert "cursor" in cmd.args
+    assert "agent" in cmd.args
+    assert "-p" in cmd.args
+    assert "--verbose" not in cmd.args  # Cursor doesn't need it
+```
+
+#### 4.2 Integration Tests
+
+```python
+# tests/integration/test_cli_execution.py
+@pytest.mark.integration
+@pytest.mark.skipif(not shutil.which("cursor"), reason="Cursor not installed")
+def test_cursor_simple_execution():
+    result = execute_cli_sync(
+        task="respond with just hello",
+        execution_id=1,
+        log_file=Path("/tmp/test.log"),
+        cli_tool="cursor",
+        model="auto",
+        timeout=30,
+    )
+    assert result["success"]
+    assert "hello" in result["output"].lower()
+```
+
+---
+
+## Risk Assessment
+
+### Low Risk
+- **Output format parsing**: Both CLIs use nearly identical NDJSON
+- **Command building**: Well-understood CLI interfaces
+- **Backward compatibility**: Factory pattern preserves existing behavior
+
+### Medium Risk
+- **Tool restrictions**: Cursor lacks `--allowedTools`, uses `--force` instead
+- **Model mapping**: Different model names between CLIs
+- **Cost tracking**: Cursor doesn't report token costs
+
+### Mitigation Strategies
+1. **Tool restrictions**: Document that Cursor has all-or-nothing tool access
+2. **Model mapping**: Create alias mapping (e.g., "opus" → appropriate model per CLI)
+3. **Cost tracking**: Return 0/None for Cursor cost fields, log warning
+
+---
+
+## Migration Path
+
+### For Existing Users
+
+1. **No breaking changes**: Default remains Claude
+2. **Opt-in**: Set `EMDX_CLI_TOOL=cursor` or use `--cli cursor` flag
+3. **Gradual rollout**: Test with specific commands before full migration
+
+### For New Users
+
+1. **Auto-detection**: If only Cursor is installed, use it by default
+2. **First-run prompt**: Ask which CLI to use if both are available
+3. **Documentation**: Clear comparison of CLI capabilities
+
+---
+
+## Timeline
+
+| Phase | Tasks | Effort | Dependencies |
+|-------|-------|--------|--------------|
+| 1 | Core abstraction | 4-6 hours | None |
+| 2 | Integration | 2-4 hours | Phase 1 |
+| 3 | User interface | 1-2 hours | Phase 2 |
+| 4 | Testing & docs | 2-3 hours | Phase 3 |
+| **Total** | | **9-15 hours** | |
+
+---
+
+## Success Criteria
+
+1. ✅ `emdx run --cli cursor "task"` works end-to-end
+2. ✅ `emdx agent --cli cursor "task"` saves output to emdx
+3. ✅ `emdx each --cli cursor ...` processes items in parallel
+4. ✅ `emdx workflow --cli cursor ...` executes full workflows
+5. ✅ Existing Claude workflows continue working unchanged
+6. ✅ Token/cost tracking works for Claude, gracefully absent for Cursor
+7. ✅ Environment validation detects and reports correct CLI
+8. ✅ All existing tests pass
+9. ✅ New integration tests pass with both CLIs
+
+---
+
+## Appendix: CLI Command Comparison
+
+### Claude CLI
+```bash
+claude --print "your prompt" \
+  --allowedTools "Read,Write,Edit,Bash" \
+  --output-format stream-json \
+  --model claude-opus-4-5-20251101 \
+  --verbose
+```
+
+### Cursor CLI
+```bash
+cursor agent -p \
+  --output-format stream-json \
+  --model auto \
+  --force \
+  "your prompt"
+```
+
+### Key Differences
+1. **Binary**: `claude` vs `cursor agent`
+2. **Prompt position**: Claude uses `--print <prompt>`, Cursor uses positional
+3. **Verbose**: Claude requires `--verbose` for stream-json, Cursor doesn't
+4. **Tool control**: Claude has `--allowedTools`, Cursor has `--force`
+5. **Workspace**: Cursor has explicit `--workspace`, Claude uses `cwd`

--- a/docs/CURSOR_VS_CLAUDE_CLI_CHEATSHEET.md
+++ b/docs/CURSOR_VS_CLAUDE_CLI_CHEATSHEET.md
@@ -1,0 +1,360 @@
+# Cursor vs Claude CLI: Quick Reference Cheatsheet
+
+## Field Comparison Matrix (One-Pager)
+
+```
+╔════════════════════════╦═════════════╦══════════════╦═══════════════════╗
+║ Field                  ║ Cursor      ║ Claude CLI   ║ Notes             ║
+╠════════════════════════╬═════════════╬══════════════╬═══════════════════╣
+║ SYSTEM/INIT MESSAGE    ║             ║              ║                   ║
+├────────────────────────┼─────────────┼──────────────┼───────────────────┤
+║ type                   ║ ✓ "system"  ║ ✓ "system"   ║ Always present    ║
+║ subtype                ║ ✓ "init"    ║ ✓ "init"     ║ Always "init"     ║
+║ session_id             ║ ✓ UUID      ║ ✓ UUID       ║ Use for tracking  ║
+║ cwd                    ║ ✓           ║ ✓            ║ Working directory ║
+║ model                  ║ ✓ "Auto"    ║ ✓ Full ID    ║ Different meaning ║
+║ permissionMode         ║ ✓           ║ ✓            ║ Usually "default" ║
+║ apiKeySource           ║ ✓ "login"   ║ ✗            ║ Cursor-only       ║
+║ tools                  ║ ✗           ║ ✓ Array      ║ Claude-only       ║
+║ mcp_servers            ║ ✗           ║ ✓ Array      ║ Claude-only       ║
+╠════════════════════════╬═════════════╬══════════════╬═══════════════════╣
+║ USER MESSAGE           ║             ║              ║                   ║
+├────────────────────────┼─────────────┼──────────────┼───────────────────┤
+║ type                   ║ ✓ "user"    ║ ✗ (not sent) ║ Cursor echoes it  ║
+║ message.role           ║ ✓ "user"    ║ ─            ║ ─                 ║
+║ message.content        ║ ✓ Array     ║ ─            ║ ─                 ║
+╠════════════════════════╬═════════════╬══════════════╬═══════════════════╣
+║ ASSISTANT MESSAGE      ║             ║              ║                   ║
+├────────────────────────┼─────────────┼──────────────┼───────────────────┤
+║ message.role           ║ ✓ "asst."   ║ ✓ "asst."    ║ Always present    ║
+║ message.content        ║ ✓ Array     ║ ✓ Array      ║ Text extraction   ║
+║ message.model          ║ ✗           ║ ✓            ║ Which model       ║
+║ message.id             ║ ✗           ║ ✓            ║ Anthropic ID      ║
+║ message.stop_reason    ║ ✗           ║ ✓            ║ Why it stopped    ║
+║ message.stop_sequence  ║ ✗           ║ ✓            ║ Stop token        ║
+║ message.usage          ║ ✗           ║ ✓            ║ Token metrics     ║
+╠════════════════════════╬═════════════╬══════════════╬═══════════════════╣
+║ RESULT MESSAGE         ║             ║              ║                   ║
+├────────────────────────┼─────────────┼──────────────┼───────────────────┤
+║ type                   ║ ✓ "result"  ║ ✓ "result"   ║ Always present    ║
+║ subtype                ║ ✓ "success" ║ ✓ "success"  ║ On success        ║
+║ is_error               ║ ✓ bool      ║ ✓ bool       ║ Error indicator   ║
+║ duration_ms            ║ ✓           ║ ✓            ║ Total time        ║
+║ duration_api_ms        ║ ✓ ~equal    ║ ✓ varies     ║ API time only     ║
+║ result                 ║ ✓ output    ║ ✓ output     ║ The response text ║
+║ session_id             ║ ✓           ║ ✓            ║ Matches init      ║
+║ request_id             ║ ✓ UUID      ║ ✗            ║ Cursor request ID ║
+║ num_turns              ║ ✗           ║ ✓            ║ Conversation      ║
+║ total_cost_usd         ║ ✗           ║ ✓            ║ Claude API cost   ║
+║ usage.input_tokens     ║ ✗           ║ ✓            ║ Input token count ║
+║ usage.output_tokens    ║ ✗           ║ ✓            ║ Output token cnt  ║
+╚════════════════════════╩═════════════╩══════════════╩═══════════════════╝
+```
+
+---
+
+## Source Detection One-Liner
+
+```python
+def detect(first_line):
+    d = json.loads(first_line)
+    return "cursor" if "apiKeySource" in d else "claude_cli"
+```
+
+---
+
+## Message Flow
+
+```
+CURSOR:
+1. system/init (apiKeySource present)
+2. user (input echo)
+3. assistant (response)
+4. result (request_id, no cost)
+
+CLAUDE CLI:
+1. system/init (tools, mcp_servers present)
+2. assistant (response with metadata)
+3. result (cost_usd, tokens, num_turns)
+```
+
+---
+
+## Text Extraction
+
+**Both formats use same structure:**
+```python
+def extract_text(content: list) -> str:
+    return "".join(item["text"] for item in content if item.get("type") == "text")
+```
+
+---
+
+## Model Field Semantics
+
+| Source | Value | Meaning | Example |
+|--------|-------|---------|---------|
+| Cursor | `"Auto"` | User's selection mode | In system/init |
+| Claude CLI | `"claude-sonnet-4-5-20250929"` | Actual model used | In system/init & messages |
+
+---
+
+## Timing Breakdown
+
+| Metric | Cursor | Claude CLI | Calculation |
+|--------|--------|-----------|-------------|
+| `duration_ms` | Total | Total | Wall-clock time |
+| `duration_api_ms` | ~Total | API only | Network + processing |
+| Overhead | ~0ms | Varies | `duration_ms - duration_api_ms` |
+
+**Example:**
+```
+Cursor:   duration_ms=5182, duration_api_ms=5182, overhead≈0
+Claude:   duration_ms=2805, duration_api_ms=2795, overhead=10ms
+```
+
+---
+
+## Cost Tracking
+
+| Source | Has Cost Info? | Field | Formula |
+|--------|---------------|-------|---------|
+| Cursor | ✗ | None | N/A |
+| Claude CLI | ✓ | `total_cost_usd` | (input_tokens / 1M × rate) + (output_tokens / 1M × rate) |
+
+---
+
+## Common Parsing Patterns
+
+### Pattern 1: Extract Entire Flow
+```python
+messages = []
+for line in stream:
+    msg = json.loads(line)
+    if msg["type"] == "system":
+        messages.append(("init", msg))
+    elif msg["type"] == "assistant":
+        messages.append(("response", extract_text(msg["message"]["content"])))
+    elif msg["type"] == "result" and not msg.get("is_error"):
+        messages.append(("success", msg.get("result")))
+```
+
+### Pattern 2: Track by Source
+```python
+source = detect(stream[0])
+for line in stream[1:]:
+    msg = json.loads(line)
+    if source == "cursor" and msg["type"] == "result":
+        req_id = msg["request_id"]  # Safe, always present
+    elif source == "claude_cli" and msg["type"] == "result":
+        cost = msg.get("total_cost_usd")  # Safe, may be None
+```
+
+### Pattern 3: Accumulate Tokens
+```python
+input_tokens = 0
+output_tokens = 0
+
+for line in stream:
+    msg = json.loads(line)
+    if msg["type"] == "assistant":
+        usage = msg["message"].get("usage", {})
+        input_tokens += usage.get("input_tokens", 0)
+        output_tokens += usage.get("output_tokens", 0)
+    elif msg["type"] == "result":
+        usage = msg.get("usage", {})
+        input_tokens += usage.get("input_tokens", 0)
+        output_tokens += usage.get("output_tokens", 0)
+```
+
+---
+
+## Minimal Parser (45 Lines)
+
+```python
+import json
+from typing import Literal
+
+def parse_ndjson(stream):
+    source = None
+
+    for line in stream:
+        if not line.strip():
+            continue
+
+        msg = json.loads(line)
+        msg_type = msg.get("type")
+
+        # Detect source from first message
+        if source is None and msg_type == "system":
+            source = "cursor" if "apiKeySource" in msg else "claude_cli"
+
+        # Route by message type
+        if msg_type == "system":
+            yield ("system", {
+                "session": msg["session_id"],
+                "cwd": msg["cwd"],
+                "model": msg["model"],
+            })
+
+        elif msg_type == "user":
+            text = "".join(
+                item["text"] for item in msg["message"]["content"]
+                if item.get("type") == "text"
+            )
+            yield ("user", text)
+
+        elif msg_type == "assistant":
+            text = "".join(
+                item["text"] for item in msg["message"]["content"]
+                if item.get("type") == "text"
+            )
+            tokens = msg["message"].get("usage", {})
+            yield ("assistant", {
+                "text": text,
+                "input_tokens": tokens.get("input_tokens"),
+                "output_tokens": tokens.get("output_tokens"),
+            })
+
+        elif msg_type == "result":
+            yield ("result", {
+                "success": not msg.get("is_error", False),
+                "duration_ms": msg["duration_ms"],
+                "cost_usd": msg.get("total_cost_usd"),
+                "output": msg.get("result"),
+            })
+
+# Usage
+with open("output.ndjson") as f:
+    for msg_type, data in parse_ndjson(f):
+        print(f"{msg_type}: {data}")
+```
+
+---
+
+## Common ✗ Mistakes & ✓ Fixes
+
+### Mistake 1: Assuming User Messages Always Present
+```python
+# ✗ WRONG
+for msg in stream:
+    if msg["type"] == "user":
+        user_input = extract_text(msg["message"]["content"])
+        # Empty for Claude CLI!
+
+# ✓ CORRECT
+if source == "cursor":
+    # Process user messages
+elif source == "claude_cli":
+    # Skip user messages (not sent)
+```
+
+### Mistake 2: Comparing Model Strings
+```python
+# ✗ WRONG
+if msg["model"] == "claude-sonnet":
+    # Fails for Cursor where model="Auto"
+
+# ✓ CORRECT
+if source == "claude_cli":
+    actual_model = msg["model"]  # "claude-sonnet-4-5-20250929"
+elif source == "cursor":
+    selection = msg["model"]  # "Auto"
+```
+
+### Mistake 3: KeyError on Optional Fields
+```python
+# ✗ WRONG
+cost = msg["total_cost_usd"]  # KeyError for Cursor
+
+# ✓ CORRECT
+cost = msg.get("total_cost_usd")  # None for Cursor
+```
+
+### Mistake 4: Assuming Equal Timing
+```python
+# ✗ WRONG
+overhead = msg["duration_ms"] - msg["duration_api_ms"]  # Always ~0 for Cursor
+
+# ✓ CORRECT
+api = msg.get("duration_api_ms", msg["duration_ms"])
+overhead = msg["duration_ms"] - api
+```
+
+---
+
+## Test Data
+
+### Cursor Minimal Test
+```json
+{"type":"system","apiKeySource":"login","session_id":"s1","cwd":"/tmp","model":"Auto","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]},"session_id":"s1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"session_id":"s1"}
+{"type":"result","is_error":false,"duration_ms":1000,"duration_api_ms":1000,"result":"hello","session_id":"s1","request_id":"r1"}
+```
+
+### Claude CLI Minimal Test
+```json
+{"type":"system","tools":[],"mcp_servers":[],"session_id":"s2","cwd":"/tmp","model":"claude-sonnet","permissionMode":"default"}
+{"type":"assistant","message":{"model":"claude-sonnet","id":"m1","role":"assistant","content":[{"type":"text","text":"hello"}],"usage":{"input_tokens":10,"output_tokens":5}}}
+{"type":"result","is_error":false,"duration_ms":2000,"duration_api_ms":1900,"result":"hello","session_id":"s2","total_cost_usd":0.001,"usage":{"input_tokens":10,"output_tokens":5}}
+```
+
+---
+
+## Integration Checklist
+
+- [ ] Detect source on first message
+- [ ] Handle Cursor's user messages (skip for Claude)
+- [ ] Use `.get()` for optional fields
+- [ ] Calculate overhead (total - api)
+- [ ] Handle None for Cursor's missing cost/tokens
+- [ ] Log source for debugging
+- [ ] Test with both formats
+- [ ] Handle parsing errors gracefully
+
+---
+
+## Documentation Links
+
+| Document | Purpose | Read Time |
+|----------|---------|-----------|
+| CURSOR_VS_CLAUDE_CLI_README.md | Navigation guide | 5 min |
+| cursor-vs-claude-cli-json.md | Structural analysis | 10 min |
+| cursor-vs-claude-cli-examples.md | Concrete examples | 15 min |
+| cursor-vs-claude-cli-parser.md | Implementation | 20 min |
+| CURSOR_VS_CLAUDE_CLI_CHEATSHEET.md | This document | 3 min |
+
+---
+
+## Emergency Quick Fixes
+
+### "Parser failing on JSON"
+```bash
+jq . < output.ndjson > /dev/null  # Validate JSON
+head -1 output.ndjson | jq .      # Check first message
+```
+
+### "Source detection failing"
+```python
+data = json.loads(line)
+print(f"Has apiKeySource: {'apiKeySource' in data}")
+print(f"Has tools: {'tools' in data}")
+```
+
+### "Text not extracting"
+```python
+content = msg["message"]["content"]
+print(json.dumps(content, indent=2))  # See structure
+```
+
+### "Cost is None but shouldn't be"
+```python
+# Claude CLI includes cost in result only
+if msg["type"] == "result" and not msg.get("is_error"):
+    cost = msg.get("total_cost_usd")  # Check in result, not assistant
+```
+
+---
+
+**Print this page for quick reference while coding!**

--- a/docs/CURSOR_VS_CLAUDE_CLI_README.md
+++ b/docs/CURSOR_VS_CLAUDE_CLI_README.md
@@ -1,0 +1,567 @@
+# Cursor vs Claude CLI: Complete Analysis & Parser Implementation
+
+A comprehensive guide for understanding and parsing JSON output from both Cursor and Claude CLI, with production-ready Python implementations.
+
+---
+
+## Document Overview
+
+This analysis consists of four interconnected documents:
+
+### 1. **[cursor-vs-claude-cli-json.md](cursor-vs-claude-cli-json.md)** - Structural Comparison
+**Best for:** Understanding the high-level differences between formats
+
+Contains:
+- Executive summary of key differences
+- Detailed comparison tables
+  - Common fields (work identically)
+  - Fields unique to Claude CLI
+  - Fields unique to Cursor
+  - Same field names with different structures
+- Compatibility implications with examples
+- Unified parser design overview
+- Parser compatibility matrix
+
+**Key sections:**
+- "Parser Compatibility Matrix" - Shows data flow differences
+- "Compatibility Implications" - 4 major challenges with solutions
+- "Unified Parser Design" - High-level architecture
+
+**Read this first if:** You want to understand the big picture.
+
+---
+
+### 2. **[cursor-vs-claude-cli-examples.md](cursor-vs-claude-cli-examples.md)** - Annotated Examples
+**Best for:** Seeing concrete JSON examples with explanations
+
+Contains:
+- Side-by-side JSON output from both tools
+- Line-by-line annotations showing differences
+- Complete example flows (init → response → result)
+- Parser strategy code snippets for each example
+- Timing analysis
+- Format detection algorithms
+- Common pitfalls to avoid (with correct solutions)
+- Test vectors for validation
+
+**Key sections:**
+- "Example 1-4" - Complete flows with annotations
+- "Parser Strategy" - Code for each example
+- "Common Pitfalls" - Shows ❌ wrong vs ✅ right patterns
+- "Test Vectors" - Copy-paste JSON for testing
+
+**Read this second if:** You're building a parser or want concrete examples.
+
+---
+
+### 3. **[cursor-vs-claude-cli-parser.md](cursor-vs-claude-cli-parser.md)** - Implementation
+**Best for:** Copy-paste production code
+
+Contains:
+- Complete data models (dataclasses)
+- Source detection class
+- Unified NDJSON parser class
+- 4 usage examples (file processing, streaming, etc.)
+- Callback-based stream processor
+- Comprehensive unit tests
+- Integration checklist
+- Performance characteristics
+
+**Key sections:**
+- "Data Models" - Ready-to-use dataclasses
+- "UnifiedNDJSONParser" - Main parser class
+- "Usage Examples" - Copy-paste ready
+- "TestUnifiedParser" - Full test suite
+
+**Read this if:** You need to implement the parser.
+
+---
+
+### 4. **This Document (README)**
+Navigation guide and quick reference
+
+---
+
+## Quick Decision Tree
+
+```
+What do you need to do?
+
+1. Understand the differences
+   → Read: cursor-vs-claude-cli-json.md
+   → Section: "Detailed Comparison Table"
+
+2. See concrete examples
+   → Read: cursor-vs-claude-cli-examples.md
+   → Section: "Example 1: System Initialization"
+
+3. Build a parser
+   → Read: cursor-vs-claude-cli-parser.md
+   → Section: "Complete Implementation"
+   → Copy: UnifiedNDJSONParser class
+
+4. Debug parser issues
+   → Read: cursor-vs-claude-cli-examples.md
+   → Section: "Common Pitfalls to Avoid"
+
+5. Find test vectors
+   → Read: cursor-vs-claude-cli-examples.md
+   → Section: "Test Vectors"
+
+6. Understand timing
+   → Read: cursor-vs-claude-cli-examples.md
+   → Section: "Timing Analysis Example"
+```
+
+---
+
+## Key Differences At A Glance
+
+| Aspect | Cursor | Claude CLI | Impact |
+|--------|--------|-----------|--------|
+| **Format** | NDJSON | NDJSON | Same |
+| **Message Types** | 4 (init, user, assistant, result) | 3 (init, assistant, result) | User messages only in Cursor |
+| **Model Field** | `"Auto"` (mode) | `"claude-sonnet-4-5-20250929"` (ID) | Different semantics |
+| **Auth Info** | `apiKeySource` field | No equivalent | Use field presence to detect |
+| **Token Tracking** | Not included | Included in messages & result | Cost tracking in Claude only |
+| **Message IDs** | No | Yes (Anthropic IDs) | Use for tracing |
+| **Timing** | `duration_ms` ≈ `duration_api_ms` | Separated (overhead visible) | API vs total time |
+| **Cost Tracking** | No | Yes (`total_cost_usd`) | Financial data only in Claude |
+
+---
+
+## Implementation Path
+
+### Minimum Viable Implementation (5 minutes)
+
+```python
+# Detect source from first line
+def detect_source(first_line):
+    data = json.loads(first_line)
+    if "apiKeySource" in data:
+        return "cursor"
+    elif "tools" in data:
+        return "claude_cli"
+
+# Extract text from both formats
+def extract_text(content):
+    return "".join(item["text"] for item in content if item.get("type") == "text")
+
+# Process stream
+for line in stream:
+    data = json.loads(line)
+    if data["type"] == "assistant":
+        text = extract_text(data["message"]["content"])
+        print(text)
+```
+
+### Recommended Implementation (30 minutes)
+
+Copy the `UnifiedNDJSONParser` class from [cursor-vs-claude-cli-parser.md](cursor-vs-claude-cli-parser.md) and use:
+
+```python
+parser = UnifiedNDJSONParser(auto_detect=True)
+with open("output.ndjson") as f:
+    for message in parser.parse_stream(f):
+        print(f"{type(message).__name__}: {message}")
+```
+
+### Production Implementation (with tests)
+
+Include the complete implementation from [cursor-vs-claude-cli-parser.md](cursor-vs-claude-cli-parser.md):
+- Data models
+- Source detection
+- Parser class
+- Stream processor
+- Unit tests
+
+---
+
+## Source Detection
+
+Two reliable methods:
+
+### Method 1: Check for Cursor-Specific Field
+```python
+data = json.loads(first_line)
+if "apiKeySource" in data:
+    return "cursor"
+```
+
+### Method 2: Check for Claude CLI-Specific Fields
+```python
+if "tools" in data or "mcp_servers" in data:
+    return "claude_cli"
+```
+
+**Both check the `system/init` message (first line).**
+
+---
+
+## Common Integration Points
+
+### Logging the Source
+
+```python
+parser = UnifiedNDJSONParser(auto_detect=True)
+messages = parser.parse_stream(stream)
+
+if parser.source == Source.CURSOR:
+    logger.info("Processing Cursor output")
+else:
+    logger.info("Processing Claude CLI output")
+```
+
+### Handling Source-Specific Fields
+
+```python
+for message in messages:
+    if isinstance(message, ResultMessage):
+        if parser.source == Source.CURSOR:
+            # Use Cursor fields
+            request_id = message.request_id
+        else:
+            # Use Claude CLI fields
+            cost = message.cost_usd
+            tokens = message.input_tokens
+```
+
+### Extracting Results
+
+```python
+# Both formats have this
+result_text = result_message.result
+
+# Claude CLI has additional metadata
+if result_message.cost_usd:
+    log(f"Cost: ${result_message.cost_usd}")
+```
+
+---
+
+## Testing Your Parser
+
+### 1. Use Provided Test Vectors
+
+Copy JSON from "Test Vectors" section in [cursor-vs-claude-cli-examples.md](cursor-vs-claude-cli-examples.md)
+
+```python
+cursor_ndjson = """{"type":"system",...}
+{"type":"user",...}
+{"type":"assistant",...}
+{"type":"result",...}"""
+
+parser = UnifiedNDJSONParser()
+messages = list(parser.parse_stream(cursor_ndjson.split("\n")))
+assert len(messages) == 4
+```
+
+### 2. Run with Real Data
+
+```bash
+# Generate test output
+cursor api "hello"
+python -c "
+import json
+with open('cursor.ndjson') as f:
+    for line in f:
+        data = json.loads(line)
+        print(f'{data[\"type\"]}: OK' if data else 'FAIL')
+"
+```
+
+### 3. Compare Outputs
+
+```bash
+# See what each CLI produces
+cursor api "test" > cursor_output.ndjson
+claude api "test" > claude_output.ndjson
+diff -u cursor_output.ndjson claude_output.ndjson
+```
+
+---
+
+## Troubleshooting
+
+### "Cannot determine source"
+
+**Cause:** First message is not `type: "system"`
+
+**Solution:** Ensure stream starts with system init message
+
+```python
+# ✓ Correct
+{"type":"system",...}  ← First line
+
+# ✗ Wrong
+{"type":"assistant",...}  ← Can't detect
+```
+
+### Parser says "Unknown message type"
+
+**Cause:** Field contains unexpected value
+
+**Solution:** Check actual CLI output format:
+
+```bash
+# See raw output
+cursor api "test" | head -20
+```
+
+### Missing token data in Cursor
+
+**Cause:** Cursor doesn't output tokens
+
+**Solution:** Handle None values:
+
+```python
+if message.input_tokens is not None:
+    print(f"Tokens: {message.input_tokens}")
+```
+
+### Timing difference confuses results
+
+**Cause:** Cursor shows `duration_ms` ≈ `duration_api_ms`, Claude CLI separates them
+
+**Solution:** Calculate overhead:
+
+```python
+overhead = message.duration_ms - message.api_duration_ms
+print(f"Total: {message.duration_ms}ms (API: {message.api_duration_ms}ms, Overhead: {overhead}ms)")
+```
+
+---
+
+## Performance Notes
+
+### Parsing Speed
+- Detect source: <1ms
+- Parse 100 messages: ~5ms
+- Extract text: <1ms per message
+
+### Memory Usage
+- Minimal for streaming (no buffering required)
+- Each message object: ~500 bytes
+- Test with 1000+ message streams
+
+### Optimization Tips
+
+1. **Use generators** for large files
+```python
+# ✓ Streaming
+for message in parser.parse_stream(f):
+    process(message)
+
+# ✗ Buffering
+messages = list(parser.parse_stream(f))  # Loads all into memory
+```
+
+2. **Skip text extraction** if not needed
+```python
+# Faster if you only need message type
+msg_type = data["type"]
+```
+
+3. **Batch processing** for multiple files
+```python
+for file in files:
+    parser = UnifiedNDJSONParser()  # Reuse source detection
+    for message in parser.parse_stream(open(file)):
+        process(message)
+```
+
+---
+
+## API Reference Quick Links
+
+| Class | Purpose | Location |
+|-------|---------|----------|
+| `SystemMessage` | Init message | parser.md § Data Models |
+| `UserMessage` | User input | parser.md § Data Models |
+| `AssistantMessage` | AI response | parser.md § Data Models |
+| `ResultMessage` | Completion | parser.md § Data Models |
+| `SourceDetector` | Detect format | parser.md § Source Detection |
+| `UnifiedNDJSONParser` | Main parser | parser.md § Parser Implementation |
+| `StreamProcessor` | Callback handler | parser.md § Advanced |
+
+---
+
+## Field Mapping Reference
+
+### Fields Present in Both
+
+```
+type              → Message classification
+session_id        → Session tracking
+duration_ms       → Total elapsed time
+is_error          → Success indicator
+```
+
+### Cursor-Only Fields
+
+```
+subtype              → "init", "success"
+apiKeySource         → "login"
+model                → "Auto" (in init)
+permissionMode       → "default"
+request_id           → Request UUID
+result               → Output value
+```
+
+### Claude CLI-Only Fields
+
+```
+tools                → Available tools (in init)
+mcp_servers          → MCP config (in init)
+model                → "claude-sonnet-4-5-..." (actual model)
+id                   → Anthropic message ID (in assistant)
+stop_reason          → Why generation stopped
+stop_sequence        → Stop sequence matched
+usage                → {"input_tokens": ..., "output_tokens": ...}
+num_turns            → Conversation turns
+total_cost_usd       → Token cost
+modelUsage           → Model-specific metrics
+```
+
+---
+
+## Examples By Use Case
+
+### Use Case 1: "I want to extract just the text response"
+
+→ See [cursor-vs-claude-cli-parser.md](cursor-vs-claude-cli-parser.md) § "Usage Examples" → Example 1
+
+```python
+parser = UnifiedNDJSONParser()
+for msg in parser.parse_stream(f):
+    if isinstance(msg, AssistantMessage):
+        print(msg.content)
+```
+
+### Use Case 2: "I need to track API costs"
+
+→ See [cursor-vs-claude-cli-examples.md](cursor-vs-claude-cli-examples.md) § "Example 4: Final Result"
+
+```python
+if isinstance(msg, ResultMessage) and msg.cost_usd:
+    total_cost += msg.cost_usd
+```
+
+### Use Case 3: "I'm debugging a parsing failure"
+
+→ See [cursor-vs-claude-cli-examples.md](cursor-vs-claude-cli-examples.md) § "Common Pitfalls to Avoid"
+
+```python
+# Look for these exact patterns in examples
+# ❌ WRONG vs ✅ CORRECT
+```
+
+### Use Case 4: "I need to write unit tests"
+
+→ See [cursor-vs-claude-cli-parser.md](cursor-vs-claude-cli-parser.md) § "Testing"
+
+```python
+# Copy TestUnifiedParser class and test vectors
+# From: cursor-vs-claude-cli-examples.md § "Test Vectors"
+```
+
+### Use Case 5: "I need to process both formats transparently"
+
+→ See [cursor-vs-claude-cli-parser.md](cursor-vs-claude-cli-parser.md) § "Advanced: Streaming with Callbacks"
+
+```python
+processor = StreamProcessor(on_result=handle_result)
+processor.process(stream)
+```
+
+---
+
+## Format Evolution Monitoring
+
+Since both formats may change, monitor for:
+
+1. **New message types** - Add to `MessageType` enum
+2. **New optional fields** - Use `.get()` for safe access
+3. **Changed field meanings** - Check `model` field semantics
+4. **New output types** - Tool results, etc.
+
+Track in git with test vectors:
+
+```bash
+git add docs/cursor-vs-claude-cli-examples.md  # Test vectors
+git commit -m "Update test vectors for Cursor v2.0"
+```
+
+---
+
+## Document Statistics
+
+| Document | Lines | Purpose |
+|----------|-------|---------|
+| cursor-vs-claude-cli-json.md | 348 | Structural comparison & analysis |
+| cursor-vs-claude-cli-examples.md | 437 | Annotated JSON examples |
+| cursor-vs-claude-cli-parser.md | 581 | Production-ready implementation |
+| **Total** | **1,366** | **Complete reference** |
+
+---
+
+## Navigation by Task
+
+| Task | Document | Section |
+|------|----------|---------|
+| Understand differences | json.md | "Detailed Comparison Table" |
+| See examples | examples.md | "Example 1-4" |
+| Implement parser | parser.md | "Complete Implementation" |
+| Test parser | parser.md | "Testing" |
+| Find test data | examples.md | "Test Vectors" |
+| Debug issues | examples.md | "Common Pitfalls" |
+| Integrate into code | parser.md | "Usage Examples" |
+| Handle errors | examples.md | "Common Pitfalls" |
+| Track costs | examples.md | "Cost Calculation" |
+| Measure timing | examples.md | "Timing Analysis" |
+
+---
+
+## Contributing & Maintenance
+
+### To Update This Reference
+
+1. Run actual CLIs to capture new output formats
+2. Update examples in `cursor-vs-claude-cli-examples.md`
+3. Update parser in `cursor-vs-claude-cli-parser.md`
+4. Update tests with new test vectors
+5. Commit with message: `docs: Update Cursor/Claude CLI format analysis`
+
+### To Report Discrepancies
+
+Include:
+- Output from your CLI
+- Expected vs actual parsing result
+- Both Cursor and Claude CLI versions
+
+---
+
+## See Also
+
+- **AI System Documentation**: [docs/ai-system.md](ai-system.md)
+- **CLI Reference**: [docs/cli-api.md](cli-api.md)
+- **Architecture**: [docs/architecture.md](architecture.md)
+
+---
+
+## Summary
+
+You now have:
+
+1. ✅ **Complete structural analysis** (json.md)
+2. ✅ **Concrete JSON examples** (examples.md)
+3. ✅ **Production-ready code** (parser.md)
+4. ✅ **Navigation guide** (this README)
+
+**Next step:** Open [cursor-vs-claude-cli-json.md](cursor-vs-claude-cli-json.md) for the quick summary, or jump to [cursor-vs-claude-cli-parser.md](cursor-vs-claude-cli-parser.md) if you need code.
+
+---
+
+**Last Updated:** 2026-01-19
+**Documents:** 4 interconnected markdown files
+**Total Content:** 1,366 lines + Python code examples

--- a/docs/cursor-vs-claude-cli-examples.md
+++ b/docs/cursor-vs-claude-cli-examples.md
@@ -1,0 +1,437 @@
+# Cursor vs Claude CLI: Side-by-Side Examples
+
+This document provides annotated JSON examples showing exactly where and how the two formats differ.
+
+---
+
+## Example 1: System Initialization
+
+### Cursor Output
+
+```json
+{
+  "type": "system",
+  "subtype": "init",
+  "apiKeySource": "login",           ← CURSOR-ONLY: How auth was obtained
+  "cwd": "/Users/alexrockwell/dev/worktrees/emdx-cursorify",
+  "session_id": "472896b5-0079-411c-9c10-ec912453c2a4",
+  "model": "Auto",                   ← CURSOR: User's selection mode
+  "permissionMode": "default"
+}
+```
+
+### Claude CLI Output
+
+```json
+{
+  "type": "system",
+  "subtype": "init",
+  "cwd": "/Users/alexrockwell/dev/worktrees/emdx-cursorify",
+  "session_id": "4318e3f4-0333-4e88-b253-fa0b89a7591a",
+  "tools": [...],                    ← CLAUDE-ONLY: Available tools
+  "mcp_servers": [...],              ← CLAUDE-ONLY: MCP server config
+  "model": "claude-sonnet-4-5-20250929",  ← CLAUDE: Actual model ID
+  "permissionMode": "default"
+}
+```
+
+### Parser Strategy
+
+```python
+source = "cursor" if "apiKeySource" in data else "claude_cli"
+
+if source == "cursor":
+    model_selection = data["model"]  # "Auto"
+    has_tools_info = False
+else:  # claude_cli
+    model_id = data["model"]         # "claude-sonnet-4-5-20250929"
+    has_tools_info = True
+    tools = data.get("tools", [])
+    mcp_servers = data.get("mcp_servers", [])
+```
+
+---
+
+## Example 2: User Input (Cursor Only)
+
+### Cursor Output
+
+```json
+{
+  "type": "user",
+  "message": {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "respond with just the word hello"
+      }
+    ]
+  },
+  "session_id": "472896b5-0079-411c-9c10-ec912453c2a4"
+}
+```
+
+### Claude CLI Output
+
+*(No user message is output - this is the key difference)*
+
+### Parser Strategy
+
+```python
+if msg_type == "user":
+    # Only Cursor outputs user messages
+    source = "cursor"
+    user_text = extract_text(msg["content"])
+    return UserMessage(text=user_text)
+else:
+    # Claude CLI doesn't echo user input in the stream
+    pass
+```
+
+---
+
+## Example 3: Assistant Response
+
+### Cursor Output
+
+```json
+{
+  "type": "assistant",
+  "message": {
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "hello"
+      }
+    ]
+  },
+  "session_id": "472896b5-0079-411c-9c10-ec912453c2a4"
+}
+```
+
+### Claude CLI Output
+
+```json
+{
+  "type": "assistant",
+  "message": {
+    "model": "claude-sonnet-4-5-20250929",  ← CLAUDE: Model that generated this
+    "id": "msg_01SK5Tg5fgiQKQgQg8xCC2UE",  ← CLAUDE: Anthropic message ID
+    "type": "message",                      ← CLAUDE: Type indicator
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "hello"
+      }
+    ],
+    "stop_reason": null,                    ← CLAUDE: Why generation stopped
+    "stop_sequence": null,                  ← CLAUDE: Stop sequence matched
+    "usage": {                              ← CLAUDE: Token metrics
+      "input_tokens": 15,
+      "output_tokens": 1
+    }
+  }
+}
+```
+
+### Parser Strategy
+
+```python
+def parse_assistant(msg_obj):
+    message = msg_obj["message"]
+
+    # Extract common fields
+    content = extract_text(message.get("content", []))
+    role = message.get("role")
+
+    # Extract optional Claude CLI fields
+    metadata = {
+        "model": message.get("model"),
+        "message_id": message.get("id"),
+        "stop_reason": message.get("stop_reason"),
+        "stop_sequence": message.get("stop_sequence"),
+        "usage": message.get("usage", {})
+    }
+
+    # Filter out None values
+    metadata = {k: v for k, v in metadata.items() if v is not None}
+
+    return AssistantMessage(
+        content=content,
+        role=role,
+        metadata=metadata
+    )
+```
+
+---
+
+## Example 4: Final Result
+
+### Cursor Output
+
+```json
+{
+  "type": "result",
+  "subtype": "success",
+  "duration_ms": 5182,                     ← Total time (including API)
+  "duration_api_ms": 5182,                 ← API time (equal to total)
+  "is_error": false,
+  "result": "hello",                       ← CURSOR: The output value
+  "session_id": "472896b5-0079-411c-9c10-ec912453c2a4",
+  "request_id": "7b570630-9840-4846-a38d-1d8ca60621da"  ← CURSOR: Request ID
+}
+```
+
+### Claude CLI Output
+
+```json
+{
+  "type": "result",
+  "subtype": "success",
+  "is_error": false,
+  "duration_ms": 2805,                     ← Total time
+  "duration_api_ms": 2795,                 ← API time (separated)
+  "num_turns": 1,                          ← CLAUDE: Conversation turns
+  "result": "hello",
+  "session_id": "...",
+  "total_cost_usd": 0.07933785,            ← CLAUDE: Token cost
+  "usage": {                               ← CLAUDE: Detailed breakdown
+    "input_tokens": 15,
+    "output_tokens": 1
+  },
+  "modelUsage": {...}                      ← CLAUDE: Model-specific metrics
+}
+```
+
+### Parser Strategy
+
+```python
+def parse_result(data, source):
+    result = {
+        "is_error": data["is_error"],
+        "total_ms": data["duration_ms"],
+        "api_ms": data.get("duration_api_ms", data["duration_ms"]),
+        "output": data.get("result"),
+    }
+
+    # Calculate overhead
+    result["overhead_ms"] = result["total_ms"] - result["api_ms"]
+
+    # Source-specific
+    if source == "cursor":
+        result["request_id"] = data["request_id"]
+    else:  # claude_cli
+        result["num_turns"] = data.get("num_turns", 1)
+        result["cost_usd"] = data.get("total_cost_usd")
+        result["usage"] = data.get("usage", {})
+        result["model_usage"] = data.get("modelUsage", {})
+
+    return result
+```
+
+---
+
+## Timing Analysis Example
+
+### Cursor
+```
+Total: 5182ms
+API:   5182ms
+Overhead: 0ms (rounded)
+```
+
+### Claude CLI
+```
+Total: 2805ms
+API:   2795ms
+Overhead: 10ms (local processing)
+```
+
+### Cost Calculation
+```python
+# Claude CLI includes this
+cost_per_million_input = 0.003  # $3 per million
+cost_per_million_output = 0.015 # $15 per million
+
+input_tokens = 15
+output_tokens = 1
+
+estimated_cost = (
+    (input_tokens / 1_000_000) * cost_per_million_input +
+    (output_tokens / 1_000_000) * cost_per_million_output
+)
+# ≈ $0.000079
+
+# Actual from result: $0.07933785
+# (Note: May include API overhead or different pricing)
+```
+
+---
+
+## Format Detection Algorithm
+
+```python
+def detect_source(first_line: str) -> str:
+    """Detect whether output is from Cursor or Claude CLI"""
+    data = json.loads(first_line)
+
+    # Check for Cursor-specific fields in system message
+    if data.get("type") == "system":
+        if "apiKeySource" in data:
+            return "cursor"
+
+        if "tools" in data or "mcp_servers" in data:
+            return "claude_cli"
+
+    # Fallback: check second line
+    raise ValueError("Cannot determine source from first line")
+```
+
+### Output
+
+```
+CURSOR:
+{"type":"system","subtype":"init","apiKeySource":"login",...}
+                                    ↑
+                         Cursor indicator
+
+CLAUDE CLI:
+{"type":"system","subtype":"init",...,"tools":[...],"mcp_servers":[...]}
+                                        ↑
+                         Claude CLI indicator
+```
+
+---
+
+## Content Extraction Pattern
+
+Both formats use the same nested structure for content, but Claude CLI has additional metadata:
+
+```
+BOTH:
+.message.content[i].type = "text"
+.message.content[i].text = "hello"
+
+CLAUDE CLI ONLY:
+.message.usage.input_tokens
+.message.usage.output_tokens
+.message.stop_reason
+.message.id
+```
+
+### Unified Extractor
+
+```python
+def extract_text(content: List[Dict]) -> str:
+    """Extract text from content array (works for both formats)"""
+    texts = []
+    for item in content:
+        if item.get("type") == "text":
+            texts.append(item["text"])
+    return "".join(texts)
+```
+
+---
+
+## Common Pitfalls to Avoid
+
+### Pitfall 1: Assuming User Messages
+
+```python
+# ❌ WRONG
+messages = [m for m in stream if m["type"] == "user"]
+print(messages)  # Empty for Claude CLI!
+
+# ✅ CORRECT
+if source == "cursor":
+    user_messages = [m for m in stream if m["type"] == "user"]
+```
+
+### Pitfall 2: Model Field Comparison
+
+```python
+# ❌ WRONG
+if data["model"] == "claude-sonnet":
+    ...  # Fails for Cursor where model="Auto"
+
+# ✅ CORRECT
+model = data.get("model")
+if source == "cursor":
+    selection_mode = model
+elif source == "claude_cli":
+    actual_model = model
+```
+
+### Pitfall 3: Missing Optional Fields
+
+```python
+# ❌ WRONG
+cost = data["total_cost_usd"]  # KeyError for Cursor
+
+# ✅ CORRECT
+cost = data.get("total_cost_usd")  # Returns None for Cursor
+```
+
+### Pitfall 4: Timing Granularity
+
+```python
+# ❌ WRONG - Assumes they're equal
+api_time = data["duration_api_ms"]
+overhead = data["duration_ms"] - api_time  # Always 0 for Cursor
+
+# ✅ CORRECT
+total = data["duration_ms"]
+api = data.get("duration_api_ms", total)
+overhead = total - api
+```
+
+---
+
+## Test Vectors
+
+### Test Case: Cursor Full Flow
+
+```json
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"/Users/alexrockwell/dev/worktrees/emdx-cursorify","session_id":"472896b5-0079-411c-9c10-ec912453c2a4","model":"Auto","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"respond with just the word hello"}]},"session_id":"472896b5-0079-411c-9c10-ec912453c2a4"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"session_id":"472896b5-0079-411c-9c10-ec912453c2a4"}
+{"type":"result","subtype":"success","duration_ms":5182,"duration_api_ms":5182,"is_error":false,"result":"hello","session_id":"472896b5-0079-411c-9c10-ec912453c2a4","request_id":"7b570630-9840-4846-a38d-1d8ca60621da"}
+```
+
+### Test Case: Claude CLI Full Flow
+
+```json
+{"type":"system","subtype":"init","cwd":"/Users/alexrockwell/dev/worktrees/emdx-cursorify","session_id":"4318e3f4-0333-4e88-b253-fa0b89a7591a","tools":[...],"mcp_servers":[...],"model":"claude-sonnet-4-5-20250929","permissionMode":"default"}
+{"type":"assistant","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01SK5Tg5fgiQKQgQg8xCC2UE","type":"message","role":"assistant","content":[{"type":"text","text":"hello"}],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"output_tokens":1}}}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":2805,"duration_api_ms":2795,"num_turns":1,"result":"hello","session_id":"...","total_cost_usd":0.07933785,"usage":{"input_tokens":15,"output_tokens":1},"modelUsage":{...}}
+```
+
+---
+
+## Summary Table: What Each Format Includes
+
+| Aspect | Cursor | Claude CLI | Both |
+|--------|--------|-----------|------|
+| System init | ✓ (apiKeySource) | ✓ (tools, mcp) | session_id, cwd, model |
+| User messages | ✓ | ✗ | — |
+| Assistant response | ✓ (basic) | ✓ (rich metadata) | content |
+| Result message | ✓ (request_id) | ✓ (cost, tokens) | duration, is_error |
+| Token tracking | ✗ | ✓ | — |
+| Cost tracking | ✗ | ✓ | — |
+| Message IDs | ✗ | ✓ | session_id |
+| Stop reason | ✗ | ✓ | — |
+| Tool definitions | ✗ | ✓ | — |
+
+---
+
+## Next Steps
+
+1. **Implement the unified parser** using the strategies shown above
+2. **Create test fixtures** from the test vectors
+3. **Add source detection** to your CLI parser
+4. **Handle both formats** transparently in downstream processing
+5. **Log source** information for debugging
+6. **Monitor for schema changes** in future releases

--- a/docs/cursor-vs-claude-cli-json.md
+++ b/docs/cursor-vs-claude-cli-json.md
@@ -1,0 +1,348 @@
+# Cursor vs Claude CLI: JSON Output Format Analysis
+
+## Executive Summary
+
+Cursor and Claude CLI output JSON in NDJSON format (newline-delimited JSON). While they share core structural elements, they diverge significantly in:
+- **Metadata richness**: Claude CLI includes extensive usage/cost tracking; Cursor focuses on API source
+- **Message structure**: Claude CLI uses Anthropic's native message format; Cursor uses a simplified wrapper
+- **Timing data**: Both track duration, but Claude CLI separates API time from total time
+- **Parser compatibility**: A robust parser must handle both formats with conditional logic
+
+---
+
+## Detailed Comparison Table
+
+### 1. Common Fields (Work Identically)
+
+| Field | Both Contain | Example Value | Purpose |
+|-------|--------------|---------------|---------|
+| `type` | Yes | `"system"`, `"user"`, `"assistant"`, `"result"` | Message classification |
+| `session_id` | Yes | UUID string | Session tracking |
+| `cwd` | Yes (in `init`) | `/path/to/project` | Working directory |
+| `is_error` | Yes (in `result`) | `false` | Success indicator |
+| `duration_ms` | Yes (in `result`) | `5182` | Total elapsed time |
+
+---
+
+### 2. Fields Unique to Claude CLI
+
+| Field | Type | Example | Purpose | Requirement |
+|-------|------|---------|---------|-------------|
+| `tools` | Array (omitted) | `[...]` | Available tool definitions | Optional, extensive |
+| `mcp_servers` | Array (omitted) | `[...]` | MCP server configs | Optional, extensive |
+| `model` | String | `"claude-sonnet-4-5-20250929"` | Exact model identifier | Required in result |
+| `duration_api_ms` | Number | `2795` | API call duration only | In result |
+| `num_turns` | Number | `1` | Conversation turn count | In result |
+| `total_cost_usd` | Number | `0.07933785` | Token cost calculation | In result |
+| `usage` | Object | `{"input_tokens": ..., "output_tokens": ...}` | Token breakdown | In result |
+| `modelUsage` | Object | `{...}` | Model-specific metrics | In result (omitted in example) |
+| `id` (in assistant msg) | String | `"msg_01SK5Tg5fgiQKQgQg8xCC2UE"` | Anthropic message ID | In message |
+| `stop_reason` | String/Null | `null` | Why model stopped generating | In message |
+| `stop_sequence` | String/Null | `null` | Stop sequence matched | In message |
+
+---
+
+### 3. Fields Unique to Cursor
+
+| Field | Type | Example | Purpose | Requirement |
+|-------|------|---------|---------|-------------|
+| `subtype` | String | `"init"`, `"success"` | Event classification | In `system` and `result` |
+| `apiKeySource` | String | `"login"` | Auth method used | In `system/init` only |
+| `model` | String | `"Auto"` | Model selection mode | In `system/init` |
+| `permissionMode` | String | `"default"` | Permission level | In `system/init` |
+| `request_id` | String | UUID | Request correlation ID | In `result` |
+| `result` | Any | `"hello"` | Output value | In `result` only |
+
+---
+
+### 4. Same Field Name, Different Structure
+
+#### A. `model` Field
+
+**Cursor (system/init):**
+```json
+"model": "Auto"
+```
+- Represents user's model selection mode
+- Values: `"Auto"`, specific model name, or provider
+- Set once at session init
+
+**Claude CLI (system/init and result):**
+```json
+"model": "claude-sonnet-4-5-20250929"
+```
+- Represents actual model being used
+- Specific Anthropic model ID with timestamp
+- Can appear in multiple message types
+
+**Parser Impact:** Different semantic meaning despite same field name. Use context (`type`/`subtype`) to disambiguate.
+
+---
+
+#### B. `duration_api_ms` Field
+
+**Cursor (result only):**
+```json
+"duration_api_ms": 5182
+```
+- Equal to `duration_ms` (no distinction)
+- Entire operation is API-bound
+
+**Claude CLI (result only):**
+```json
+"duration_ms": 2805,
+"duration_api_ms": 2795
+```
+- Shows network/API latency separately
+- Total time includes I/O overhead, parsing, etc.
+- `duration_ms - duration_api_ms` = local processing time (10ms)
+
+**Parser Impact:** Claude CLI provides more granular timing. Cursor conflates them.
+
+---
+
+#### C. `message` Field Structure
+
+**Cursor (user/assistant):**
+```json
+{
+  "type": "user",
+  "message": {
+    "role": "user",
+    "content": [{"type": "text", "text": "..."}]
+  }
+}
+```
+
+**Claude CLI (assistant only):**
+```json
+{
+  "type": "assistant",
+  "message": {
+    "model": "claude-sonnet-4-5-20250929",
+    "id": "msg_01SK5Tg5fgiQKQgQg8xCC2UE",
+    "type": "message",
+    "role": "assistant",
+    "content": [...],
+    "stop_reason": null,
+    "stop_sequence": null,
+    "usage": {...}
+  }
+}
+```
+
+**Differences:**
+| Sub-field | Cursor | Claude CLI | Purpose |
+|-----------|--------|-----------|---------|
+| `role` | Yes | Yes | Common field |
+| `content` | Yes | Yes | Message body |
+| `model` | No | Yes | Which model responded |
+| `id` | No | Yes | Message ID (for tracing) |
+| `type` | No (redundant) | Yes | Message type indicator |
+| `stop_reason` | No | Yes | Why generation stopped |
+| `stop_sequence` | No | Yes | Sequence that triggered stop |
+| `usage` | No | Yes | Token metrics |
+
+**Parser Impact:** Claude CLI's message object is richer. Parser must handle optional fields.
+
+---
+
+## Parser Compatibility Matrix
+
+### Message Flow Differences
+
+```
+CURSOR                          CLAUDE CLI
+┌──────────────────┐            ┌──────────────────┐
+│ system/init      │            │ system/init      │
+│ (apiKeySource)   │            │ (tools, servers) │
+└──────────────────┘            └──────────────────┘
+         ↓                                ↓
+┌──────────────────┐            (no user message output)
+│ user             │
+│ (input echo)     │
+└──────────────────┘
+         ↓                                ↓
+┌──────────────────┐            ┌──────────────────┐
+│ assistant        │            │ assistant        │
+│ (simple content) │            │ (full metadata)  │
+└──────────────────┘            └──────────────────┘
+         ↓                                ↓
+┌──────────────────┐            ┌──────────────────┐
+│ result           │            │ result           │
+│ (request_id)     │            │ (total_cost_usd) │
+└──────────────────┘            └──────────────────┘
+```
+
+---
+
+## Compatibility Implications
+
+### Challenge 1: Model Field Ambiguity
+
+**Problem:**
+- Cursor: `"model": "Auto"` (user selection)
+- Claude CLI: `"model": "claude-sonnet-4-5-20250929"` (actual model)
+
+**Solution:**
+```python
+def parse_model(msg, source):
+    if source == "cursor":
+        # In init: selection mode
+        # In result: not present
+        return msg.get("model", "Auto")
+    else:  # claude_cli
+        # Always the actual model ID
+        return msg["model"]
+```
+
+---
+
+### Challenge 2: Timing Granularity
+
+**Problem:**
+- Cursor conflates `duration_api_ms` with `duration_ms`
+- Claude CLI separates API time from total time
+
+**Solution:**
+```python
+def parse_timing(result):
+    total = result["duration_ms"]
+    api = result.get("duration_api_ms", total)
+    overhead = total - api
+
+    return {
+        "total_ms": total,
+        "api_ms": api,
+        "overhead_ms": overhead
+    }
+```
+
+---
+
+### Challenge 3: Message Metadata
+
+**Problem:**
+- Claude CLI's message has optional fields that Cursor lacks
+- Different message routing (Cursor echoes user, Claude doesn't)
+
+**Solution:**
+```python
+def parse_assistant_message(msg):
+    content = msg.get("content", [])
+
+    metadata = {
+        "stop_reason": msg.get("stop_reason"),
+        "stop_sequence": msg.get("stop_sequence"),
+        "model": msg.get("model"),
+        "message_id": msg.get("id"),
+        "tokens_used": msg.get("usage", {})
+    }
+
+    return {
+        "content": extract_text(content),
+        "metadata": metadata
+    }
+```
+
+---
+
+### Challenge 4: Cost Tracking
+
+**Problem:**
+- Claude CLI includes `total_cost_usd` and detailed `usage`
+- Cursor has no cost tracking
+
+**Solution:**
+```python
+def extract_cost(result):
+    if "total_cost_usd" in result:
+        return {
+            "cost_usd": result["total_cost_usd"],
+            "input_tokens": result.get("usage", {}).get("input_tokens", 0),
+            "output_tokens": result.get("usage", {}).get("output_tokens", 0)
+        }
+    else:
+        return None  # Cursor has no cost info
+```
+
+---
+
+## Unified Parser Design
+
+```python
+class UnifiedParser:
+    def __init__(self, source: Literal["cursor", "claude_cli"]):
+        self.source = source
+
+    def parse_line(self, json_line: str) -> Message:
+        data = json.loads(json_line)
+        msg_type = data.get("type")
+
+        if msg_type == "system":
+            return self._parse_system(data)
+        elif msg_type == "user":
+            return self._parse_user(data)
+        elif msg_type == "assistant":
+            return self._parse_assistant(data)
+        elif msg_type == "result":
+            return self._parse_result(data)
+        else:
+            raise ValueError(f"Unknown message type: {msg_type}")
+
+    def _parse_system(self, data):
+        # Extract common: session_id, cwd, permissionMode
+        # Extract source-specific: apiKeySource (cursor), tools/mcp (cli)
+        pass
+
+    def _parse_assistant(self, data):
+        # Extract content (both have this)
+        # Extract metadata: model, stop_reason, usage (cli only)
+        pass
+
+    def _parse_result(self, data):
+        # Extract common: duration_ms, is_error
+        # Extract source-specific: request_id (cursor), cost (cli)
+        pass
+```
+
+---
+
+## Key Takeaways
+
+| Aspect | Cursor | Claude CLI | For Parsers |
+|--------|--------|-----------|------------|
+| **Format** | NDJSON | NDJSON | Same |
+| **Message flow** | 4 types (init, user, assistant, result) | 3-4 types (init, assistant, result) | User message differs |
+| **Metadata** | Minimal | Rich (tokens, costs, IDs) | Must handle optional fields |
+| **Timing** | Conflated | Separated | Use `.get()` for optional |
+| **Model info** | Selection mode in init | Actual model ID throughout | Context-aware parsing |
+| **Error handling** | Basic (`is_error`) | Basic (`is_error`) | Same |
+| **Future compatibility** | May add more fields | Likely to expand | Plan for extensibility |
+
+---
+
+## Recommended Parser Strategy
+
+1. **Detect source** from first message (presence of `apiKeySource` = Cursor, presence of `tools` = Claude CLI)
+2. **Use source-aware parsing** with conditional field extraction
+3. **Build schema** that accepts both formats without loss
+4. **Handle optional fields** gracefully with `.get()` and defaults
+5. **Test against both** formats in CI/CD to catch regressions
+6. **Document assumptions** about field presence/absence per source
+
+---
+
+## Implementation Checklist
+
+- [ ] Detect source reliably (first message analysis)
+- [ ] Parse system/init (both sources)
+- [ ] Parse user (Cursor only)
+- [ ] Parse assistant (handle metadata differences)
+- [ ] Parse result (handle timing and cost differences)
+- [ ] Extract text content from nested structure
+- [ ] Convert to canonical format (for uniform downstream processing)
+- [ ] Handle missing optional fields
+- [ ] Add logging for debugging mismatches
+- [ ] Unit test both formats
+- [ ] Integration test with real CLI output

--- a/docs/cursor-vs-claude-cli-parser.md
+++ b/docs/cursor-vs-claude-cli-parser.md
@@ -1,0 +1,581 @@
+# Unified Parser Implementation: Cursor vs Claude CLI
+
+A practical guide to building a robust NDJSON parser that handles both Cursor and Claude CLI output formats.
+
+---
+
+## Overview
+
+```
+Cursor NDJSON Stream
+        ↓
+    Unified Parser ← Auto-detect source
+        ↓
+  Canonical Format
+        ↓
+  Downstream Processing
+```
+
+---
+
+## Complete Implementation
+
+### 1. Data Models
+
+```python
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Literal
+from enum import Enum
+
+class MessageType(str, Enum):
+    SYSTEM = "system"
+    USER = "user"
+    ASSISTANT = "assistant"
+    RESULT = "result"
+
+class Source(str, Enum):
+    CURSOR = "cursor"
+    CLAUDE_CLI = "claude_cli"
+
+@dataclass
+class SystemMessage:
+    """Initialization message - varies by source"""
+    session_id: str
+    cwd: str
+    model: str
+    permission_mode: str
+    source: Source
+
+    # Cursor-only
+    api_key_source: Optional[str] = None
+
+    # Claude CLI-only
+    tools: Optional[List[Dict]] = None
+    mcp_servers: Optional[List[Dict]] = None
+
+    def __str__(self):
+        return f"System init: {self.source.value} / {self.model}"
+
+@dataclass
+class UserMessage:
+    """User input - Cursor only"""
+    text: str
+    session_id: str
+
+    def __str__(self):
+        return f"User: {self.text[:50]}..."
+
+@dataclass
+class AssistantMessage:
+    """AI response - both formats, different metadata"""
+    content: str
+    session_id: str
+
+    # Claude CLI only
+    model: Optional[str] = None
+    message_id: Optional[str] = None
+    stop_reason: Optional[str] = None
+    stop_sequence: Optional[str] = None
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+
+    def __str__(self):
+        tokens = ""
+        if self.input_tokens is not None:
+            tokens = f" [{self.input_tokens}i/{self.output_tokens}o tokens]"
+        return f"Assistant: {self.content[:50]}...{tokens}"
+
+@dataclass
+class ResultMessage:
+    """Execution result - both formats, different metrics"""
+    is_error: bool
+    duration_ms: int
+    session_id: str
+
+    # Both have this field, but different semantics
+    result: Optional[Any] = None
+
+    # Common but separated
+    api_duration_ms: Optional[int] = None
+
+    # Calculated
+    overhead_ms: int = 0
+
+    # Cursor-only
+    request_id: Optional[str] = None
+
+    # Claude CLI-only
+    num_turns: Optional[int] = None
+    cost_usd: Optional[float] = None
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+
+    def __str__(self):
+        if self.is_error:
+            return f"Result: ERROR in {self.duration_ms}ms"
+        status = f"{self.duration_ms}ms"
+        if self.cost_usd:
+            status += f" (${self.cost_usd:.6f})"
+        return f"Result: Success in {status}"
+
+# Union type for convenience
+Message = SystemMessage | UserMessage | AssistantMessage | ResultMessage
+```
+
+---
+
+### 2. Source Detection
+
+```python
+import json
+
+class SourceDetector:
+    """Detect whether a stream is from Cursor or Claude CLI"""
+
+    @staticmethod
+    def detect(first_json_line: str) -> Source:
+        """
+        Detect source from first message in stream.
+
+        Args:
+            first_json_line: First complete JSON line from stream
+
+        Returns:
+            Source.CURSOR or Source.CLAUDE_CLI
+
+        Raises:
+            ValueError: If source cannot be determined
+        """
+        try:
+            data = json.loads(first_json_line)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON: {e}")
+
+        if data.get("type") != "system":
+            raise ValueError("First message must be 'system' type")
+
+        # Cursor-specific field
+        if "apiKeySource" in data:
+            return Source.CURSOR
+
+        # Claude CLI-specific fields
+        if "tools" in data or "mcp_servers" in data:
+            return Source.CLAUDE_CLI
+
+        raise ValueError(
+            "Cannot determine source: missing identifying fields. "
+            "Expected 'apiKeySource' (Cursor) or 'tools'/'mcp_servers' (Claude CLI)"
+        )
+
+    @staticmethod
+    def explain(source: Source) -> str:
+        """Explain which fields indicated the source"""
+        if source == Source.CURSOR:
+            return "Cursor detected via 'apiKeySource' field in system init"
+        else:
+            return "Claude CLI detected via 'tools' or 'mcp_servers' fields"
+```
+
+---
+
+### 3. Parser Implementation
+
+```python
+import logging
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+class UnifiedNDJSONParser:
+    """
+    Parse NDJSON from both Cursor and Claude CLI, normalizing to canonical format.
+
+    Usage:
+        with open("output.ndjson") as f:
+            parser = UnifiedNDJSONParser(auto_detect=True)
+            for message in parser.parse_stream(f):
+                print(message)
+    """
+
+    def __init__(self, source: Optional[Source] = None, auto_detect: bool = True):
+        """
+        Initialize parser.
+
+        Args:
+            source: Source format (auto-detected if None)
+            auto_detect: If True, detect source from first message
+        """
+        self.source = source
+        self.auto_detect = auto_detect
+        self._source_detected = False
+
+    def parse_stream(self, stream) -> Iterator[Message]:
+        """
+        Parse NDJSON stream and yield normalized messages.
+
+        Args:
+            stream: File-like object or iterator of lines
+
+        Yields:
+            Message objects (System, User, Assistant, or Result)
+        """
+        lines = stream if isinstance(stream, list) else stream.readlines()
+
+        for line_no, line in enumerate(lines, 1):
+            line = line.strip()
+
+            if not line:
+                continue
+
+            try:
+                data = json.loads(line)
+
+                # Auto-detect source on first message
+                if not self._source_detected and self.auto_detect:
+                    if data.get("type") == "system":
+                        self.source = SourceDetector.detect(line)
+                        self._source_detected = True
+                        logger.info(f"Detected source: {self.source.value}")
+                        logger.debug(SourceDetector.explain(self.source))
+
+                message = self._parse_message(data, line_no)
+                if message:
+                    yield message
+
+            except json.JSONDecodeError as e:
+                logger.warning(f"Line {line_no}: Invalid JSON: {e}")
+                continue
+            except (KeyError, TypeError) as e:
+                logger.warning(f"Line {line_no}: Parsing error: {e}")
+                continue
+
+    def _parse_message(self, data: Dict, line_no: int) -> Optional[Message]:
+        """Parse individual JSON object to Message"""
+        msg_type = data.get("type")
+
+        if msg_type == "system":
+            return self._parse_system(data)
+        elif msg_type == "user":
+            return self._parse_user(data)
+        elif msg_type == "assistant":
+            return self._parse_assistant(data)
+        elif msg_type == "result":
+            return self._parse_result(data)
+        else:
+            logger.warning(f"Unknown message type: {msg_type}")
+            return None
+
+    def _parse_system(self, data: Dict) -> SystemMessage:
+        """Parse system initialization message"""
+        msg = SystemMessage(
+            session_id=data["session_id"],
+            cwd=data["cwd"],
+            model=data.get("model", "unknown"),
+            permission_mode=data.get("permissionMode", "default"),
+            source=self.source or Source.CURSOR,  # Default to Cursor if not detected
+            api_key_source=data.get("apiKeySource"),
+            tools=data.get("tools"),
+            mcp_servers=data.get("mcp_servers"),
+        )
+        logger.debug(f"Parsed system message: {msg}")
+        return msg
+
+    def _parse_user(self, data: Dict) -> UserMessage:
+        """Parse user input message (Cursor only)"""
+        message_obj = data.get("message", {})
+        content = message_obj.get("content", [])
+        text = self._extract_text(content)
+
+        msg = UserMessage(
+            text=text,
+            session_id=data["session_id"],
+        )
+        logger.debug(f"Parsed user message: {msg}")
+        return msg
+
+    def _parse_assistant(self, data: Dict) -> AssistantMessage:
+        """Parse assistant response message"""
+        message_obj = data.get("message", {})
+        content = message_obj.get("content", [])
+        text = self._extract_text(content)
+
+        usage = message_obj.get("usage", {})
+
+        msg = AssistantMessage(
+            content=text,
+            session_id=data["session_id"],
+            model=message_obj.get("model"),
+            message_id=message_obj.get("id"),
+            stop_reason=message_obj.get("stop_reason"),
+            stop_sequence=message_obj.get("stop_sequence"),
+            input_tokens=usage.get("input_tokens"),
+            output_tokens=usage.get("output_tokens"),
+        )
+        logger.debug(f"Parsed assistant message: {msg}")
+        return msg
+
+    def _parse_result(self, data: Dict) -> ResultMessage:
+        """Parse result/completion message"""
+        total_ms = data["duration_ms"]
+        api_ms = data.get("duration_api_ms", total_ms)
+
+        msg = ResultMessage(
+            is_error=data.get("is_error", False),
+            duration_ms=total_ms,
+            api_duration_ms=api_ms,
+            overhead_ms=total_ms - api_ms,
+            session_id=data["session_id"],
+            result=data.get("result"),
+            request_id=data.get("request_id"),  # Cursor
+            num_turns=data.get("num_turns"),  # Claude CLI
+            cost_usd=data.get("total_cost_usd"),  # Claude CLI
+            input_tokens=data.get("usage", {}).get("input_tokens"),  # Claude CLI
+            output_tokens=data.get("usage", {}).get("output_tokens"),  # Claude CLI
+        )
+        logger.debug(f"Parsed result message: {msg}")
+        return msg
+
+    @staticmethod
+    def _extract_text(content: List[Dict]) -> str:
+        """Extract text from content array (works for both formats)"""
+        texts = []
+        for item in content:
+            if item.get("type") == "text":
+                texts.append(item.get("text", ""))
+        return "".join(texts)
+```
+
+---
+
+### 4. Usage Examples
+
+#### Example 1: Parse Cursor Output
+
+```python
+cursor_output = """{"type":"system","subtype":"init","apiKeySource":"login","cwd":"/Users/alexrockwell/dev/worktrees/emdx-cursorify","session_id":"472896b5-0079-411c-9c10-ec912453c2a4","model":"Auto","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"respond with just the word hello"}]},"session_id":"472896b5-0079-411c-9c10-ec912453c2a4"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"session_id":"472896b5-0079-411c-9c10-ec912453c2a4"}
+{"type":"result","subtype":"success","duration_ms":5182,"duration_api_ms":5182,"is_error":false,"result":"hello","session_id":"472896b5-0079-411c-9c10-ec912453c2a4","request_id":"7b570630-9840-4846-a38d-1d8ca60621da"}"""
+
+parser = UnifiedNDJSONParser()
+messages = list(parser.parse_stream(cursor_output.split("\n")))
+
+assert len(messages) == 4
+assert isinstance(messages[0], SystemMessage)
+assert messages[0].source == Source.CURSOR
+assert isinstance(messages[1], UserMessage)
+assert messages[1].text == "respond with just the word hello"
+assert isinstance(messages[2], AssistantMessage)
+assert messages[2].content == "hello"
+assert isinstance(messages[3], ResultMessage)
+assert messages[3].request_id is not None
+assert messages[3].cost_usd is None  # Cursor doesn't have this
+```
+
+#### Example 2: Parse Claude CLI Output
+
+```python
+claude_output = """{"type":"system","subtype":"init","cwd":"/path","session_id":"abc123","tools":[],"mcp_servers":[],"model":"claude-sonnet-4-5-20250929","permissionMode":"default"}
+{"type":"assistant","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_xyz","type":"message","role":"assistant","content":[{"type":"text","text":"hello"}],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"output_tokens":1}}}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":2805,"duration_api_ms":2795,"num_turns":1,"result":"hello","session_id":"abc123","total_cost_usd":0.07933785,"usage":{"input_tokens":15,"output_tokens":1}}"""
+
+parser = UnifiedNDJSONParser()
+messages = list(parser.parse_stream(claude_output.split("\n")))
+
+assert len(messages) == 3  # No user message
+assert isinstance(messages[0], SystemMessage)
+assert messages[0].source == Source.CLAUDE_CLI
+assert messages[0].tools == []  # Claude CLI specific
+assert isinstance(messages[1], AssistantMessage)
+assert messages[1].input_tokens == 15  # Claude CLI specific
+assert isinstance(messages[2], ResultMessage)
+assert messages[2].cost_usd == 0.07933785  # Claude CLI specific
+assert messages[2].overhead_ms == 10  # 2805 - 2795
+```
+
+#### Example 3: File Processing
+
+```python
+import sys
+
+def process_ndjson_file(filepath: str):
+    """Process NDJSON file from either Cursor or Claude CLI"""
+
+    parser = UnifiedNDJSONParser(auto_detect=True)
+
+    with open(filepath) as f:
+        for message in parser.parse_stream(f):
+            print(f"[{type(message).__name__}] {message}")
+
+            # Source-specific logic
+            if isinstance(message, ResultMessage):
+                if parser.source == Source.CURSOR:
+                    print(f"  Request ID: {message.request_id}")
+                else:
+                    print(f"  Cost: ${message.cost_usd:.6f}")
+                    print(f"  Tokens: {message.input_tokens}i / {message.output_tokens}o")
+
+# Usage
+if __name__ == "__main__":
+    process_ndjson_file(sys.argv[1])
+```
+
+---
+
+### 5. Advanced: Streaming with Callbacks
+
+```python
+from typing import Callable
+
+class StreamProcessor:
+    """Process stream with callbacks for different message types"""
+
+    def __init__(
+        self,
+        on_system: Optional[Callable[[SystemMessage], None]] = None,
+        on_user: Optional[Callable[[UserMessage], None]] = None,
+        on_assistant: Optional[Callable[[AssistantMessage], None]] = None,
+        on_result: Optional[Callable[[ResultMessage], None]] = None,
+    ):
+        self.on_system = on_system
+        self.on_user = on_user
+        self.on_assistant = on_assistant
+        self.on_result = on_result
+
+    def process(self, stream) -> Dict[str, int]:
+        """Process stream, calling appropriate callbacks"""
+        parser = UnifiedNDJSONParser(auto_detect=True)
+        counts = {"system": 0, "user": 0, "assistant": 0, "result": 0}
+
+        for message in parser.parse_stream(stream):
+            if isinstance(message, SystemMessage):
+                counts["system"] += 1
+                if self.on_system:
+                    self.on_system(message)
+
+            elif isinstance(message, UserMessage):
+                counts["user"] += 1
+                if self.on_user:
+                    self.on_user(message)
+
+            elif isinstance(message, AssistantMessage):
+                counts["assistant"] += 1
+                if self.on_assistant:
+                    self.on_assistant(message)
+
+            elif isinstance(message, ResultMessage):
+                counts["result"] += 1
+                if self.on_result:
+                    self.on_result(message)
+
+        return counts
+
+# Usage
+def main():
+    def on_result(msg: ResultMessage):
+        if msg.source == Source.CLAUDE_CLI:
+            total_cost = msg.cost_usd or 0
+            print(f"✓ Completed in {msg.duration_ms}ms for ${total_cost:.6f}")
+        else:
+            print(f"✓ Completed in {msg.duration_ms}ms")
+
+    processor = StreamProcessor(on_result=on_result)
+
+    with open("output.ndjson") as f:
+        counts = processor.process(f)
+
+    print(f"Processed: {counts}")
+```
+
+---
+
+### 6. Testing
+
+```python
+import unittest
+from io import StringIO
+
+class TestUnifiedParser(unittest.TestCase):
+    def test_cursor_detection(self):
+        cursor_init = '{"type":"system","apiKeySource":"login","session_id":"123","cwd":"/tmp","model":"Auto","permissionMode":"default"}'
+        source = SourceDetector.detect(cursor_init)
+        self.assertEqual(source, Source.CURSOR)
+
+    def test_claude_cli_detection(self):
+        claude_init = '{"type":"system","tools":[],"session_id":"123","cwd":"/tmp","model":"claude-sonnet","permissionMode":"default"}'
+        source = SourceDetector.detect(claude_init)
+        self.assertEqual(source, Source.CLAUDE_CLI)
+
+    def test_parse_cursor_full(self):
+        lines = [
+            '{"type":"system","subtype":"init","apiKeySource":"login","session_id":"123","cwd":"/tmp","model":"Auto","permissionMode":"default"}',
+            '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]},"session_id":"123"}',
+            '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"session_id":"123"}',
+            '{"type":"result","subtype":"success","duration_ms":1000,"duration_api_ms":1000,"is_error":false,"result":"hello","session_id":"123","request_id":"req123"}',
+        ]
+
+        parser = UnifiedNDJSONParser()
+        messages = list(parser.parse_stream(lines))
+
+        self.assertEqual(len(messages), 4)
+        self.assertIsInstance(messages[0], SystemMessage)
+        self.assertIsInstance(messages[1], UserMessage)
+        self.assertIsInstance(messages[2], AssistantMessage)
+        self.assertIsInstance(messages[3], ResultMessage)
+
+    def test_parse_claude_full(self):
+        lines = [
+            '{"type":"system","tools":[],"mcp_servers":[],"session_id":"123","cwd":"/tmp","model":"claude-sonnet-4-5","permissionMode":"default"}',
+            '{"type":"assistant","message":{"model":"claude-sonnet","id":"msg123","type":"message","role":"assistant","content":[{"type":"text","text":"hello"}],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":5}}}',
+            '{"type":"result","duration_ms":2000,"duration_api_ms":1900,"num_turns":1,"is_error":false,"result":"hello","session_id":"123","total_cost_usd":0.001,"usage":{"input_tokens":10,"output_tokens":5}}',
+        ]
+
+        parser = UnifiedNDJSONParser()
+        messages = list(parser.parse_stream(lines))
+
+        self.assertEqual(len(messages), 3)
+        self.assertIsNone(messages[1].stop_reason)  # null → None
+        self.assertEqual(messages[1].input_tokens, 10)
+        self.assertEqual(messages[2].overhead_ms, 100)  # 2000 - 1900
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+---
+
+## Integration Checklist
+
+- [ ] Import parser module in your CLI code
+- [ ] Detect source format on first message
+- [ ] Store detected source for source-aware processing
+- [ ] Handle Cursor's user messages (skip for Claude CLI)
+- [ ] Extract token costs from Claude CLI results
+- [ ] Calculate timing overhead (total - api)
+- [ ] Log source type and format info
+- [ ] Add comprehensive error handling
+- [ ] Write unit tests for both formats
+- [ ] Test with real output from both CLIs
+- [ ] Document source-specific behavior for users
+
+---
+
+## Performance Characteristics
+
+| Operation | Time | Memory |
+|-----------|------|--------|
+| Detect source | <1ms | Minimal |
+| Parse 100 lines | ~5ms | ~1MB |
+| Extract text | <1ms | Variable (content size) |
+| Full stream processing | Linear in lines | Streaming (no buffering) |
+
+---
+
+## Future Considerations
+
+1. **Schema versioning**: Monitor for changes in both formats
+2. **Streaming optimization**: Use generators for large files
+3. **Error recovery**: Continue parsing after malformed lines
+4. **Logging**: Track which format is encountered for analytics
+5. **Extensions**: Add hooks for custom message handlers
+6. **Caching**: Cache parsed messages if needed for multiple passes

--- a/emdx/commands/agent.py
+++ b/emdx/commands/agent.py
@@ -1,4 +1,4 @@
-"""Run a Claude Code sub-agent with EMDX tracking."""
+"""Run a CLI agent sub-process with EMDX tracking."""
 
 from pathlib import Path
 from typing import List, Optional
@@ -41,8 +41,26 @@ def agent(
         300, "--timeout",
         help="Timeout in seconds (default 5 minutes)"
     ),
+    cli_tool: str = typer.Option(
+        "claude",
+        "--cli", "-C",
+        help="CLI tool to use: claude or cursor",
+    ),
+    model: str = typer.Option(
+        None,
+        "--model", "-m",
+        help="Model to use (overrides CLI default)",
+    ),
 ):
-    """Run a Claude Code sub-agent with automatic EMDX tracking."""
+    """Run a CLI agent sub-process with automatic EMDX tracking.
+
+    Supports both Claude Code and Cursor Agent CLIs.
+
+    Examples:
+        emdx agent "analyze the auth module" --tags analysis
+        emdx agent --cli cursor "analyze the auth module"
+        emdx agent --cli cursor --model auto "quick task"
+    """
     # Flatten tags (handle both comma-separated and multiple -t flags)
     flat_tags = []
     if tags:
@@ -88,7 +106,13 @@ After saving your output, if you made any code changes, create a pull request:
         output_instruction=output_instruction,
         working_dir=str(Path.cwd()),
         timeout_seconds=timeout,
+        cli_tool=cli_tool,
+        model=model,
+        verbose=verbose,
     )
+
+    cli_name = "Cursor" if cli_tool == "cursor" else "Claude"
+    console.print(f"[dim]Using {cli_name}[/dim]")
 
     result = UnifiedExecutor().execute(config)
 

--- a/emdx/commands/workflows.py
+++ b/emdx/commands/workflows.py
@@ -279,6 +279,16 @@ def run_workflow(
         "--max-concurrent",
         help="Override max concurrent executions for parallel/dynamic stages",
     ),
+    cli_tool: str = typer.Option(
+        "claude",
+        "--cli", "-C",
+        help="CLI tool to use: claude or cursor",
+    ),
+    model: Optional[str] = typer.Option(
+        None,
+        "--model", "-m",
+        help="Model to use (overrides CLI default)",
+    ),
 ):
     """Run a workflow.
 
@@ -309,6 +319,12 @@ def run_workflow(
 
         # Save current run variables as a new preset
         emdx workflow run task_parallel -t "Review code" --var topic=Performance --save-as perf_review
+
+        # Use Cursor instead of Claude
+        emdx workflow run task_parallel -t "Analyze code" --cli cursor
+
+        # Specify a model
+        emdx workflow run task_parallel -t "Quick task" --cli cursor --model auto
     """
     worktree_path = None
 
@@ -363,11 +379,18 @@ def run_workflow(
             variables['_max_concurrent_override'] = max_concurrent
         variables['base_branch'] = base_branch
 
+        # Pass CLI tool and model to workflow
+        if cli_tool != "claude":
+            variables["_cli_tool"] = cli_tool
+        if model:
+            variables["_model"] = model
+
         # Store title in input_variables (used by Activity view)
         if title:
             variables['task_title'] = title
 
-        console.print(f"[cyan]Starting workflow:[/cyan] {workflow.display_name}")
+        cli_name = "Cursor" if cli_tool == "cursor" else "Claude"
+        console.print(f"[cyan]Starting workflow:[/cyan] {workflow.display_name} (using {cli_name})")
         if title:
             console.print(f"  Title: {title}")
         console.print(f"  Stages: {len(workflow.stages)}")

--- a/emdx/config/cli_config.py
+++ b/emdx/config/cli_config.py
@@ -1,0 +1,173 @@
+"""CLI tool configuration for EMDX execution system.
+
+This module defines configurations for different CLI tools (Claude, Cursor)
+that can be used to execute agent tasks.
+"""
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional
+
+
+class CliTool(str, Enum):
+    """Supported CLI tools."""
+
+    CLAUDE = "claude"
+    CURSOR = "cursor"
+
+
+@dataclass
+class CliConfig:
+    """Configuration for a CLI tool."""
+
+    # Command structure
+    binary: List[str]  # e.g., ["claude"] or ["cursor", "agent"]
+    prompt_flag: str  # e.g., "--print" or "-p"
+    prompt_is_positional: bool  # True if prompt goes at end (Cursor)
+
+    # Output format
+    output_format_flag: str  # "--output-format"
+    default_output_format: str  # "stream-json" or "text"
+    requires_verbose_for_stream: bool  # Claude needs --verbose for stream-json
+
+    # Model configuration
+    model_flag: str  # "--model"
+    default_model: str  # Default model for this CLI
+
+    # Tool control
+    supports_allowed_tools: bool  # Claude has --allowedTools
+    allowed_tools_flag: Optional[str]  # "--allowedTools"
+    force_flag: Optional[str]  # Cursor uses "--force"
+
+    # Workspace
+    workspace_flag: Optional[str]  # Cursor has "--workspace"
+
+    # Environment
+    config_path: Optional[str]  # Path to CLI config file
+    api_key_env: Optional[str]  # Environment variable for API key
+
+
+# CLI configurations
+CLI_CONFIGS: Dict[CliTool, CliConfig] = {
+    CliTool.CLAUDE: CliConfig(
+        binary=["claude"],
+        prompt_flag="--print",
+        prompt_is_positional=False,
+        output_format_flag="--output-format",
+        default_output_format="stream-json",
+        requires_verbose_for_stream=True,
+        model_flag="--model",
+        default_model="claude-opus-4-5-20251101",
+        supports_allowed_tools=True,
+        allowed_tools_flag="--allowedTools",
+        force_flag=None,
+        workspace_flag=None,
+        config_path="~/.claude/claude_cli.json",
+        api_key_env="ANTHROPIC_API_KEY",
+    ),
+    CliTool.CURSOR: CliConfig(
+        binary=["cursor", "agent"],
+        prompt_flag="-p",
+        prompt_is_positional=True,
+        output_format_flag="--output-format",
+        default_output_format="stream-json",
+        requires_verbose_for_stream=False,
+        model_flag="--model",
+        default_model="auto",
+        supports_allowed_tools=False,
+        allowed_tools_flag=None,
+        force_flag="--force",
+        workspace_flag="--workspace",
+        config_path=None,
+        api_key_env="CURSOR_API_KEY",
+    ),
+}
+
+# Model aliases for cross-CLI compatibility
+# Use these aliases for portable commands that work with either CLI
+MODEL_ALIASES: Dict[str, Dict[str, str]] = {
+    "opus": {
+        "claude": "claude-opus-4-5-20251101",
+        "cursor": "opus-4.5",
+    },
+    "sonnet": {
+        "claude": "claude-sonnet-4-5-20250929",
+        "cursor": "sonnet-4.5",
+    },
+    "auto": {
+        "claude": "claude-sonnet-4-5-20250929",
+        "cursor": "auto",
+    },
+    "fast": {
+        "claude": "claude-sonnet-4-5-20250929",
+        "cursor": "auto",
+    },
+}
+
+
+def get_default_cli_tool() -> CliTool:
+    """Get the default CLI tool from environment or fallback to Claude.
+
+    Checks EMDX_CLI_TOOL environment variable first.
+    """
+    env_value = os.environ.get("EMDX_CLI_TOOL", "claude").lower()
+    try:
+        return CliTool(env_value)
+    except ValueError:
+        return CliTool.CLAUDE
+
+
+def get_cli_config(cli_tool: Optional[CliTool] = None) -> CliConfig:
+    """Get configuration for a CLI tool.
+
+    Args:
+        cli_tool: The CLI tool to get config for. If None, uses default.
+
+    Returns:
+        CliConfig for the specified tool.
+    """
+    if cli_tool is None:
+        cli_tool = get_default_cli_tool()
+    return CLI_CONFIGS[cli_tool]
+
+
+def resolve_model_alias(alias: str, cli_tool: CliTool) -> str:
+    """Resolve a model alias to the actual model name for a CLI.
+
+    Args:
+        alias: Model alias (e.g., "opus", "sonnet", "auto")
+        cli_tool: Target CLI tool
+
+    Returns:
+        Actual model name for the CLI, or the alias if not found.
+    """
+    if alias in MODEL_ALIASES:
+        return MODEL_ALIASES[alias].get(cli_tool.value, alias)
+    return alias
+
+
+def get_available_models(cli_tool: CliTool) -> List[str]:
+    """Get list of known models for a CLI tool.
+
+    Returns:
+        List of model names/aliases available for the CLI.
+    """
+    if cli_tool == CliTool.CLAUDE:
+        return [
+            "claude-opus-4-5-20251101",
+            "claude-sonnet-4-5-20250929",
+            "opus",
+            "sonnet",
+        ]
+    elif cli_tool == CliTool.CURSOR:
+        return [
+            "auto",
+            "opus-4.5",
+            "opus-4.5-thinking",
+            "sonnet-4.5",
+            "sonnet-4.5-thinking",
+            "gpt-5.2",
+            "gemini-3-pro",
+        ]
+    return []

--- a/emdx/services/cli_executor/__init__.py
+++ b/emdx/services/cli_executor/__init__.py
@@ -1,0 +1,15 @@
+"""CLI executor package for EMDX.
+
+This package provides a strategy pattern implementation for different CLI tools
+(Claude, Cursor) that can execute agent tasks.
+"""
+
+from .base import CliCommand, CliExecutor, CliResult
+from .factory import get_cli_executor
+
+__all__ = [
+    "CliCommand",
+    "CliExecutor",
+    "CliResult",
+    "get_cli_executor",
+]

--- a/emdx/services/cli_executor/base.py
+++ b/emdx/services/cli_executor/base.py
@@ -1,0 +1,159 @@
+"""Base class for CLI executors.
+
+This module defines the abstract interface that all CLI executors must implement.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class CliCommand:
+    """Represents a CLI command to execute."""
+
+    args: List[str]  # Command arguments
+    env: Dict[str, str] = field(default_factory=dict)  # Additional env vars
+    cwd: Optional[str] = None  # Working directory
+
+
+@dataclass
+class CliResult:
+    """Result from CLI execution."""
+
+    success: bool
+    output: str
+    error: Optional[str] = None
+    exit_code: int = 0
+
+    # Token usage (may be unavailable for some CLIs)
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_create_tokens: int = 0
+
+    # Cost (Claude only)
+    cost_usd: float = 0.0
+
+    # Timing
+    duration_ms: int = 0
+    duration_api_ms: int = 0
+
+    # Session tracking
+    session_id: Optional[str] = None
+
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens used including cache."""
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_read_tokens
+            + self.cache_create_tokens
+        )
+
+
+class CliExecutor(ABC):
+    """Abstract base class for CLI executors.
+
+    Each CLI tool (Claude, Cursor) implements this interface to provide
+    tool-specific command building and output parsing.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable name of this executor."""
+        pass
+
+    @abstractmethod
+    def build_command(
+        self,
+        prompt: str,
+        model: Optional[str] = None,
+        allowed_tools: Optional[List[str]] = None,
+        output_format: str = "stream-json",
+        working_dir: Optional[str] = None,
+        timeout: Optional[int] = None,
+    ) -> CliCommand:
+        """Build the CLI command to execute.
+
+        Args:
+            prompt: The task/prompt to execute
+            model: Model to use (None = default)
+            allowed_tools: List of allowed tools (may be ignored by some CLIs)
+            output_format: Output format ("text", "stream-json", "json")
+            working_dir: Working directory for execution
+            timeout: Timeout in seconds (optional)
+
+        Returns:
+            CliCommand with args, env, and cwd
+        """
+        pass
+
+    @abstractmethod
+    def parse_output(
+        self,
+        stdout: str,
+        stderr: str,
+        exit_code: int,
+    ) -> CliResult:
+        """Parse CLI output into structured result.
+
+        Args:
+            stdout: Standard output from the CLI
+            stderr: Standard error from the CLI
+            exit_code: Process exit code
+
+        Returns:
+            CliResult with parsed output and metrics
+        """
+        pass
+
+    @abstractmethod
+    def parse_stream_line(self, line: str) -> Optional[Dict[str, Any]]:
+        """Parse a single line from stream-json output.
+
+        Args:
+            line: A single JSON line from the stream
+
+        Returns:
+            Parsed dict or None if line should be skipped
+        """
+        pass
+
+    @abstractmethod
+    def validate_environment(self) -> tuple[bool, Dict[str, Any]]:
+        """Validate that the CLI is properly installed and configured.
+
+        Returns:
+            Tuple of (is_valid, info_dict with details/errors)
+        """
+        pass
+
+    @abstractmethod
+    def get_binary_path(self) -> Optional[str]:
+        """Get the path to the CLI binary.
+
+        Returns:
+            Path to the binary or None if not found
+        """
+        pass
+
+    def extract_text_content(self, content: List[Dict[str, Any]]) -> str:
+        """Extract text from message content array.
+
+        This is common to both Claude and Cursor formats.
+
+        Args:
+            content: List of content items with type and text fields
+
+        Returns:
+            Concatenated text content
+        """
+        return "".join(
+            item.get("text", "")
+            for item in content
+            if item.get("type") == "text"
+        )

--- a/emdx/services/cli_executor/claude.py
+++ b/emdx/services/cli_executor/claude.py
@@ -1,0 +1,217 @@
+"""Claude CLI executor implementation."""
+
+import json
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ...config.cli_config import CLI_CONFIGS, CliTool, resolve_model_alias
+from .base import CliCommand, CliExecutor, CliResult
+
+logger = logging.getLogger(__name__)
+
+
+class ClaudeCliExecutor(CliExecutor):
+    """Executor for Claude Code CLI."""
+
+    def __init__(self):
+        self.config = CLI_CONFIGS[CliTool.CLAUDE]
+
+    @property
+    def name(self) -> str:
+        return "Claude Code"
+
+    def build_command(
+        self,
+        prompt: str,
+        model: Optional[str] = None,
+        allowed_tools: Optional[List[str]] = None,
+        output_format: str = "stream-json",
+        working_dir: Optional[str] = None,
+        timeout: Optional[int] = None,
+    ) -> CliCommand:
+        """Build Claude CLI command.
+
+        Claude command format:
+            claude --print "prompt" --model <model> --output-format <format> [--verbose] [--allowedTools X,Y,Z]
+        """
+        # Start with binary
+        cmd = list(self.config.binary)
+
+        # Add prompt flag and prompt (not positional for Claude)
+        cmd.extend([self.config.prompt_flag, prompt])
+
+        # Add model
+        resolved_model = resolve_model_alias(
+            model or self.config.default_model, CliTool.CLAUDE
+        )
+        cmd.extend([self.config.model_flag, resolved_model])
+
+        # Add output format
+        cmd.extend([self.config.output_format_flag, output_format])
+
+        # Claude requires --verbose for stream-json output
+        if self.config.requires_verbose_for_stream and output_format == "stream-json":
+            cmd.append("--verbose")
+
+        # Add allowed tools if supported and provided
+        if allowed_tools and self.config.supports_allowed_tools:
+            cmd.extend([self.config.allowed_tools_flag, ",".join(allowed_tools)])
+
+        return CliCommand(args=cmd, cwd=working_dir)
+
+    def parse_output(
+        self,
+        stdout: str,
+        stderr: str,
+        exit_code: int,
+    ) -> CliResult:
+        """Parse Claude CLI output.
+
+        For text format, output is plain text.
+        For stream-json, we need to find the result message.
+        """
+        if exit_code != 0:
+            return CliResult(
+                success=False,
+                output=stdout,
+                error=stderr or f"Exit code {exit_code}",
+                exit_code=exit_code,
+            )
+
+        # Try to parse as stream-json (look for result line)
+        result_data = None
+        assistant_text = []
+
+        for line in stdout.strip().split("\n"):
+            if not line.strip():
+                continue
+            try:
+                data = json.loads(line)
+                msg_type = data.get("type")
+
+                if msg_type == "assistant":
+                    # Extract text content
+                    message = data.get("message", {})
+                    content = message.get("content", [])
+                    text = self.extract_text_content(content)
+                    if text:
+                        assistant_text.append(text)
+
+                elif msg_type == "result":
+                    result_data = data
+
+            except json.JSONDecodeError:
+                # Not JSON, might be plain text output
+                continue
+
+        # Build result
+        if result_data:
+            usage = result_data.get("usage", {})
+            return CliResult(
+                success=not result_data.get("is_error", False),
+                output=result_data.get("result", "\n".join(assistant_text)),
+                exit_code=exit_code,
+                input_tokens=usage.get("input_tokens", 0),
+                output_tokens=usage.get("output_tokens", 0),
+                cache_read_tokens=usage.get("cache_read_input_tokens", 0),
+                cache_create_tokens=usage.get("cache_creation_input_tokens", 0),
+                cost_usd=result_data.get("total_cost_usd", 0.0),
+                duration_ms=result_data.get("duration_ms", 0),
+                duration_api_ms=result_data.get("duration_api_ms", 0),
+                session_id=result_data.get("session_id"),
+            )
+
+        # Fallback: treat entire output as text
+        return CliResult(
+            success=exit_code == 0,
+            output=stdout,
+            exit_code=exit_code,
+        )
+
+    def parse_stream_line(self, line: str) -> Optional[Dict[str, Any]]:
+        """Parse a single line from Claude's stream-json output."""
+        if not line.strip():
+            return None
+
+        try:
+            data = json.loads(line)
+            msg_type = data.get("type")
+
+            if msg_type == "system":
+                return {
+                    "type": "system",
+                    "subtype": data.get("subtype"),
+                    "session_id": data.get("session_id"),
+                    "model": data.get("model"),
+                    "cwd": data.get("cwd"),
+                    "tools": data.get("tools", []),
+                }
+
+            elif msg_type == "assistant":
+                message = data.get("message", {})
+                content = message.get("content", [])
+                return {
+                    "type": "assistant",
+                    "text": self.extract_text_content(content),
+                    "tool_uses": [
+                        item for item in content if item.get("type") == "tool_use"
+                    ],
+                    "usage": message.get("usage", {}),
+                }
+
+            elif msg_type == "result":
+                return {
+                    "type": "result",
+                    "success": not data.get("is_error", False),
+                    "result": data.get("result"),
+                    "duration_ms": data.get("duration_ms", 0),
+                    "cost_usd": data.get("total_cost_usd", 0.0),
+                    "usage": data.get("usage", {}),
+                }
+
+            return data
+
+        except json.JSONDecodeError:
+            logger.debug(f"Failed to parse line as JSON: {line[:100]}")
+            return None
+
+    def validate_environment(self) -> tuple[bool, Dict[str, Any]]:
+        """Validate Claude CLI is installed and configured."""
+        info: Dict[str, Any] = {"cli": "claude", "errors": [], "warnings": []}
+
+        # Check if binary exists
+        binary_path = self.get_binary_path()
+        if not binary_path:
+            info["errors"].append("Claude CLI not found in PATH")
+            return False, info
+
+        info["binary_path"] = binary_path
+
+        # Check version
+        try:
+            result = subprocess.run(
+                ["claude", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                info["version"] = result.stdout.strip()
+        except Exception as e:
+            info["warnings"].append(f"Could not get version: {e}")
+
+        # Check config file
+        config_path = Path(self.config.config_path).expanduser()
+        if config_path.exists():
+            info["config_path"] = str(config_path)
+        else:
+            info["warnings"].append(f"Config file not found: {config_path}")
+
+        return len(info["errors"]) == 0, info
+
+    def get_binary_path(self) -> Optional[str]:
+        """Get path to claude binary."""
+        return shutil.which("claude")

--- a/emdx/services/cli_executor/cursor.py
+++ b/emdx/services/cli_executor/cursor.py
@@ -1,0 +1,271 @@
+"""Cursor CLI executor implementation."""
+
+import json
+import logging
+import shutil
+import subprocess
+from typing import Any, Dict, List, Optional
+
+from ...config.cli_config import CLI_CONFIGS, CliTool, resolve_model_alias
+from .base import CliCommand, CliExecutor, CliResult
+
+logger = logging.getLogger(__name__)
+
+
+class CursorCliExecutor(CliExecutor):
+    """Executor for Cursor Agent CLI."""
+
+    def __init__(self):
+        self.config = CLI_CONFIGS[CliTool.CURSOR]
+
+    @property
+    def name(self) -> str:
+        return "Cursor Agent"
+
+    def build_command(
+        self,
+        prompt: str,
+        model: Optional[str] = None,
+        allowed_tools: Optional[List[str]] = None,
+        output_format: str = "stream-json",
+        working_dir: Optional[str] = None,
+        timeout: Optional[int] = None,
+    ) -> CliCommand:
+        """Build Cursor CLI command.
+
+        Cursor command format:
+            cursor agent -p --output-format <format> --model <model> [--force] [--workspace <path>] "prompt"
+
+        Note: Cursor uses positional prompt at the end with -p flag.
+        """
+        # Start with binary (cursor agent)
+        cmd = list(self.config.binary)
+
+        # Add print flag (enables non-interactive mode)
+        cmd.append(self.config.prompt_flag)
+
+        # Add output format
+        cmd.extend([self.config.output_format_flag, output_format])
+
+        # Add model
+        resolved_model = resolve_model_alias(
+            model or self.config.default_model, CliTool.CURSOR
+        )
+        cmd.extend([self.config.model_flag, resolved_model])
+
+        # Cursor doesn't have --allowedTools, use --force for full tool access
+        # Only add --force if tools are requested (implies full access needed)
+        if allowed_tools and self.config.force_flag:
+            cmd.append(self.config.force_flag)
+
+        # Add workspace if specified
+        if working_dir and self.config.workspace_flag:
+            cmd.extend([self.config.workspace_flag, working_dir])
+
+        # Add prompt as positional argument at the end (Cursor style)
+        cmd.append(prompt)
+
+        return CliCommand(args=cmd, cwd=working_dir)
+
+    def parse_output(
+        self,
+        stdout: str,
+        stderr: str,
+        exit_code: int,
+    ) -> CliResult:
+        """Parse Cursor CLI output.
+
+        Cursor's output format is very similar to Claude's stream-json.
+        Key differences:
+        - Cursor echoes user messages
+        - Cursor doesn't include cost/token info in result
+        - Cursor uses request_id instead of detailed usage
+        """
+        if exit_code != 0:
+            # Check for specific Cursor errors
+            error_msg = stderr or stdout
+            if "ActionRequiredError" in error_msg:
+                # Premium model or auth error
+                error_msg = self._extract_cursor_error(error_msg)
+            return CliResult(
+                success=False,
+                output=stdout,
+                error=error_msg or f"Exit code {exit_code}",
+                exit_code=exit_code,
+            )
+
+        # Parse stream-json output
+        result_data = None
+        assistant_text = []
+
+        for line in stdout.strip().split("\n"):
+            if not line.strip():
+                continue
+            try:
+                data = json.loads(line)
+                msg_type = data.get("type")
+
+                if msg_type == "assistant":
+                    # Extract text content
+                    message = data.get("message", {})
+                    content = message.get("content", [])
+                    text = self.extract_text_content(content)
+                    if text:
+                        assistant_text.append(text)
+
+                elif msg_type == "result":
+                    result_data = data
+
+            except json.JSONDecodeError:
+                continue
+
+        # Build result
+        if result_data:
+            return CliResult(
+                success=not result_data.get("is_error", False),
+                output=result_data.get("result", "\n".join(assistant_text)),
+                exit_code=exit_code,
+                # Cursor doesn't provide token/cost info
+                input_tokens=0,
+                output_tokens=0,
+                cost_usd=0.0,
+                duration_ms=result_data.get("duration_ms", 0),
+                duration_api_ms=result_data.get("duration_api_ms", 0),
+                session_id=result_data.get("session_id"),
+            )
+
+        # Fallback: treat entire output as text
+        return CliResult(
+            success=exit_code == 0,
+            output=stdout,
+            exit_code=exit_code,
+        )
+
+    def _extract_cursor_error(self, error_text: str) -> str:
+        """Extract meaningful error message from Cursor output."""
+        # Look for ActionRequiredError pattern
+        if "Premium Model Upgrade Required" in error_text:
+            return "Cursor requires a paid plan for this model. Try --model auto"
+        if "Authentication required" in error_text:
+            return "Cursor authentication required. Run 'cursor agent login'"
+        if "Cannot use this model" in error_text:
+            # Extract available models hint
+            if "Available models:" in error_text:
+                start = error_text.find("Available models:")
+                return error_text[start:].split("\n")[0]
+            return "Model not available for your account"
+        return error_text
+
+    def parse_stream_line(self, line: str) -> Optional[Dict[str, Any]]:
+        """Parse a single line from Cursor's stream-json output."""
+        if not line.strip():
+            return None
+
+        try:
+            data = json.loads(line)
+            msg_type = data.get("type")
+
+            if msg_type == "system":
+                return {
+                    "type": "system",
+                    "subtype": data.get("subtype"),
+                    "session_id": data.get("session_id"),
+                    "model": data.get("model"),
+                    "cwd": data.get("cwd"),
+                    "api_key_source": data.get("apiKeySource"),
+                }
+
+            elif msg_type == "user":
+                # Cursor echoes user input (Claude doesn't)
+                message = data.get("message", {})
+                content = message.get("content", [])
+                return {
+                    "type": "user",
+                    "text": self.extract_text_content(content),
+                }
+
+            elif msg_type == "assistant":
+                message = data.get("message", {})
+                content = message.get("content", [])
+                return {
+                    "type": "assistant",
+                    "text": self.extract_text_content(content),
+                    "tool_uses": [
+                        item for item in content if item.get("type") == "tool_use"
+                    ],
+                }
+
+            elif msg_type == "tool_call":
+                # Cursor has explicit tool_call messages
+                return {
+                    "type": "tool_call",
+                    "subtype": data.get("subtype"),  # "started" or "completed"
+                    "call_id": data.get("call_id"),
+                    "tool_call": data.get("tool_call", {}),
+                }
+
+            elif msg_type == "result":
+                return {
+                    "type": "result",
+                    "success": not data.get("is_error", False),
+                    "result": data.get("result"),
+                    "duration_ms": data.get("duration_ms", 0),
+                    "request_id": data.get("request_id"),
+                    # Cursor doesn't provide cost info
+                    "cost_usd": 0.0,
+                }
+
+            return data
+
+        except json.JSONDecodeError:
+            logger.debug(f"Failed to parse line as JSON: {line[:100]}")
+            return None
+
+    def validate_environment(self) -> tuple[bool, Dict[str, Any]]:
+        """Validate Cursor CLI is installed and authenticated."""
+        info: Dict[str, Any] = {"cli": "cursor", "errors": [], "warnings": []}
+
+        # Check if binary exists
+        binary_path = self.get_binary_path()
+        if not binary_path:
+            info["errors"].append("Cursor CLI not found in PATH")
+            return False, info
+
+        info["binary_path"] = binary_path
+
+        # Check version
+        try:
+            result = subprocess.run(
+                ["cursor", "agent", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                info["version"] = result.stdout.strip()
+        except Exception as e:
+            info["warnings"].append(f"Could not get version: {e}")
+
+        # Check authentication status
+        try:
+            result = subprocess.run(
+                ["cursor", "agent", "status"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if "Not logged in" in result.stdout:
+                info["warnings"].append(
+                    "Not authenticated. Run 'cursor agent login' to authenticate."
+                )
+                info["authenticated"] = False
+            else:
+                info["authenticated"] = True
+        except Exception as e:
+            info["warnings"].append(f"Could not check auth status: {e}")
+
+        return len(info["errors"]) == 0, info
+
+    def get_binary_path(self) -> Optional[str]:
+        """Get path to cursor binary."""
+        return shutil.which("cursor")

--- a/emdx/services/cli_executor/factory.py
+++ b/emdx/services/cli_executor/factory.py
@@ -1,0 +1,80 @@
+"""Factory for creating CLI executors."""
+
+import os
+from typing import Optional, Union
+
+from ...config.cli_config import CliTool
+from .base import CliExecutor
+from .claude import ClaudeCliExecutor
+from .cursor import CursorCliExecutor
+
+# Registry of executor classes
+_EXECUTORS = {
+    CliTool.CLAUDE: ClaudeCliExecutor,
+    CliTool.CURSOR: CursorCliExecutor,
+}
+
+
+def get_cli_executor(cli_tool: Optional[Union[str, CliTool]] = None) -> CliExecutor:
+    """Get the appropriate CLI executor.
+
+    Args:
+        cli_tool: "claude", "cursor", CliTool enum, or None (uses default/env var)
+
+    Returns:
+        CliExecutor instance for the specified tool
+
+    Raises:
+        ValueError: If cli_tool is not recognized
+
+    Examples:
+        >>> executor = get_cli_executor()  # Uses EMDX_CLI_TOOL env var or "claude"
+        >>> executor = get_cli_executor("cursor")
+        >>> executor = get_cli_executor(CliTool.CLAUDE)
+    """
+    # Determine which CLI to use
+    if cli_tool is None:
+        # Check environment variable, default to Claude
+        env_value = os.environ.get("EMDX_CLI_TOOL", "claude").lower()
+        cli_tool = env_value
+
+    # Convert string to enum if needed
+    if isinstance(cli_tool, str):
+        try:
+            cli_tool = CliTool(cli_tool.lower())
+        except ValueError:
+            valid = ", ".join(t.value for t in CliTool)
+            raise ValueError(
+                f"Unknown CLI tool: {cli_tool}. Valid options: {valid}"
+            )
+
+    # Get executor class and instantiate
+    executor_class = _EXECUTORS.get(cli_tool)
+    if executor_class is None:
+        raise ValueError(f"No executor registered for CLI tool: {cli_tool}")
+
+    return executor_class()
+
+
+def get_available_cli_tools() -> list[str]:
+    """Get list of available CLI tools.
+
+    Returns:
+        List of CLI tool names that have executors registered
+    """
+    return [tool.value for tool in _EXECUTORS.keys()]
+
+
+def detect_available_cli() -> Optional[CliTool]:
+    """Detect which CLI tools are available on the system.
+
+    Checks for installed CLIs in order of preference (Claude first).
+
+    Returns:
+        The first available CliTool, or None if none found
+    """
+    for tool in [CliTool.CLAUDE, CliTool.CURSOR]:
+        executor = _EXECUTORS[tool]()
+        if executor.get_binary_path() is not None:
+            return tool
+    return None

--- a/emdx/services/unified_executor.py
+++ b/emdx/services/unified_executor.py
@@ -1,5 +1,11 @@
-"""Unified executor for Claude execution paths."""
+"""Unified executor for CLI execution paths.
 
+This module provides a unified interface for executing tasks with different
+CLI tools (Claude, Cursor). It abstracts the differences between CLIs and
+provides consistent execution tracking and result handling.
+"""
+
+import json
 import logging
 import time
 from dataclasses import dataclass, field
@@ -7,9 +13,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ..config.cli_config import CliTool, get_default_cli_tool
 from ..models.executions import create_execution, update_execution_status
-from ..utils.environment import ensure_claude_in_path
-from .claude_executor import execute_claude_sync
+from .cli_executor import get_cli_executor
 
 logger = logging.getLogger(__name__)
 
@@ -19,22 +25,136 @@ DEFAULT_ALLOWED_TOOLS = [
     "WebFetch", "WebSearch"
 ]
 
+# Tool emojis for log formatting
+TOOL_EMOJIS = {
+    "Read": "📖", "Write": "📝", "Edit": "✏️", "MultiEdit": "✏️",
+    "Bash": "💻", "Glob": "🔍", "Grep": "🔎", "LS": "📂",
+    "Task": "📋", "TodoWrite": "✅", "WebFetch": "🌐", "WebSearch": "🔍",
+}
+
+
+def format_timestamp(ts: float) -> str:
+    """Format timestamp as [HH:MM:SS]."""
+    dt = datetime.fromtimestamp(ts)
+    return f"[{dt.strftime('%H:%M:%S')}]"
+
+
+def format_stream_line(line: str, timestamp: float) -> Optional[str]:
+    """Format a stream-json line into readable log output.
+
+    Works with both Claude and Cursor output formats.
+    """
+    line = line.strip()
+    if not line:
+        return None
+
+    try:
+        data = json.loads(line)
+        msg_type = data.get("type")
+
+        if msg_type == "system":
+            if data.get("subtype") == "init":
+                model = data.get("model", "Unknown")
+                return f"{format_timestamp(timestamp)} 🚀 Session started (model: {model})"
+            return None
+
+        elif msg_type == "thinking":
+            # Cursor thinking - accumulate but don't spam logs
+            text = data.get("text", "")
+            if data.get("subtype") == "completed":
+                return f"{format_timestamp(timestamp)} 💭 Thinking completed"
+            # Skip delta messages (too spammy)
+            return None
+
+        elif msg_type == "assistant":
+            msg = data.get("message", {})
+            content = msg.get("content", [])
+            for item in content:
+                if item.get("type") == "text":
+                    text = item.get("text", "").strip()
+                    if text:
+                        # Truncate long messages
+                        if len(text) > 200:
+                            text = text[:200] + "..."
+                        return f"{format_timestamp(timestamp)} 🤖 Assistant: {text}"
+                elif item.get("type") == "tool_use":
+                    tool_name = item.get("name", "Unknown")
+                    emoji = TOOL_EMOJIS.get(tool_name, "🛠️")
+                    return f"{format_timestamp(timestamp)} {emoji} Using tool: {tool_name}"
+
+        elif msg_type == "tool_call":
+            subtype = data.get("subtype")
+            tool_call = data.get("tool_call", {})
+
+            if subtype == "started":
+                # Extract tool name from various formats
+                if "shellToolCall" in tool_call:
+                    cmd = tool_call["shellToolCall"].get("args", {}).get("command", "")[:60]
+                    return f"{format_timestamp(timestamp)} 💻 Running: {cmd}..."
+                elif "readToolCall" in tool_call:
+                    path = tool_call["readToolCall"].get("args", {}).get("path", "")
+                    return f"{format_timestamp(timestamp)} 📖 Reading: {path}"
+                elif "globToolCall" in tool_call:
+                    pattern = tool_call["globToolCall"].get("args", {}).get("globPattern", "")
+                    return f"{format_timestamp(timestamp)} 🔍 Glob: {pattern}"
+                else:
+                    return f"{format_timestamp(timestamp)} 🛠️ Tool call started"
+
+            elif subtype == "completed":
+                # Check for success/failure
+                result = tool_call.get("result", {})
+                if "success" in result:
+                    return f"{format_timestamp(timestamp)} ✅ Tool completed"
+                elif "error" in result:
+                    err = result.get("error", {}).get("message", "Unknown error")[:100]
+                    return f"{format_timestamp(timestamp)} ❌ Tool error: {err}"
+
+        elif msg_type == "user":
+            # Tool result or user message - usually can skip
+            return None
+
+        elif msg_type == "result":
+            # Final result
+            is_error = data.get("is_error", False)
+            duration = data.get("duration_ms", 0)
+            if is_error:
+                result_text = data.get("result", "Unknown error")[:100]
+                return f"{format_timestamp(timestamp)} ❌ Failed ({duration}ms): {result_text}\n__RAW_RESULT_JSON__:{line}"
+            else:
+                return f"{format_timestamp(timestamp)} ✅ Completed ({duration}ms)\n__RAW_RESULT_JSON__:{line}"
+
+        elif msg_type == "error":
+            error = data.get("error", {}).get("message", "Unknown error")
+            return f"{format_timestamp(timestamp)} ❌ Error: {error}"
+
+        # Unknown type - skip
+        return None
+
+    except json.JSONDecodeError:
+        # Not JSON - return as plain text
+        if line and not line.startswith("{"):
+            return f"{format_timestamp(timestamp)} 💬 {line}"
+        return None
+
 
 @dataclass
 class ExecutionConfig:
-    """Configuration for a Claude execution."""
+    """Configuration for a CLI execution."""
     prompt: str
     working_dir: str = field(default_factory=lambda: str(Path.cwd()))
-    title: str = "Claude Execution"
+    title: str = "CLI Execution"
     doc_id: Optional[int] = None
     output_instruction: Optional[str] = None
     allowed_tools: List[str] = field(default_factory=lambda: DEFAULT_ALLOWED_TOOLS.copy())
     timeout_seconds: int = 300
+    cli_tool: str = "claude"  # "claude" or "cursor"
+    model: Optional[str] = None  # Override default model for the CLI
+    verbose: bool = False  # Stream output in real-time
 
 
 @dataclass
 class ExecutionResult:
-    """Result of a Claude execution."""
+    """Result of a CLI execution."""
     success: bool
     execution_id: int
     log_file: Path
@@ -47,6 +167,7 @@ class ExecutionResult:
     execution_time_ms: int = 0
     error_message: Optional[str] = None
     exit_code: Optional[int] = None
+    cli_tool: str = "claude"  # Which CLI was used
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -62,24 +183,50 @@ class ExecutionResult:
             'execution_time_ms': self.execution_time_ms,
             'error_message': self.error_message,
             'exit_code': self.exit_code,
+            'cli_tool': self.cli_tool,
         }
 
 
 class UnifiedExecutor:
-    """Unified executor for all Claude execution paths."""
+    """Unified executor for all CLI execution paths.
+
+    Supports multiple CLI tools (Claude, Cursor) through the strategy pattern.
+    """
 
     def __init__(self, log_dir: Optional[Path] = None):
         self.log_dir = log_dir or (Path.home() / ".config" / "emdx" / "logs")
         self.log_dir.mkdir(parents=True, exist_ok=True)
 
     def execute(self, config: ExecutionConfig) -> ExecutionResult:
-        """Execute Claude with the given configuration."""
+        """Execute a task with the configured CLI tool.
+
+        Args:
+            config: Execution configuration including prompt, cli_tool, etc.
+
+        Returns:
+            ExecutionResult with success status, output, and metrics.
+        """
+        import subprocess
+
         from ..workflows.output_parser import extract_output_doc_id, extract_token_usage_detailed
 
-        ensure_claude_in_path()
+        # Get the appropriate executor for the CLI tool
+        executor = get_cli_executor(config.cli_tool)
+
+        # Validate environment
+        is_valid, env_info = executor.validate_environment()
+        if not is_valid:
+            errors = env_info.get("errors", ["Unknown error"])
+            return ExecutionResult(
+                success=False,
+                execution_id=0,
+                log_file=Path("/dev/null"),
+                error_message=f"Environment validation failed: {'; '.join(errors)}",
+                cli_tool=config.cli_tool,
+            )
 
         timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
-        log_file = self.log_dir / f"unified-{timestamp}.log"
+        log_file = self.log_dir / f"unified-{config.cli_tool}-{timestamp}.log"
 
         exec_id = create_execution(
             doc_id=config.doc_id,
@@ -95,18 +242,147 @@ class UnifiedExecutor:
         start_time = time.time()
 
         try:
-            result_data = execute_claude_sync(
-                task=full_prompt,
-                execution_id=exec_id,
-                log_file=log_file,
+            # Build command using the CLI executor
+            cmd = executor.build_command(
+                prompt=full_prompt,
+                model=config.model,
                 allowed_tools=config.allowed_tools,
+                output_format="stream-json",  # Use stream-json for consistent parsing
                 working_dir=config.working_dir,
-                doc_id=str(config.doc_id) if config.doc_id else None,
-                timeout=config.timeout_seconds,
             )
 
-            success = result_data.get('success', False)
-            exit_code = result_data.get('exit_code', -1)
+            logger.debug(f"Executing {config.cli_tool} command: {' '.join(cmd.args[:3])}...")
+
+            # Ensure log file directory exists
+            log_file.parent.mkdir(parents=True, exist_ok=True)
+
+            if config.verbose:
+                # Stream output in real-time using Popen
+                stdout_lines = []
+                stderr_lines = []
+
+                with open(log_file, 'w') as f:
+                    process = subprocess.Popen(
+                        cmd.args,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                        cwd=cmd.cwd,
+                    )
+
+                    import sys
+
+                    # Stream stdout in real-time
+                    while True:
+                        # Check if process has finished
+                        retcode = process.poll()
+
+                        # Read available stdout
+                        if process.stdout:
+                            line = process.stdout.readline()
+                            if line:
+                                stdout_lines.append(line)
+                                # Format the line for readable output
+                                formatted = format_stream_line(line, time.time())
+                                if formatted:
+                                    f.write(formatted + "\n")
+                                    f.flush()
+                                    # Print formatted output to terminal
+                                    sys.stdout.write(formatted + "\n")
+                                    sys.stdout.flush()
+
+                        if retcode is not None:
+                            # Process finished, read any remaining output
+                            if process.stdout:
+                                for line in process.stdout:
+                                    stdout_lines.append(line)
+                                    formatted = format_stream_line(line, time.time())
+                                    if formatted:
+                                        f.write(formatted + "\n")
+                                        sys.stdout.write(formatted + "\n")
+                                        sys.stdout.flush()
+                            break
+
+                    # Capture stderr
+                    if process.stderr:
+                        stderr_output = process.stderr.read()
+                        if stderr_output:
+                            stderr_lines.append(stderr_output)
+                            f.write(f"\n--- STDERR ---\n{stderr_output}\n")
+
+                    exit_code = process.returncode
+
+                # Create a mock result object for compatibility
+                class ProcResult:
+                    pass
+                proc_result = ProcResult()
+                proc_result.stdout = ''.join(stdout_lines)
+                proc_result.stderr = ''.join(stderr_lines)
+                proc_result.returncode = exit_code
+            else:
+                # Stream output to log file in real-time (without terminal output)
+                # This enables Activity browser to show live logs
+                stdout_lines = []
+                stderr_lines = []
+
+                with open(log_file, 'w') as f:
+                    process = subprocess.Popen(
+                        cmd.args,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                        cwd=cmd.cwd,
+                    )
+
+                    # Stream stdout to log file in real-time
+                    while True:
+                        retcode = process.poll()
+
+                        if process.stdout:
+                            line = process.stdout.readline()
+                            if line:
+                                stdout_lines.append(line)
+                                formatted = format_stream_line(line, time.time())
+                                if formatted:
+                                    f.write(formatted + "\n")
+                                    f.flush()  # Flush immediately for live viewing
+
+                        if retcode is not None:
+                            # Process finished, read any remaining output
+                            if process.stdout:
+                                for line in process.stdout:
+                                    stdout_lines.append(line)
+                                    formatted = format_stream_line(line, time.time())
+                                    if formatted:
+                                        f.write(formatted + "\n")
+                            break
+
+                    # Capture stderr
+                    if process.stderr:
+                        stderr_output = process.stderr.read()
+                        if stderr_output:
+                            stderr_lines.append(stderr_output)
+                            f.write(f"\n--- STDERR ---\n{stderr_output}\n")
+
+                    exit_code = process.returncode
+
+                # Create a mock result object for compatibility
+                class ProcResult:
+                    pass
+                proc_result = ProcResult()
+                proc_result.stdout = ''.join(stdout_lines)
+                proc_result.stderr = ''.join(stderr_lines)
+                proc_result.returncode = exit_code
+
+            # Parse the result
+            cli_result = executor.parse_output(
+                proc_result.stdout,
+                proc_result.stderr,
+                proc_result.returncode,
+            )
+
+            success = cli_result.success
+            exit_code = cli_result.exit_code
             status = 'completed' if success else 'failed'
             update_execution_status(exec_id, status, exit_code)
 
@@ -115,24 +391,45 @@ class UnifiedExecutor:
                 execution_id=exec_id,
                 log_file=log_file,
                 exit_code=exit_code,
+                cli_tool=config.cli_tool,
             )
 
             if success:
                 result.output_doc_id = extract_output_doc_id(log_file)
-                result.output_content = result_data.get('output')
+                result.output_content = cli_result.output
             else:
-                result.error_message = result_data.get('error', 'Unknown error')
+                result.error_message = cli_result.error or 'Unknown error'
 
             result.execution_time_ms = int((time.time() - start_time) * 1000)
 
-            if log_file.exists():
+            # Get token usage from CLI result (may be zero for Cursor)
+            result.tokens_used = cli_result.total_tokens
+            result.input_tokens = cli_result.input_tokens + cli_result.cache_read_tokens
+            result.output_tokens = cli_result.output_tokens
+            result.cost_usd = cli_result.cost_usd
+
+            # Try to extract from log file as fallback (for stream-json format)
+            if result.tokens_used == 0 and log_file.exists():
                 usage = extract_token_usage_detailed(log_file)
-                result.tokens_used = usage.get('total', 0)
-                result.input_tokens = usage.get('input', 0) + usage.get('cache_in', 0) + usage.get('cache_create', 0)
-                result.output_tokens = usage.get('output', 0)
-                result.cost_usd = usage.get('cost_usd', 0.0)
+                if usage.get('total', 0) > 0:
+                    result.tokens_used = usage.get('total', 0)
+                    result.input_tokens = usage.get('input', 0) + usage.get('cache_in', 0) + usage.get('cache_create', 0)
+                    result.output_tokens = usage.get('output', 0)
+                    result.cost_usd = usage.get('cost_usd', 0.0)
 
             return result
+
+        except subprocess.TimeoutExpired:
+            logger.error(f"Execution timed out after {config.timeout_seconds}s")
+            update_execution_status(exec_id, 'failed', -1)
+            return ExecutionResult(
+                success=False,
+                execution_id=exec_id,
+                log_file=log_file,
+                error_message=f"Timeout after {config.timeout_seconds} seconds",
+                execution_time_ms=int((time.time() - start_time) * 1000),
+                cli_tool=config.cli_tool,
+            )
 
         except Exception as e:
             logger.exception("Execution failed: %s", e)
@@ -143,4 +440,5 @@ class UnifiedExecutor:
                 log_file=log_file,
                 error_message=str(e),
                 execution_time_ms=int((time.time() - start_time) * 1000),
+                cli_tool=config.cli_tool,
             )

--- a/emdx/ui/activity/activity_items.py
+++ b/emdx/ui/activity/activity_items.py
@@ -23,6 +23,9 @@ class ActivityItem(ABC):
     depth: int = 0
     expanded: bool = False
     children: List["ActivityItem"] = field(default_factory=list)
+    status: str = "completed"  # Default status for items that don't track status
+    doc_id: Optional[int] = None  # Document ID if this item has associated content
+    cost: float = 0.0  # Cost in USD if tracked
 
     @property
     @abstractmethod
@@ -750,3 +753,70 @@ class GroupItem(ActivityItem):
 
         content = "".join(content_parts)
         return content, f"{self.type_icon} Group #{self.group.get('id', '?')}"
+
+
+@dataclass
+class AgentExecutionItem(ActivityItem):
+    """A standalone agent execution (from `emdx agent` command).
+
+    These are direct CLI agent runs not part of any workflow or cascade.
+    """
+
+    execution: Dict[str, Any] = field(default_factory=dict)
+    status: str = "running"
+    doc_id: Optional[int] = None
+    log_file: str = ""
+    cli_tool: str = "claude"
+
+    @property
+    def item_type(self) -> str:
+        return "agent_execution"
+
+    @property
+    def type_icon(self) -> str:
+        # Show different icon based on CLI tool
+        if self.cli_tool == "cursor":
+            return "🖱️"  # Cursor icon
+        return "🤖"  # Claude icon
+
+    @property
+    def status_icon(self) -> str:
+        icons = {
+            "running": "🔄",
+            "completed": "✅",
+            "failed": "❌",
+        }
+        return icons.get(self.status, "⚪")
+
+    def can_expand(self) -> bool:
+        return False
+
+    async def load_children(self, wf_db, doc_db) -> List["ActivityItem"]:
+        """Agent executions don't have children."""
+        return []
+
+    async def get_preview_content(self, wf_db, doc_db) -> tuple[str, str]:
+        """Show execution log content in preview."""
+        from pathlib import Path
+
+        # If we have an output doc, show it
+        if self.doc_id and doc_db:
+            doc = doc_db.get_document(self.doc_id)
+            if doc:
+                return doc.get("content", ""), f"{self.type_icon} #{self.doc_id}"
+
+        # Otherwise show the log file
+        if self.log_file:
+            log_path = Path(self.log_file)
+            if log_path.exists():
+                try:
+                    content = log_path.read_text()
+                    # Show last 100 lines max
+                    lines = content.split('\n')
+                    if len(lines) > 100:
+                        content = '\n'.join(lines[-100:])
+                    return f"```\n{content}\n```", f"{self.type_icon} Log"
+                except Exception:
+                    pass
+
+        return f"[italic]{self.title}[/italic]", "PREVIEW"

--- a/emdx/ui/activity/activity_view.py
+++ b/emdx/ui/activity/activity_view.py
@@ -31,6 +31,7 @@ from .activity_items import (
     ExplorationItem,
     CascadeRunItem,
     CascadeStageItem,
+    AgentExecutionItem,
 )
 from .group_picker import GroupPicker
 from ..modals import HelpMixin
@@ -461,10 +462,16 @@ class ActivityView(HelpMixin, Widget):
         # Load cascade executions
         await self._load_cascade_executions()
 
-        # Sort: running workflows first (pinned), then by timestamp descending
-        # Running workflows should always be at the top for visibility
+        # Load standalone agent executions
+        await self._load_agent_executions()
+
+        # Sort: running items first (pinned), then by timestamp descending
+        # Running workflows and agent executions should always be at the top for visibility
         def sort_key(item):
-            is_running = item.item_type == "workflow" and item.status == "running"
+            is_running = (
+                (item.item_type == "workflow" and item.status == "running") or
+                (item.item_type == "agent_execution" and item.status == "running")
+            )
             # Running items get priority 0 (will be first after sort)
             # Non-running items get priority 1
             # Within each group, sort by timestamp descending (negate for descending)
@@ -862,6 +869,87 @@ class ActivityView(HelpMixin, Widget):
         except Exception as e:
             logger.error(f"Error loading cascade executions: {e}", exc_info=True)
 
+    async def _load_agent_executions(self) -> None:
+        """Load standalone agent executions into activity items.
+
+        These are executions from `emdx agent` command that are not part of
+        any workflow or cascade. They show up as top-level items with their
+        log files available for preview.
+        """
+        try:
+            from emdx.database.connection import db_connection
+            from emdx.models.executions import get_recent_executions
+            from datetime import datetime, timedelta
+
+            cutoff = datetime.now() - timedelta(days=7)
+
+            # Get recent executions - filter for standalone agent runs
+            # (no workflow_run_id, and not part of cascade)
+            with db_connection.get_connection() as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT e.id, e.doc_id, e.doc_title, e.status, e.started_at,
+                           e.completed_at, e.log_file, e.exit_code, e.working_dir
+                    FROM executions e
+                    WHERE e.started_at > ?
+                      AND e.doc_title LIKE 'Agent:%'
+                      AND e.cascade_run_id IS NULL
+                    ORDER BY e.started_at DESC
+                    LIMIT 30
+                    """,
+                    (cutoff.isoformat(),),
+                )
+                rows = cursor.fetchall()
+
+            for row in rows:
+                exec_id, doc_id, doc_title, status, started_at, completed_at, log_file, exit_code, working_dir = row
+
+                # Parse timestamp
+                if started_at:
+                    if isinstance(started_at, str):
+                        timestamp = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+                    else:
+                        timestamp = started_at
+                else:
+                    timestamp = datetime.now()
+
+                # Detect CLI tool from log file name
+                cli_tool = "claude"
+                if log_file and "cursor" in log_file.lower():
+                    cli_tool = "cursor"
+
+                # Build title
+                title = doc_title or f"Execution #{exec_id}"
+                if title.startswith("Agent: "):
+                    title = title[7:]  # Strip "Agent: " prefix for cleaner display
+                title = title[:50]  # Truncate long titles
+
+                item = AgentExecutionItem(
+                    item_id=exec_id,
+                    title=title,
+                    timestamp=timestamp,
+                    execution={
+                        "id": exec_id,
+                        "doc_id": doc_id,
+                        "doc_title": doc_title,
+                        "status": status,
+                        "started_at": started_at,
+                        "completed_at": completed_at,
+                        "log_file": log_file,
+                        "exit_code": exit_code,
+                        "working_dir": working_dir,
+                    },
+                    status=status or "unknown",
+                    doc_id=doc_id,
+                    log_file=log_file or "",
+                    cli_tool=cli_tool,
+                )
+
+                self.activity_items.append(item)
+
+        except Exception as e:
+            logger.error(f"Error loading agent executions: {e}", exc_info=True)
+
     def _flatten_items(self) -> None:
         """Flatten activity items for display, respecting expansion state."""
         self.flat_items = []
@@ -1155,8 +1243,8 @@ class ActivityView(HelpMixin, Widget):
         # Stop any existing stream
         self._stop_stream()
 
-        # For running workflows or individual runs, show live log
-        if item.status == "running" and item.item_type in ("workflow", "individual_run"):
+        # For running workflows, individual runs, or agent executions, show live log
+        if item.status == "running" and item.item_type in ("workflow", "individual_run", "agent_execution"):
             await self._show_live_log(item)
             return
 
@@ -1238,7 +1326,7 @@ class ActivityView(HelpMixin, Widget):
         elif item.item_type == "group":
             await self._show_group_context(item, context_content, context_header)
         # Individual run details
-        elif item.item_type == "individual_run" or item.individual_run:
+        elif item.item_type == "individual_run" or getattr(item, 'individual_run', None):
             await self._show_individual_run_context(item, context_content, context_header)
         else:
             context_header.update("DETAILS")
@@ -1516,7 +1604,7 @@ class ActivityView(HelpMixin, Widget):
         self, item: ActivityItem, content: RichLog, header: Static
     ) -> None:
         """Show individual run details in context panel."""
-        run = item.individual_run or item.workflow_run
+        run = getattr(item, 'individual_run', None) or getattr(item, 'workflow_run', None)
         if not run:
             header.update("RUN")
             return
@@ -1760,21 +1848,47 @@ class ActivityView(HelpMixin, Widget):
         try:
             log_path = None
 
+            # For agent executions, get log file directly from the item
+            if item.item_type == "agent_execution":
+                log_file = getattr(item, 'log_file', None)
+                if log_file:
+                    log_path = Path(log_file)
+
             # For individual runs, get log file from the execution record
-            if item.item_type == "individual_run" and item.item_id:
+            elif item.item_type == "individual_run" and item.item_id:
                 try:
                     from emdx.models.executions import get_execution
+                    from emdx.database.connection import db_connection
+
                     # Get the individual run to find its execution ID
                     ir = wf_db.get_individual_run(item.item_id)
-                    if ir and ir.get("agent_execution_id"):
-                        exec_record = get_execution(ir["agent_execution_id"])
-                        if exec_record and exec_record.log_file:
-                            log_path = Path(exec_record.log_file)
+                    if ir:
+                        # Try agent_execution_id first (set after completion)
+                        if ir.get("agent_execution_id"):
+                            exec_record = get_execution(ir["agent_execution_id"])
+                            if exec_record and exec_record.log_file:
+                                log_path = Path(exec_record.log_file)
+
+                        # Fallback: find running execution by title pattern
+                        if not log_path:
+                            with db_connection.get_connection() as conn:
+                                cursor = conn.execute(
+                                    """
+                                    SELECT log_file FROM executions
+                                    WHERE doc_title LIKE ?
+                                    AND status = 'running'
+                                    ORDER BY id DESC LIMIT 1
+                                    """,
+                                    (f"Workflow Agent Run #{item.item_id}%",),
+                                )
+                                row = cursor.fetchone()
+                                if row and row['log_file']:
+                                    log_path = Path(row['log_file'])
                 except Exception as e:
                     logger.debug(f"Could not get individual run log: {e}")
 
             # For workflow runs, find active execution
-            elif item.item_type == "workflow" and item.workflow_run:
+            elif item.item_type == "workflow" and getattr(item, 'workflow_run', None):
                 run = item.workflow_run
                 active_exec = wf_db.get_active_execution_for_run(run["id"])
                 if active_exec and active_exec.get("log_file"):
@@ -1782,13 +1896,15 @@ class ActivityView(HelpMixin, Widget):
 
             if not log_path:
                 preview_log.write(f"[yellow]⏳ Waiting for log...[/yellow]")
+                preview_log.write(f"[dim]item_type={item.item_type}, has workflow_run={getattr(item, 'workflow_run', None) is not None}[/dim]")
                 return
 
             if not log_path.exists():
-                preview_log.write(f"[yellow]⏳ Log file pending...[/yellow]")
+                preview_log.write(f"[yellow]⏳ Log file pending: {log_path}[/yellow]")
                 return
 
             # Start streaming
+            preview_log.write(f"[green]● Streaming from: {log_path.name}[/green]")
             self.log_stream = LogStream(log_path)
             self.streaming_item_id = item.item_id
 
@@ -1806,14 +1922,22 @@ class ActivityView(HelpMixin, Widget):
             preview_log.write(f"[red]Error: {e}[/red]")
 
     def _handle_log_content(self, content: str) -> None:
-        """Handle new log content from stream."""
-        try:
-            preview_log = self.query_one("#preview-log", RichLog)
-            for line in content.splitlines():
-                preview_log.write(escape_markup(line))
-            preview_log.scroll_end(animate=False)
-        except Exception as e:
-            logger.error(f"Error handling log content: {e}")
+        """Handle new log content from stream.
+
+        This is called from a background thread (file watcher), so we must
+        use call_from_thread to safely update the UI.
+        """
+        def update_ui():
+            try:
+                preview_log = self.query_one("#preview-log", RichLog)
+                for line in content.splitlines():
+                    preview_log.write(escape_markup(line))
+                preview_log.scroll_end(animate=False)
+            except Exception as e:
+                logger.error(f"Error handling log content: {e}")
+
+        # Schedule UI update on the main thread
+        self.call_from_thread(update_ui)
 
     def _stop_stream(self) -> None:
         """Stop any active log stream."""

--- a/emdx/workflows/agent_runner.py
+++ b/emdx/workflows/agent_runner.py
@@ -75,8 +75,8 @@ async def run_agent(
             title=f"Workflow Agent Run #{individual_run_id}",
             doc_id=context.get('input_doc_id'),
             allowed_tools=["Read", "Write", "Edit", "Bash", "Glob", "Grep", "LS", "Task", "TodoWrite", "WebFetch", "WebSearch"],
-            sync=True,
-            verbose=False,
+            cli_tool=context.get('_cli_tool', 'claude'),
+            model=context.get('_model'),
         )
 
         # Run execution in thread pool to not block async

--- a/emdx/workflows/database.py
+++ b/emdx/workflows/database.py
@@ -596,13 +596,14 @@ def update_individual_run(
 def get_active_execution_for_run(workflow_run_id: int) -> Optional[Dict[str, Any]]:
     """Get the currently running execution (log file) for a workflow run.
 
-    Returns the execution record with log_file path if there's an active individual run.
+    Returns the execution record with log_file path if there's an active individual run
+    or synthesis execution.
     """
     with db_connection.get_connection() as conn:
         # Find any running individual run for this workflow
         cursor = conn.execute(
             """
-            SELECT ir.*, sr.stage_name
+            SELECT ir.*, sr.stage_name, sr.id as stage_run_id_ref
             FROM workflow_individual_runs ir
             JOIN workflow_stage_runs sr ON ir.stage_run_id = sr.id
             WHERE sr.workflow_run_id = ?
@@ -613,16 +614,33 @@ def get_active_execution_for_run(workflow_run_id: int) -> Optional[Dict[str, Any
             (workflow_run_id,),
         )
         row = cursor.fetchone()
-        if not row:
-            return None
 
-        result = dict(row)
+        if row:
+            result = dict(row)
 
-        # Try to find execution by agent_execution_id first
-        if result.get('agent_execution_id'):
+            # Try to find execution by agent_execution_id first
+            if result.get('agent_execution_id'):
+                exec_cursor = conn.execute(
+                    "SELECT log_file, status as exec_status FROM executions WHERE id = ?",
+                    (result['agent_execution_id'],),
+                )
+                exec_row = exec_cursor.fetchone()
+                if exec_row:
+                    result['log_file'] = exec_row['log_file']
+                    result['exec_status'] = exec_row['exec_status']
+                    return result
+
+            # Fallback: find execution by title pattern "Workflow Agent Run #{individual_run_id}"
+            individual_run_id = result['id']
             exec_cursor = conn.execute(
-                "SELECT log_file, status as exec_status FROM executions WHERE id = ?",
-                (result['agent_execution_id'],),
+                """
+                SELECT log_file, status as exec_status FROM executions
+                WHERE doc_title LIKE ?
+                AND status = 'running'
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (f"Workflow Agent Run #{individual_run_id}%",),
             )
             exec_row = exec_cursor.fetchone()
             if exec_row:
@@ -630,27 +648,42 @@ def get_active_execution_for_run(workflow_run_id: int) -> Optional[Dict[str, Any
                 result['exec_status'] = exec_row['exec_status']
                 return result
 
-        # Fallback: find execution by title pattern "Workflow Agent Run #{individual_run_id}"
-        individual_run_id = result['id']
-        exec_cursor = conn.execute(
+        # Check for synthesis execution (when stage is synthesizing)
+        cursor = conn.execute(
             """
-            SELECT log_file, status as exec_status FROM executions
-            WHERE doc_title LIKE ?
-            AND status = 'running'
-            ORDER BY id DESC
+            SELECT sr.id as stage_run_id, sr.stage_name
+            FROM workflow_stage_runs sr
+            WHERE sr.workflow_run_id = ?
+            AND sr.status = 'synthesizing'
+            ORDER BY sr.id DESC
             LIMIT 1
             """,
-            (f"Workflow Agent Run #{individual_run_id}%",),
+            (workflow_run_id,),
         )
-        exec_row = exec_cursor.fetchone()
-        if exec_row:
-            result['log_file'] = exec_row['log_file']
-            result['exec_status'] = exec_row['exec_status']
-        else:
-            result['log_file'] = None
-            result['exec_status'] = None
+        synth_row = cursor.fetchone()
+        if synth_row:
+            stage_run_id = synth_row['stage_run_id']
+            # Find synthesis execution by title pattern
+            exec_cursor = conn.execute(
+                """
+                SELECT log_file, status as exec_status FROM executions
+                WHERE doc_title LIKE ?
+                AND status = 'running'
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (f"Workflow Synthesis #{stage_run_id}%",),
+            )
+            exec_row = exec_cursor.fetchone()
+            if exec_row:
+                return {
+                    'stage_name': synth_row['stage_name'],
+                    'log_file': exec_row['log_file'],
+                    'exec_status': exec_row['exec_status'],
+                    'is_synthesis': True,
+                }
 
-        return result
+        return None
 
 
 def get_agent_execution(execution_id: int) -> Optional[Dict[str, Any]]:

--- a/emdx/workflows/output_parser.py
+++ b/emdx/workflows/output_parser.py
@@ -49,9 +49,12 @@ def extract_output_doc_id(log_file: Path) -> Optional[int]:
             r'Saved as #(\d+)',           # CLI output
             r'Created document #(\d+)',
             r'Document ID(?:\s+created)?[:\s]*\*?\*?#?(\d+)\*?\*?',  # Agent output (with optional "created" and markdown bold)
+            r'\*\*Document ID:\*\*\s*(\d+)',  # Cursor markdown: **Document ID:** 5714
             r'document ID[:\s]+#?(\d+)',
             r'doc_id[:\s]+(\d+)',
             r'✅ Saved as\s*#(\d+)',      # With emoji
+            r'doc ID\s*`(\d+)`',          # Markdown backtick format: doc ID `123`
+            r'Saved to EMDX as.*?(\d+)',  # "Saved to EMDX as **doc ID `5704`**"
         ]
 
         # Find ALL matches and return the LAST one (most likely the final output)


### PR DESCRIPTION
## Summary
- Add support for Cursor Agent CLI alongside Claude Code CLI with `--cli cursor` flag
- Fix live log streaming in Activity browser for all execution types
- Create unified CLI executor abstraction using strategy pattern

## Changes

### CLI Support
- Add `--cli/-C` flag to `agent`, `run`, `each`, and `workflow` commands
- Support both "claude" and "cursor" CLI tools
- Add `--model/-m` flag for model override
- Create `cli_executor/` module with strategy pattern for CLI abstraction
- Add `CursorCliExecutor` with proper command building and output parsing

### Live Log Streaming (Major Fix)
- Fix non-verbose mode to stream logs in real-time using `Popen` instead of `subprocess.run()`
- Add `f.flush()` for immediate log file updates
- Fix thread-safe UI updates with `call_from_thread()` (was causing silent failures)
- Support live logs for workflows, individual runs, and synthesis phases
- Add fallback query for individual run logs during execution (before `agent_execution_id` is set)

### Activity Browser
- Add `AgentExecutionItem` for standalone agent executions
- Add `status`, `doc_id`, `cost` attributes to base `ActivityItem` class
- Fix `_show_live_log()` for individual runs and synthesis
- Update `get_active_execution_for_run()` to find synthesis executions

## Test plan
- [x] Test `emdx agent --cli cursor "task"` - works
- [x] Test `emdx run --cli cursor "task1" "task2"` - works  
- [x] Test `emdx each --cli cursor --from "..." --do "..."` - works
- [x] Test `emdx workflow run task_parallel --cli cursor -t "..."` - works
- [x] Verify live logs stream in Activity browser for running workflows
- [x] Verify live logs stream for individual runs when expanded
- [x] Verify live logs stream during synthesis phase

🤖 Generated with [Claude Code](https://claude.ai/claude-code)