### PR TITLE
refactor(ui): Replace DataTable with Tree widget to fix activity scroll jumping (Issue #403)

### DIFF
--- a/emdx/ui/activity/__init__.py
+++ b/emdx/ui/activity/__init__.py
@@ -1,6 +1,8 @@
 """Activity view - Mission Control for EMDX."""
 
 from .activity_view import ActivityView
+from .activity_tree import ActivityTree
 from .sparkline import sparkline
 
-__all__ = ["ActivityView", "sparkline"]
+__all__ = ["ActivityView", "ActivityTree", "sparkline"]
+

--- a/emdx/ui/activity/activity_data.py
+++ b/emdx/ui/activity/activity_data.py
@@ -1,0 +1,523 @@
+"""Activity data loading — extracts DB queries from activity_view.py.
+
+Produces typed ActivityItem subclasses from activity_items.py.
+"""
+
+import json
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from emdx.utils.datetime_utils import parse_datetime
+
+from .activity_items import (
+    ActivityItem,
+    WorkflowItem,
+    DocumentItem,
+    GroupItem,
+    CascadeRunItem,
+    CascadeStageItem,
+    AgentExecutionItem,
+    MailItem,
+)
+
+logger = logging.getLogger(__name__)
+
+# Import services (same guards as activity_view)
+try:
+    from emdx.workflows import database as wf_db
+    from emdx.workflows.registry import workflow_registry
+
+    HAS_WORKFLOWS = True
+except ImportError:
+    wf_db = None
+    workflow_registry = None
+    HAS_WORKFLOWS = False
+
+try:
+    from emdx.database import documents as doc_db
+    from emdx.database import groups as groups_db
+    from emdx.database.documents import (
+        get_workflow_document_ids,
+        list_non_workflow_documents,
+    )
+
+    HAS_DOCS = True
+    HAS_GROUPS = True
+except ImportError:
+    doc_db = None
+    groups_db = None
+    HAS_DOCS = False
+    HAS_GROUPS = False
+
+    def get_workflow_document_ids():
+        return set()
+
+    def list_non_workflow_documents(**kwargs):
+        return []
+
+
+class ActivityDataLoader:
+    """Loads activity data from DB and returns typed ActivityItem instances."""
+
+    def __init__(self) -> None:
+        # Track workflow states for completion notifications
+        self._last_workflow_states: Dict[int, str] = {}
+        # Callbacks for notifications
+        self.on_workflow_complete: Optional[callable] = None
+
+    async def load_all(self, zombies_cleaned: bool = True) -> List[ActivityItem]:
+        """Load all activity items, sorted.
+
+        Args:
+            zombies_cleaned: Whether zombie cleanup has already been done.
+
+        Returns:
+            Sorted list of typed ActivityItem instances.
+        """
+        items: List[ActivityItem] = []
+
+        # Clean up zombie workflow runs on first load
+        if HAS_WORKFLOWS and wf_db and not zombies_cleaned:
+            try:
+                cleaned = wf_db.cleanup_zombie_workflow_runs(max_age_hours=24.0)
+                if cleaned > 0:
+                    logger.info(f"Cleaned up {cleaned} zombie workflow runs")
+            except Exception as e:
+                logger.debug(f"Could not cleanup zombies: {e}")
+
+        if HAS_GROUPS and groups_db:
+            items.extend(await self._load_groups())
+
+        if HAS_WORKFLOWS and wf_db:
+            items.extend(await self._load_workflows())
+
+        if HAS_DOCS and doc_db:
+            items.extend(await self._load_direct_saves())
+
+        items.extend(await self._load_cascade_executions())
+        items.extend(await self._load_agent_executions())
+        items.extend(await self._load_mail_messages())
+
+        # Sort: running items first (pinned), then by timestamp descending
+        def sort_key(item: ActivityItem) -> Tuple:
+            is_running = (
+                (item.item_type == "workflow" and item.status == "running")
+                or (item.item_type == "agent_execution" and item.status == "running")
+                or (item.item_type == "mail" and not getattr(item, "is_read", True))
+            )
+            return (
+                0 if is_running else 1,
+                -item.timestamp.timestamp() if item.timestamp else 0,
+            )
+
+        items.sort(key=sort_key)
+        return items
+
+    async def _load_workflows(self) -> List[ActivityItem]:
+        """Load workflow runs into typed WorkflowItem instances.
+
+        Merges stage_runs + individual_runs into a single pass to halve DB calls.
+        """
+        items: List[ActivityItem] = []
+        try:
+            runs = wf_db.list_workflow_runs(limit=50)
+
+            for run in runs:
+                started = parse_datetime(run.get("started_at")) or datetime.now()
+
+                # Skip zombie running workflows (running for > 2 hours)
+                if run.get("status") == "running":
+                    age_hours = (datetime.now() - started).total_seconds() / 3600
+                    if age_hours > 2:
+                        continue
+
+                # Get workflow name
+                wf_name = "Workflow"
+                if workflow_registry:
+                    try:
+                        wf = workflow_registry.get_workflow(run["workflow_id"])
+                        if wf:
+                            wf_name = wf.display_name
+                    except Exception:
+                        pass
+
+                # Get task title from input variables
+                task_title = ""
+                try:
+                    input_vars = run.get("input_variables")
+                    if isinstance(input_vars, str):
+                        input_vars = json.loads(input_vars)
+                    if input_vars:
+                        task_title = input_vars.get("task_title", "")
+                except Exception:
+                    pass
+
+                title = task_title or wf_name
+
+                # Single pass over stage_runs and individual_runs
+                # (previously done twice: once for cost, once for outputs/progress)
+                cost = run.get("total_cost_usd", 0) or 0
+                has_outputs = False
+                output_doc_id = None
+                output_count = 0
+                total_target = 0
+                total_completed = 0
+                current_stage = ""
+                is_synthesizing = False
+                total_input_tokens = 0
+                total_output_tokens = 0
+                cost_from_runs = 0.0
+
+                try:
+                    stage_runs = wf_db.list_stage_runs(run["id"])
+                    for sr in stage_runs:
+                        target = sr.get("target_runs", 1)
+                        completed = sr.get("runs_completed", 0)
+                        total_target += target
+                        total_completed += completed
+
+                        if sr.get("status") == "running":
+                            current_stage = sr.get("stage_name", "")
+                        elif sr.get("status") == "synthesizing":
+                            current_stage = sr.get("stage_name", "")
+                            is_synthesizing = True
+
+                        if sr.get("synthesis_doc_id"):
+                            output_count += 1
+                            has_outputs = True
+                            if not output_doc_id:
+                                output_doc_id = sr["synthesis_doc_id"]
+
+                        ind_runs = wf_db.list_individual_runs(sr["id"])
+                        for ir in ind_runs:
+                            total_input_tokens += ir.get("input_tokens", 0) or 0
+                            total_output_tokens += ir.get("output_tokens", 0) or 0
+                            ir_cost = ir.get("cost_usd", 0) or 0
+                            cost_from_runs += ir_cost
+                            if ir.get("output_doc_id"):
+                                output_count += 1
+                                has_outputs = True
+                                if not output_doc_id:
+                                    output_doc_id = ir["output_doc_id"]
+                except Exception as e:
+                    logger.debug(f"Error scanning workflow outputs for run {run['id']}: {e}")
+
+                # Use summed cost from runs if top-level cost is missing
+                if not cost:
+                    cost = cost_from_runs
+
+                # For completed workflows, use output document timestamp
+                timestamp = started
+                if output_doc_id and run.get("status") in ("completed", "failed") and HAS_DOCS:
+                    try:
+                        out_doc = doc_db.get_document(output_doc_id)
+                        if out_doc:
+                            doc_created = parse_datetime(out_doc.get("created_at"))
+                            if doc_created:
+                                timestamp = doc_created
+                    except Exception:
+                        pass
+
+                item = WorkflowItem(
+                    item_id=run["id"],
+                    title=title,
+                    timestamp=timestamp,
+                    workflow_run=run,
+                    status=run.get("status", "unknown"),
+                    cost=cost,
+                    tokens=0,
+                    input_tokens=total_input_tokens,
+                    output_tokens=total_output_tokens,
+                    progress_completed=total_completed if run.get("status") == "running" else 0,
+                    progress_total=total_target if run.get("status") == "running" else 0,
+                    progress_stage=current_stage if run.get("status") == "running" else "",
+                    output_count=output_count,
+                    doc_id=output_doc_id if run.get("status") in ("completed", "failed") else None,
+                    has_workflow_outputs=has_outputs,
+                )
+
+                # Store synthesizing state for display
+                if run.get("status") == "running" and is_synthesizing:
+                    item._is_synthesizing = True
+
+                # Track for notifications
+                old_status = self._last_workflow_states.get(run["id"])
+                new_status = run.get("status")
+                if old_status == "running" and new_status in ("completed", "failed"):
+                    if self.on_workflow_complete:
+                        self.on_workflow_complete(run["id"], new_status == "completed")
+                self._last_workflow_states[run["id"]] = new_status
+
+                items.append(item)
+
+        except Exception as e:
+            logger.error(f"Error loading workflows: {e}", exc_info=True)
+
+        return items
+
+    async def _load_groups(self) -> List[ActivityItem]:
+        """Load document groups into typed GroupItem instances."""
+        items: List[ActivityItem] = []
+        try:
+            top_groups = groups_db.list_groups(top_level_only=True)
+
+            for group in top_groups:
+                group_id = group["id"]
+                created = parse_datetime(group.get("created_at")) or datetime.now()
+                child_groups = groups_db.get_child_groups(group_id)
+                doc_count = groups_db.get_recursive_doc_count(group_id)
+
+                item = GroupItem(
+                    item_id=group_id,
+                    title=group["name"],
+                    timestamp=created,
+                    group=group,
+                    doc_count=doc_count,
+                    total_cost=group.get("total_cost_usd", 0) or 0,
+                    total_tokens=group.get("total_tokens", 0) or 0,
+                    child_group_count=len(child_groups),
+                    cost=group.get("total_cost_usd", 0) or 0,
+                )
+
+                items.append(item)
+
+        except Exception as e:
+            logger.error(f"Error loading groups: {e}", exc_info=True)
+
+        return items
+
+    async def _load_direct_saves(self) -> List[ActivityItem]:
+        """Load documents not created by workflows or added to groups."""
+        items: List[ActivityItem] = []
+        try:
+            grouped_doc_ids: Set[int] = set()
+            if HAS_GROUPS and groups_db:
+                try:
+                    grouped_doc_ids = groups_db.get_all_grouped_document_ids()
+                except Exception as e:
+                    logger.debug(f"Error getting grouped doc IDs: {e}")
+
+            docs = list_non_workflow_documents(limit=100, days=7, include_archived=False)
+
+            for doc in docs:
+                doc_id = doc["id"]
+                if doc_id in grouped_doc_ids:
+                    continue
+
+                created = doc.get("created_at")
+                title = doc.get("title", "")
+                children_docs = doc_db.get_children(doc_id, include_archived=False)
+                has_children = len(children_docs) > 0
+
+                item = DocumentItem(
+                    item_id=doc_id,
+                    title=title or "Untitled",
+                    status="completed",
+                    timestamp=parse_datetime(created) or datetime.now(),
+                    doc_id=doc_id,
+                    has_children=has_children,
+                )
+
+                items.append(item)
+
+        except Exception as e:
+            logger.error(f"Error loading direct saves: {e}", exc_info=True)
+
+        return items
+
+    async def _load_cascade_executions(self) -> List[ActivityItem]:
+        """Load cascade executions into CascadeRunItem instances."""
+        items: List[ActivityItem] = []
+        try:
+            from emdx.database.connection import db_connection
+            from emdx.database import cascade as cascade_db
+
+            cutoff = datetime.now() - timedelta(days=7)
+            seen_run_ids: Set[int] = set()
+
+            # Load cascade runs (grouped view)
+            try:
+                runs = cascade_db.list_cascade_runs(limit=30)
+
+                for run in runs:
+                    run_id = run.get("id")
+                    if not run_id:
+                        continue
+
+                    seen_run_ids.add(run_id)
+                    timestamp = parse_datetime(run.get("started_at")) or datetime.now()
+                    title = run.get("initial_doc_title", f"Cascade Run #{run_id}")[:40]
+                    executions = cascade_db.get_cascade_run_executions(run_id)
+
+                    item = CascadeRunItem(
+                        item_id=run_id,
+                        title=title,
+                        timestamp=timestamp,
+                        cascade_run=run,
+                        status=run.get("status", "running"),
+                        pipeline_name=run.get("pipeline_name", "default"),
+                        current_stage=run.get("current_stage", ""),
+                        execution_count=len(executions),
+                    )
+                    items.append(item)
+
+            except Exception as e:
+                logger.debug(f"Could not load cascade runs (may not exist yet): {e}")
+
+            # Backward-compat: individual executions not part of any run
+            with db_connection.get_connection() as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT e.id, e.doc_id, e.doc_title, e.status, e.started_at, e.completed_at,
+                           d.stage, d.pr_url, e.cascade_run_id
+                    FROM executions e
+                    LEFT JOIN documents d ON e.doc_id = d.id
+                    WHERE e.doc_id IS NOT NULL
+                      AND e.started_at > ?
+                      AND (e.cascade_run_id IS NULL OR e.cascade_run_id NOT IN (SELECT id FROM cascade_runs))
+                      AND e.id = (
+                          SELECT MAX(e2.id) FROM executions e2
+                          WHERE e2.doc_id = e.doc_id
+                      )
+                    ORDER BY e.started_at DESC
+                    LIMIT 50
+                    """,
+                    (cutoff.isoformat(),),
+                )
+                rows = cursor.fetchall()
+
+            for row in rows:
+                exec_id, doc_id, doc_title, status, started_at, completed_at, stage, pr_url, run_id = row
+
+                if run_id and run_id in seen_run_ids:
+                    continue
+
+                timestamp = parse_datetime(started_at) or datetime.now()
+                title = doc_title or f"Document #{doc_id}"
+                if stage:
+                    title = f"📋 {title}"
+                if pr_url:
+                    title = f"🔗 {title}"
+
+                # Use CascadeStageItem for individual cascade executions (backward compat)
+                item = CascadeStageItem(
+                    item_id=exec_id,
+                    title=title,
+                    status=status or "unknown",
+                    timestamp=timestamp,
+                    doc_id=doc_id,
+                    stage=stage or "",
+                )
+                items.append(item)
+
+        except Exception as e:
+            logger.error(f"Error loading cascade executions: {e}", exc_info=True)
+
+        return items
+
+    async def _load_agent_executions(self) -> List[ActivityItem]:
+        """Load standalone agent executions."""
+        items: List[ActivityItem] = []
+        try:
+            from emdx.database.connection import db_connection
+
+            cutoff = datetime.now() - timedelta(days=7)
+
+            with db_connection.get_connection() as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT e.id, e.doc_id, e.doc_title, e.status, e.started_at,
+                           e.completed_at, e.log_file, e.exit_code, e.working_dir
+                    FROM executions e
+                    WHERE e.started_at > ?
+                      AND e.doc_title LIKE 'Agent:%'
+                      AND e.cascade_run_id IS NULL
+                    ORDER BY e.started_at DESC
+                    LIMIT 30
+                    """,
+                    (cutoff.isoformat(),),
+                )
+                rows = cursor.fetchall()
+
+            for row in rows:
+                exec_id, doc_id, doc_title, status, started_at, completed_at, log_file, exit_code, working_dir = row
+
+                timestamp = parse_datetime(started_at) or datetime.now()
+
+                cli_tool = "claude"
+                if log_file and "cursor" in log_file.lower():
+                    cli_tool = "cursor"
+
+                title = doc_title or f"Execution #{exec_id}"
+                if title.startswith("Agent: "):
+                    title = title[7:]
+                title = title[:50]
+
+                item = AgentExecutionItem(
+                    item_id=exec_id,
+                    title=title,
+                    timestamp=timestamp,
+                    execution={
+                        "id": exec_id,
+                        "doc_id": doc_id,
+                        "doc_title": doc_title,
+                        "status": status,
+                        "started_at": started_at,
+                        "completed_at": completed_at,
+                        "log_file": log_file,
+                        "exit_code": exit_code,
+                        "working_dir": working_dir,
+                    },
+                    status=status or "unknown",
+                    doc_id=doc_id,
+                    log_file=log_file or "",
+                    cli_tool=cli_tool,
+                )
+                items.append(item)
+
+        except Exception as e:
+            logger.error(f"Error loading agent executions: {e}", exc_info=True)
+
+        return items
+
+    async def _load_mail_messages(self) -> List[ActivityItem]:
+        """Load mail messages."""
+        items: List[ActivityItem] = []
+        try:
+            import asyncio
+            from emdx.services.mail_service import get_mail_service, get_mail_config_repo
+
+            if not get_mail_config_repo():
+                return items
+
+            service = get_mail_service()
+            messages = await asyncio.to_thread(service.list_inbox, limit=20)
+
+            for msg in messages:
+                ts = parse_datetime(msg.created_at)
+                timestamp = ts.replace(tzinfo=None) if ts and ts.tzinfo else (ts or datetime.now())
+
+                item = MailItem(
+                    item_id=msg.number,
+                    title=msg.title,
+                    timestamp=timestamp,
+                    mail_message={
+                        "body": msg.body,
+                        "sender": msg.sender,
+                        "recipient": msg.recipient,
+                        "url": msg.url,
+                        "comment_count": msg.comment_count,
+                    },
+                    sender=msg.sender,
+                    recipient=msg.recipient,
+                    is_read=msg.is_read,
+                    comment_count=msg.comment_count,
+                    url=msg.url,
+                )
+                items.append(item)
+
+        except Exception as e:
+            logger.debug(f"Could not load mail messages: {e}")
+
+        return items

