### PR TITLE
feat(ui): Render activity tree rows as aligned table columns (Issue #406)

### DIFF
--- a/emdx/ui/activity/activity_items.py
+++ b/emdx/ui/activity/activity_items.py
@@ -135,7 +135,7 @@ class WorkflowItem(ActivityItem):
                             doc_db.get_document(ir["output_doc_id"]) if doc_db else None
                         )
                         title = (
-                            doc.get("title", f"Run {run_num}")[:25]
+                            doc.get("title", f"Run {run_num}")
                             if doc
                             else f"Run {run_num}"
                         )
@@ -186,7 +186,7 @@ class WorkflowItem(ActivityItem):
                     children.append(
                         SynthesisItem(
                             item_id=sr["synthesis_doc_id"],
-                            title=title[:30],
+                            title=title,
                             timestamp=self.timestamp,
                             doc_id=sr["synthesis_doc_id"],
                             depth=self.depth + 1,
@@ -204,7 +204,7 @@ class WorkflowItem(ActivityItem):
                                 else None
                             )
                             out_title = (
-                                out_doc.get("title", f"Output #{ir['run_number']}")[:25]
+                                out_doc.get("title", f"Output #{ir['run_number']}")
                                 if out_doc
                                 else f"Output #{ir['run_number']}"
                             )
@@ -231,7 +231,7 @@ class WorkflowItem(ActivityItem):
                                 else None
                             )
                             title = (
-                                doc.get("title", f"Output #{ir['run_number']}")[:25]
+                                doc.get("title", f"Output #{ir['run_number']}")
                                 if doc
                                 else f"Output #{ir['run_number']}"
                             )
@@ -302,7 +302,7 @@ class DocumentItem(ActivityItem):
                 "variant": "≈",
             }.get(relationship, "")
 
-            title = child_doc.get("title", "")[:30]
+            title = child_doc.get("title", "")
             if rel_icon:
                 title = f"{rel_icon} {title}"
 
@@ -524,7 +524,7 @@ class CascadeRunItem(ActivityItem):
                 doc_stage = exec_data.get("doc_stage", "")
 
                 # Build title showing stage transition
-                title = exec_data.get("doc_title", "Stage execution")[:35]
+                title = exec_data.get("doc_title", "Stage execution")
                 if doc_stage:
                     title = f"{doc_stage}: {title}"
 
