### PR TITLE
fix(test): Remove gui from lazy loading test expectations

### DIFF
--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -200,7 +200,6 @@ class TestCLIIntegration:
             'emdx.commands.ask',
             'emdx.commands.similarity',
             'emdx.commands.gdoc',
-            'emdx.ui.gui',
         ]
 
         # Clear any cached imports


### PR DESCRIPTION
## Summary
- Removes `emdx.ui.gui` from the lazy loading test's list of expected-unloaded modules
- The gui command was moved from lazy to eager registration in #397 to fix it not launching, but the test wasn't updated

## Test plan
- [x] `test_help_does_not_load_lazy_modules` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)