### PR TITLE
refactor: Add datetime utilities and fix deprecated utcnow

### DIFF
--- a/emdx/services/embedding_service.py
+++ b/emdx/services/embedding_service.py
@@ -7,12 +7,12 @@ enabling semantic search without API costs.
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
 from typing import List, Optional
 
 import numpy as np
 
 from ..database import db
+from ..utils.datetime_utils import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +124,7 @@ class EmbeddingService:
                     self.MODEL_NAME,
                     embedding.tobytes(),
                     self.EMBEDDING_DIM,
-                    datetime.utcnow().isoformat(),
+                    utc_now_iso(),
                 ),
             )
             conn.commit()
@@ -188,7 +188,7 @@ class EmbeddingService:
                             self.MODEL_NAME,
                             embedding.tobytes(),
                             self.EMBEDDING_DIM,
-                            datetime.utcnow().isoformat(),
+                            utc_now_iso(),
                         ),
                     )
                 conn.commit()


### PR DESCRIPTION
## Summary
- Add format constants (DISPLAY_FORMAT, ISO_FORMAT, SQLITE_FORMAT, etc.)
- Add `utc_now()` and `utc_now_iso()` to replace deprecated `datetime.utcnow()`
- Add `format_relative_time()` for human-readable display ("2 hours ago")
- Add `get_age_days()` for age calculations
- Fix deprecated utcnow usage in embedding_service.py

## Files
- `emdx/utils/datetime_utils.py` - New utilities
- `emdx/services/embedding_service.py` - Use new utilities

🤖 Generated with [Claude Code](https://claude.ai/claude-code)