### PR TITLE
fix(ui): Prevent activity view from jumping to cursor on refresh

### DIFF
--- a/emdx/ui/activity/activity_view.py
+++ b/emdx/ui/activity/activity_view.py
@@ -2141,14 +2141,15 @@ class ActivityView(HelpMixin, Widget):
             self._flatten_items()
             await self._update_table()
 
-        # Restore selection if possible
+        # Restore selection if possible (without scrolling — user may have
+        # scrolled away from the selected row and we shouldn't jump back)
         if selected_id:
             for idx, item in enumerate(self.flat_items):
                 if (item.item_type, item.item_id) == selected_id:
                     self.selected_idx = idx
                     try:
                         table = self.query_one("#activity-table", DataTable)
-                        table.move_cursor(row=idx)
+                        table.move_cursor(row=idx, scroll=False)
                     except Exception:
                         pass
                     break


### PR DESCRIPTION
## Summary
- Fix scroll position jumping in Activity screen during 5-second periodic refresh
- `_refresh_data()` called `move_cursor(row=idx)` to restore cursor selection, which auto-scrolled the viewport to the cursor row
- If you scrolled away from the selected row to browse other items, the next refresh would yank you back
- Fix: pass `scroll=False` to `move_cursor()` so the cursor is restored without moving the viewport

## Test plan
- [ ] Open TUI, scroll down in activity view, select a row
- [ ] Scroll back up to the top of the list
- [ ] Wait 5+ seconds for periodic refresh
- [ ] Verify the viewport stays at the top (no jump back to selected row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)