### PR TITLE
fix(cli): Add missing DEFAULT_ALLOWED_TOOLS constant

### DIFF
--- a/emdx/config/cli_config.py
+++ b/emdx/config/cli_config.py
@@ -10,6 +10,14 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 
+# Default allowed tools for Claude Code execution
+DEFAULT_ALLOWED_TOOLS: List[str] = [
+    "Read", "Write", "Edit", "MultiEdit", "Bash",
+    "Glob", "Grep", "LS", "Task", "TodoWrite",
+    "WebFetch", "WebSearch",
+]
+
+
 class CliTool(str, Enum):
     """Supported CLI tools."""
 


### PR DESCRIPTION
## Summary
- Adds the missing `DEFAULT_ALLOWED_TOOLS` constant to `cli_config.py`
- This constant was present in WIP commit f5b98a3 but wasn't included in the Cursor CLI merge
- Fixes ImportError that broke all emdx commands

## Test plan
- [x] Verified `poetry run emdx --help` works
- [x] Verified import succeeds: `from emdx.config.cli_config import DEFAULT_ALLOWED_TOOLS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)