### PR TITLE
fix(scripts): Only update poetry version in release script

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -137,10 +137,22 @@ def get_current_version() -> str:
 
 
 def bump_version(new_version: str) -> None:
-    """Bump the version in pyproject.toml."""
+    """Bump the version in pyproject.toml.
+
+    Only updates the [tool.poetry] version, not other version strings
+    like typer version or python_version.
+    """
     pyproject = Path("pyproject.toml")
     content = pyproject.read_text()
-    new_content = re.sub(r'version = "[^"]+"', f'version = "{new_version}"', content)
+
+    # Only replace the version in [tool.poetry] section
+    # Match: version = "x.y.z" that appears right after name = "emdx"
+    new_content = re.sub(
+        r'(\[tool\.poetry\]\nname = "emdx"\n)version = "[^"]+"',
+        f'\\1version = "{new_version}"',
+        content
+    )
+
     pyproject.write_text(new_content)
     print(f"Updated pyproject.toml to version {new_version}")
 


### PR DESCRIPTION
## Summary

The `scripts/release.py bump` command was replacing ALL version strings in pyproject.toml, corrupting other version configs.

## Problem

Before this fix, running `python scripts/release.py bump 0.9.1` would change:
- ✅ `version = "0.8.0"` → `version = "0.9.1"` (correct)
- ❌ `typer = {version = "^0.15.0"}` → `typer = {version = "0.9.1"}` (wrong!)
- ❌ `python_version = "3.13"` → `python_version = "0.9.1"` (wrong!)
- ❌ `minversion = "7.0.0"` → `minversion = "0.9.1"` (wrong!)

## Fix

Updated the regex to only match the version in `[tool.poetry]` section by anchoring it to the preceding lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)