--- a/emdx/ui/activity/activity_tree.py
+++ b/emdx/ui/activity/activity_tree.py
@@ -1,0 +1,226 @@
+"""ActivityTree — Tree[ActivityItem] widget for the activity view.
+
+Replaces DataTable with Textual's native Tree widget to eliminate
+scroll jumping on periodic refresh. TreeNode objects persist across
+refreshes; we update .data and .label via set_label() which only
+repaints the label line, never touching scroll or cursor position.
+"""
+
+import logging
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
+
+from rich.text import Text
+from textual.widgets import Tree
+from textual.widgets._tree import TreeNode
+
+from .activity_items import ActivityItem
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Type alias for the key that uniquely identifies an item
+ItemKey = Tuple[str, int]  # (item_type, item_id)
+
+
+def _item_key(item: ActivityItem) -> ItemKey:
+    """Return a unique key for an ActivityItem."""
+    return (item.item_type, item.item_id)
+
+
+class ActivityTree(Tree[ActivityItem]):
+    """Tree widget for the activity stream.
+
+    Each TreeNode.data holds an ActivityItem instance.
+    The tree handles expand/collapse, cursor tracking, and scroll
+    preservation natively — no manual ViewState needed.
+    """
+
+    show_root = False
+    show_guides = False
+    guide_depth = 2
+    auto_expand = False  # We handle expand/collapse explicitly
+
+    BINDINGS = []  # Parent ActivityView owns all bindings
+
+    def _make_label(self, item: ActivityItem) -> str:
+        """Build a Rich-markup label string for a tree node.
+
+        Combines icon + time + title + badge/progress + id into a
+        single line. The Tree's built-in guide lines handle indentation.
+        """
+        from .activity_view import format_time_ago
+
+        # Icon: status icon for actionable states, type icon otherwise
+        is_recently_completed = (
+            item.item_type == "workflow"
+            and hasattr(self, "_recently_completed")
+            and item.item_id in self._recently_completed
+        )
+        if is_recently_completed:
+            icon = "✨"
+        elif item.status in ("running", "failed", "pending", "queued"):
+            icon = item.status_icon
+        else:
+            icon = item.type_icon
+
+        time_str = format_time_ago(item.timestamp)
+
+        # Badge or progress bar
+        suffix = ""
+        output_count = getattr(item, "output_count", 0)
+        doc_count = getattr(item, "doc_count", 0)
+
+        if item.item_type == "workflow" and item.status == "running":
+            progress_total = getattr(item, "progress_total", 0)
+            progress_completed = getattr(item, "progress_completed", 0)
+            if getattr(item, "_is_synthesizing", False):
+                suffix = " 🔮 Synthesizing..."
+            elif progress_total > 0:
+                pct = progress_completed / progress_total
+                bar_width = 10
+                filled_exact = pct * bar_width
+                filled_full = int(filled_exact)
+                remainder = filled_exact - filled_full
+                partial_chars = " ▏▎▍▌▋▊▉█"
+                partial_idx = int(remainder * 8)
+                partial = partial_chars[partial_idx] if partial_idx > 0 else ""
+                empty = bar_width - filled_full - (1 if partial else 0)
+                bar = "█" * filled_full + partial + "░" * empty
+                suffix = f" {bar} {progress_completed}/{progress_total}"
+        elif not item.expanded:
+            if output_count > 0 and item.item_type == "workflow":
+                suffix = f" [{output_count}]"
+            elif doc_count > 0 and item.item_type == "group":
+                suffix = f" [{doc_count}]"
+
+        # ID string
+        if item.item_type in ("workflow", "group"):
+            id_str = f"#{item.item_id}" if item.item_id else ""
+        elif item.item_type in ("document", "exploration", "synthesis", "cascade"):
+            id_str = f"#{item.doc_id}" if getattr(item, "doc_id", None) else ""
+        elif item.item_type == "individual_run":
+            doc_id = getattr(item, "doc_id", None)
+            if doc_id:
+                id_str = f"#{doc_id}"
+            elif item.item_id:
+                id_str = f"r{item.item_id}"
+            else:
+                id_str = ""
+        else:
+            id_str = f"#{item.item_id}" if item.item_id else ""
+
+        # Combine: icon  time  title+suffix  id
+        parts = [icon, time_str, f"{item.title}{suffix}"]
+        if id_str:
+            parts.append(id_str)
+        return "  ".join(parts)
+
+    def populate_from_items(self, items: List[ActivityItem]) -> None:
+        """Initial full load: clear tree and add all top-level items."""
+        self.clear()
+        for item in items:
+            if item.can_expand():
+                node = self.root.add(self._make_label(item), data=item)
+                node.allow_expand = True
+            else:
+                node = self.root.add_leaf(self._make_label(item), data=item)
+
+    def refresh_from_items(self, items: List[ActivityItem]) -> None:
+        """Diff-based periodic refresh.
+
+        Updates existing nodes in-place via set_label() (no scroll disruption).
+        Adds new nodes and removes stale ones.
+        Recursively refreshes children of expanded nodes.
+        """
+        self._refresh_children(self.root, items)
+
+    def _refresh_children(
+        self, parent: TreeNode[ActivityItem], fresh_items: List[ActivityItem]
+    ) -> None:
+        """Diff and update children of a parent node."""
+        # Build map of existing children by item key
+        existing: Dict[ItemKey, TreeNode[ActivityItem]] = {}
+        for child in parent.children:
+            if child.data is not None:
+                existing[_item_key(child.data)] = child
+
+        # Build set of fresh keys for removal detection
+        fresh_keys = {_item_key(item) for item in fresh_items}
+
+        # Remove nodes no longer present
+        to_remove = [
+            node for key, node in existing.items() if key not in fresh_keys
+        ]
+        for node in to_remove:
+            node.remove()
+
+        # Rebuild existing map after removals
+        existing = {}
+        for child in parent.children:
+            if child.data is not None:
+                existing[_item_key(child.data)] = child
+
+        # Update existing nodes and add new ones
+        for i, item in enumerate(fresh_items):
+            key = _item_key(item)
+
+            if key in existing:
+                node = existing[key]
+                # Update data and label in-place
+                node.data = item
+                new_label = self._make_label(item)
+                node.set_label(new_label)
+
+                # Update expandability
+                if item.can_expand():
+                    node.allow_expand = True
+                else:
+                    node.allow_expand = False
+
+                # If this node is expanded, refresh its children too
+                if node.is_expanded and node.data and node.data.children:
+                    self._refresh_children(node, node.data.children)
+            else:
+                # New item — add it
+                if item.can_expand():
+                    parent.add(self._make_label(item), data=item)
+                else:
+                    parent.add_leaf(self._make_label(item), data=item)
+
+    def find_node_by_item_key(
+        self, item_type: str, item_id: int
+    ) -> Optional[TreeNode[ActivityItem]]:
+        """Walk the tree to find a node matching (item_type, item_id)."""
+        target_key = (item_type, item_id)
+
+        def _search(node: TreeNode[ActivityItem]) -> Optional[TreeNode[ActivityItem]]:
+            if node.data is not None and _item_key(node.data) == target_key:
+                return node
+            for child in node.children:
+                result = _search(child)
+                if result is not None:
+                    return result
+            return None
+
+        return _search(self.root)
+
+    def find_node_by_doc_id(
+        self, doc_id: int, skip_workflows: bool = True
+    ) -> Optional[TreeNode[ActivityItem]]:
+        """Walk the tree to find a node with a matching doc_id."""
+
+        def _search(node: TreeNode[ActivityItem]) -> Optional[TreeNode[ActivityItem]]:
+            if node.data is not None:
+                if skip_workflows and node.data.item_type == "workflow":
+                    pass  # Skip workflow nodes, look for actual document children
+                elif getattr(node.data, "doc_id", None) == doc_id:
+                    return node
+            for child in node.children:
+                result = _search(child)
+                if result is not None:
+                    return result
+            return None
+
+        return _search(self.root)