@@ -681,7 +681,7 @@ class GroupItem(ActivityItem):
             children.append(
                 GroupItem(
                     item_id=cg["id"],
-                    title=cg["name"][:35],
+                    title=cg["name"],
                     timestamp=self.timestamp,
                     group=cg,
                     doc_count=cg.get("doc_count", 0),
@@ -702,7 +702,7 @@ class GroupItem(ActivityItem):
                 "variant": "≈",
             }
             role_icon = role_icons.get(m.get("role", ""), "")
-            title = m.get("title", "Untitled")[:30]
+            title = m.get("title", "Untitled")
             if role_icon:
                 title = f"{role_icon} {title}"
 

--- a/emdx/ui/activity/activity_tree.py
+++ b/emdx/ui/activity/activity_tree.py
@@ -4,11 +4,22 @@ Replaces DataTable with Textual's native Tree widget to eliminate
 scroll jumping on periodic refresh. TreeNode objects persist across
 refreshes; we update .data and .label via set_label() which only
 repaints the label line, never touching scroll or cursor position.
+
+Each row is rendered as a table-like line with aligned columns.
+render_label() produces a fixed-width Text that, combined with the
+Tree's guide prefix, always fills the widget width:
+
+  Left edge                                          Right edge
+  |[guides][expand][icon] title..............  [time] [  id]|
+
+Title fills available space. Time and id are right-justified and
+aligned across all rows regardless of depth.
 """
 
 import logging
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
+from rich.style import Style
 from rich.text import Text
 from textual.widgets import Tree
 from textual.widgets._tree import TreeNode
@@ -23,10 +34,28 @@ logger = logging.getLogger(__name__)
 # Type alias for the key that uniquely identifies an item
 ItemKey = Tuple[str, int]  # (item_type, item_id)
 
+# guide_depth=2 is the minimum Textual allows.
+# With show_root=False, a node at depth d gets (d+1)*2 chars of guide prefix.
+GUIDE_DEPTH = 2
+
+# Right-side column widths
+TIME_WIDTH = 3   # "2m", "1h", "3d" — compact
+ID_WIDTH = 6     # " #5921" / "   #42" right-aligned
+
 
 def _item_key(item: ActivityItem) -> ItemKey:
     """Return a unique key for an ActivityItem."""
     return (item.item_type, item.item_id)
+
+
+def _node_depth(node: TreeNode) -> int:
+    """Compute depth of a node (0 = direct child of root)."""
+    depth = 0
+    n = node._parent
+    while n is not None and n._parent is not None:
+        depth += 1
+        n = n._parent
+    return depth
 
 
 class ActivityTree(Tree[ActivityItem]):
@@ -35,40 +64,48 @@ class ActivityTree(Tree[ActivityItem]):
     Each TreeNode.data holds an ActivityItem instance.
     The tree handles expand/collapse, cursor tracking, and scroll
     preservation natively — no manual ViewState needed.
+
+    Rows are rendered with aligned columns via render_label().
     """
 
     show_root = False
     show_guides = False
-    guide_depth = 2
-    auto_expand = False  # We handle expand/collapse explicitly
+    guide_depth = GUIDE_DEPTH
+    auto_expand = False
+
+    # Suppress Tree's default expand icons — we render our own in render_label()
+    ICON_NODE = ""
+    ICON_NODE_EXPANDED = ""
 
     BINDINGS = []  # Parent ActivityView owns all bindings
 
-    def _make_label(self, item: ActivityItem) -> str:
-        """Build a Rich-markup label string for a tree node.
+    def get_label_width(self, node: TreeNode[ActivityItem]) -> int:
+        """Return label width so virtual_size equals the viewport.
 
-        Combines icon + time + title + badge/progress + id into a
-        single line. The Tree's built-in guide lines handle indentation.
+        We need virtual_size.width == size.width so the Tree never
+        adds right-padding that would push our right-justified columns
+        away from the edge.
         """
-        from .activity_view import format_time_ago
+        depth = _node_depth(node)
+        guides_width = (depth + 1) * GUIDE_DEPTH
+        return max(0, self.size.width - guides_width)
 
-        # Icon: status icon for actionable states, type icon otherwise
+    def _get_icon(self, item: ActivityItem) -> str:
+        """Get the display icon for an item."""
         is_recently_completed = (
             item.item_type == "workflow"
             and hasattr(self, "_recently_completed")
             and item.item_id in self._recently_completed
         )
         if is_recently_completed:
-            icon = "✨"
+            return "✨"
         elif item.status in ("running", "failed", "pending", "queued"):
-            icon = item.status_icon
+            return item.status_icon
         else:
-            icon = item.type_icon
+            return item.type_icon
 
-        time_str = format_time_ago(item.timestamp)
-
-        # Badge or progress bar
-        suffix = ""
+    def _get_suffix(self, item: ActivityItem) -> str:
+        """Get the badge or progress bar suffix for an item's title."""
         output_count = getattr(item, "output_count", 0)
         doc_count = getattr(item, "doc_count", 0)
 
@@ -76,7 +113,7 @@ class ActivityTree(Tree[ActivityItem]):
             progress_total = getattr(item, "progress_total", 0)
             progress_completed = getattr(item, "progress_completed", 0)
             if getattr(item, "_is_synthesizing", False):
-                suffix = " 🔮 Synthesizing..."
+                return " 🔮 Synthesizing..."
             elif progress_total > 0:
                 pct = progress_completed / progress_total
                 bar_width = 10
@@ -88,34 +125,135 @@ class ActivityTree(Tree[ActivityItem]):
                 partial = partial_chars[partial_idx] if partial_idx > 0 else ""
                 empty = bar_width - filled_full - (1 if partial else 0)
                 bar = "█" * filled_full + partial + "░" * empty
-                suffix = f" {bar} {progress_completed}/{progress_total}"
+                return f" {bar} {progress_completed}/{progress_total}"
         elif not item.expanded:
             if output_count > 0 and item.item_type == "workflow":
-                suffix = f" [{output_count}]"
+                return f" [{output_count}]"
             elif doc_count > 0 and item.item_type == "group":
-                suffix = f" [{doc_count}]"
+                return f" [{doc_count}]"
+        return ""
 
-        # ID string
+    def _get_id_str(self, item: ActivityItem) -> str:
+        """Get the ID string for an item."""
         if item.item_type in ("workflow", "group"):
-            id_str = f"#{item.item_id}" if item.item_id else ""
+            return f"#{item.item_id}" if item.item_id else ""
         elif item.item_type in ("document", "exploration", "synthesis", "cascade"):
-            id_str = f"#{item.doc_id}" if getattr(item, "doc_id", None) else ""
+            return f"#{item.doc_id}" if getattr(item, "doc_id", None) else ""
         elif item.item_type == "individual_run":
             doc_id = getattr(item, "doc_id", None)
             if doc_id:
-                id_str = f"#{doc_id}"
+                return f"#{doc_id}"
             elif item.item_id:
-                id_str = f"r{item.item_id}"
+                return f"r{item.item_id}"
             else:
-                id_str = ""
+                return ""
         else:
-            id_str = f"#{item.item_id}" if item.item_id else ""
+            return f"#{item.item_id}" if item.item_id else ""
 
-        # Combine: icon  time  title+suffix  id
-        parts = [icon, time_str, f"{item.title}{suffix}"]
+    def _make_label(self, item: ActivityItem) -> str:
+        """Build a compact change-detection string for set_label().
+
+        The visual rendering is handled by render_label(). This string
+        is only used to detect changes (so set_label triggers repaints).
+        """
+        from .activity_view import format_time_ago
+
+        icon = self._get_icon(item)
+        time_str = format_time_ago(item.timestamp)
+        suffix = self._get_suffix(item)
+        id_str = self._get_id_str(item)
+        return f"{icon}|{time_str}|{item.title}{suffix}|{id_str}"
+
+    def render_label(
+        self, node: TreeNode[ActivityItem], base_style: Style, style: Style
+    ) -> Text:
+        """Render a fixed-width table row with aligned columns.
+
+        Layout: [expand][icon] title...  [time] [  id]
+
+        The Tree prepends (depth+1)*GUIDE_DEPTH chars of guides. We return
+        a Text exactly (widget_width - guides_width) chars wide, so that
+        guides + label = widget_width on every row. Time and id are
+        right-justified and stay flush against the right edge at every depth.
+        """
+        from .activity_view import format_time_ago
+
+        item = node.data
+        if item is None:
+            return Text("")
+
+        depth = _node_depth(node)
+        guides_width = (depth + 1) * GUIDE_DEPTH
+        widget_width = self.size.width
+        label_width = max(0, widget_width - guides_width)
+
+        # Expand indicator
+        if node._allow_expand:
+            expand = "▼ " if node.is_expanded else "▶ "
+        else:
+            expand = "  "
+
+        icon = self._get_icon(item)
+        time_str = format_time_ago(item.timestamp)
+        suffix = self._get_suffix(item)
+        full_title = f"{item.title}{suffix}"
+        id_str = self._get_id_str(item)
+
+        # Styles
+        title_style = style + Style(bold=True) if (
+            item.item_type == "workflow" and item.status == "running"
+        ) else style
+        icon_style = Style(color="red") if item.status == "failed" else style
+        dim = Style(dim=True)
+
+        # Build left portion: expand + "icon "
+        left = Text()
+        left.append(expand, style=base_style)
+        left.append(f"{icon} ", style=icon_style)
+        left_cells = left.cell_len
+
+        # Build right portion: " time  #id" (always present for alignment)
+        right = Text()
+        right.append(f" {time_str:>{TIME_WIDTH}}", style=dim)
         if id_str:
-            parts.append(id_str)
-        return "  ".join(parts)
+            right.append(f" {id_str:>{ID_WIDTH}}", style=dim)
+        right_cells = right.cell_len
+
+        # Title fills the remaining space exactly
+        title_avail = max(0, label_width - left_cells - right_cells)
+
+        # Truncate title to fit (accounting for cell width, not char count)
+        title_text = Text(full_title)
+        if title_text.cell_len > title_avail:
+            truncated = full_title
+            while Text(truncated + "…").cell_len > title_avail and truncated:
+                truncated = truncated[:-1]
+            title_display = truncated + "…" if truncated else ""
+        else:
+            title_display = full_title
+
+        # Pad title to exact cell width (pushes right columns flush-right)
+        title_cell_len = Text(title_display).cell_len
+        pad_needed = max(0, title_avail - title_cell_len)
+
+        # Assemble the row
+        text = Text()
+        text.append_text(left)
+        text.append(title_display, style=title_style)
+        if pad_needed > 0:
+            text.append(" " * pad_needed, style=base_style)
+        text.append_text(right)
+        return text
+
+    def _add_children(
+        self, parent: TreeNode[ActivityItem], children: List[ActivityItem]
+    ) -> None:
+        """Add child items to a parent node."""
+        for child in children:
+            if child.can_expand():
+                parent.add(self._make_label(child), data=child)
+            else:
+                parent.add_leaf(self._make_label(child), data=child)
 
     def populate_from_items(self, items: List[ActivityItem]) -> None:
         """Initial full load: clear tree and add all top-level items."""
@@ -174,10 +312,7 @@ class ActivityTree(Tree[ActivityItem]):
                 node.set_label(new_label)
 
                 # Update expandability
-                if item.can_expand():
-                    node.allow_expand = True
-                else:
-                    node.allow_expand = False
+                node.allow_expand = item.can_expand()
 
                 # If this node is expanded, refresh its children too
                 if node.is_expanded and node.data and node.data.children:

--- a/emdx/ui/activity/activity_view.py
+++ b/emdx/ui/activity/activity_view.py
@@ -1291,11 +1291,7 @@ class ActivityView(HelpMixin, Widget):
                 item.expanded = True
                 # Add children to tree node
                 node.remove_children()
-                for child in item.children:
-                    if child.can_expand():
-                        node.add(tree._make_label(child), data=child)
-                    else:
-                        node.add_leaf(tree._make_label(child), data=child)
+                tree._add_children(node, item.children)
                 node.expand()
             except Exception as e:
                 logger.error(f"Error expanding {item.item_type} #{item.item_id}: {e}", exc_info=True)
@@ -1316,11 +1312,7 @@ class ActivityView(HelpMixin, Widget):
                 item.children = await item.load_children(wf_db, doc_db)
                 item.expanded = True
                 node.remove_children()
-                for child in item.children:
-                    if child.can_expand():
-                        node.add(tree._make_label(child), data=child)
-                    else:
-                        node.add_leaf(tree._make_label(child), data=child)
+                tree._add_children(node, item.children)
                 node.expand()
             except Exception as e:
                 logger.error(f"Error expanding {item.item_type} #{item.item_id}: {e}", exc_info=True)
@@ -1407,11 +1399,7 @@ class ActivityView(HelpMixin, Widget):
                 item.children = await item.load_children(wf_db, doc_db)
                 item.expanded = True
                 tree = self.query_one("#activity-tree", ActivityTree)
-                for child in item.children:
-                    if child.can_expand():
-                        node.add(tree._make_label(child), data=child)
-                    else:
-                        node.add_leaf(tree._make_label(child), data=child)
+                tree._add_children(node, item.children)
             except Exception as e:
                 logger.error(f"Error loading children for {item.item_type} #{item.item_id}: {e}", exc_info=True)
 
@@ -1699,11 +1687,7 @@ class ActivityView(HelpMixin, Widget):
                         item.children = await item.load_children(wf_db, doc_db)
                         item.expanded = True
                         top_node.remove_children()
-                        for child in item.children:
-                            if child.can_expand():
-                                top_node.add(tree._make_label(child), data=child)
-                            else:
-                                top_node.add_leaf(tree._make_label(child), data=child)
+                        tree._add_children(top_node, item.children)
                         top_node.expand()
                     except Exception as e:
                         logger.error(f"Error expanding workflow: {e}")


### PR DESCRIPTION
## Summary
- Override `render_label()` in ActivityTree to produce fixed-width Rich.Text rows with aligned columns: `[expand][icon] title... [time] [id]`
- Time and ID columns are right-justified and stay flush against the right edge regardless of nesting depth
- Remove 8 hard title truncations (`[:25]`, `[:30]`, `[:35]`) from activity_items.py — render_label() now handles truncation dynamically based on available width
- Centralize child node creation via `_add_children()` helper

## Layout
```
Left edge                                          Right edge
|[guides][expand][icon] title..............  [time] [  id]|
```

- Guides: automatic from Tree widget (2 chars per depth level)
- Expand: `▶`/`▼`/` ` (2 chars)
- Icon: emoji status/type icon (measured dynamically for cell width)
- Title: flex-width, truncated with `…` when needed
- Time: right-justified, 3 chars (`2m`, `1h`, `3d`)
- ID: right-justified, 6 chars (`#5921`, `r42`)

## Key technical details
- `get_label_width()` override ensures `virtual_size.width == size.width` so the Tree never adds right-padding
- Uses Rich `Text.cell_len` for accurate emoji width measurement (emojis = 2 cells, symbols = 1 cell)
- `_make_label()` remains a pipe-delimited change-detection string for `set_label()` diff updates
- Works at any nesting depth — no artificial depth limits

## Test plan
- [x] `poetry run pytest` — all 411 tests pass (no tests touch the UI)
- [x] Visual verification: columns align across workflows, documents, groups, cascades at all depths
- [x] Expand/collapse works correctly with custom `▶`/`▼` icons
- [x] Progress bars render in the title column for running workflows
- [x] Scrolling doesn't jump (regression check for the core fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)