--- a/emdx/ui/activity_browser.py
+++ b/emdx/ui/activity_browser.py
@@ -102,9 +102,9 @@ class ActivityBrowser(Widget):
         """Focus the activity view."""
         if self.activity_view:
             try:
-                table = self.activity_view.query_one("#activity-table")
-                if table:
-                    table.focus()
+                tree = self.activity_view.query_one("#activity-tree")
+                if tree:
+                    tree.focus()
             except Exception:
                 # Widget not mounted yet, will focus on mount
                 pass


### PR DESCRIPTION
## Summary

- **Replaces `DataTable` with Textual's `Tree[ActivityItem]` widget** to permanently eliminate the activity view scroll-to-top bug on refresh
- **New `activity_tree.py`** (226 lines): `ActivityTree` widget with diff-based `refresh_from_items()` using `set_label()` — updates labels in-place, never disrupts scroll or cursor position
- **New `activity_data.py`** (523 lines): Extracted DB queries from `activity_view.py` into dedicated `ActivityDataLoader` class
- **Rewrote `activity_view.py`** (-326 net lines): Removed ~400 lines of manual tree management (`_ViewState`, `_flatten_items`, `_build_row_data`, `_update_table`, `flat_items`/`selected_idx` tracking) and replaced with Tree's native hierarchy, expand/collapse, and cursor tracking by node reference

### Why the old approach failed

The DataTable approach was fundamentally fragile:
1. Fresh `ActivityItem` objects created every 1s (new Python objects)
2. Expansion state had to be re-applied to these new objects
3. Row count changed during the expand/collapse restoration cycle
4. Selection tracked by integer index that drifts when rows shift

### Why Tree fixes it permanently

1. `TreeNode` objects persist across refreshes — we update `.data` and `.label`, never recreate them
2. Expansion state owned by `TreeNode` itself — persists automatically
3. `set_label()` triggers lazy repaint of individual lines — never changes tree structure
4. `cursor_node` is a direct reference to a `TreeNode` object, not an index

## Test plan

- [x] `poetry run pytest` — 411 tests pass, 5 skipped
- [ ] Launch TUI, verify all 6 item types render with correct icons/badges
- [ ] Expand/collapse with Enter, l, h works for all expandable types
- [ ] **Scroll down and verify it stays in place during 1-second refresh** (the core fix)
- [ ] Preview pane updates on cursor movement
- [ ] Live log streaming for running workflows
- [ ] Status bar shows counts/sparkline/cost
- [ ] Group picker operations work (g, G, u)
- [ ] `select_document_by_id` navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)