### PR TITLE
fix(activity): Prevent duplicate entries for synthesis docs

### DIFF
--- a/emdx/workflows/synthesis.py
+++ b/emdx/workflows/synthesis.py
@@ -125,6 +125,20 @@ async def synthesize_outputs(
                 output_doc_id = _save_fallback_synthesis(
                     stage_run_id, log_file, outputs, "Log"
                 )
+            else:
+                # Record document source so synthesis doc doesn't appear
+                # as a duplicate "direct save" in the activity view
+                try:
+                    sr = wf_db.get_stage_run(stage_run_id)
+                    if sr:
+                        record_document_source(
+                            document_id=output_doc_id,
+                            workflow_run_id=sr.get("workflow_run_id"),
+                            workflow_stage_run_id=stage_run_id,
+                            source_type="synthesis",
+                        )
+                except Exception as e:
+                    logger.debug(f"Failed to record synthesis source: {e}")
 
             return {
                 'output_doc_id': output_doc_id,


### PR DESCRIPTION
## Summary
- Fixes duplicate entries in the activity view where synthesis docs appeared both as children of their workflow run AND as standalone top-level items
- Root cause: `synthesize_outputs()` success path didn't call `record_document_source`, so synthesis docs weren't tracked in `document_sources` table
- The fallback path already had the call; this adds it to the success path too

## Root Cause Analysis

`emdx/workflows/synthesis.py` has two paths:

1. **Success path** (line 119-133): Claude synthesizes and saves via `emdx save` → `extract_output_doc_id` finds the doc → **but `record_document_source` was never called**
2. **Fallback path** (`_save_fallback_synthesis`): saves manually → correctly calls `record_document_source`

Without a `document_sources` entry, `list_non_workflow_documents()` (which uses `LEFT JOIN document_sources WHERE ds.id IS NULL`) included synthesis docs as "direct saves", causing them to appear twice in the activity view.

## Fix
- Added `record_document_source()` call to the success path in `synthesize_outputs()`
- Backfilled 20+ existing synthesis docs missing from `document_sources` in the live database

## Verification
- Confirmed via SQL that all synthesis docs now have `document_sources` entries
- 411 tests pass, 5 skipped

## Test plan
- [x] `poetry run pytest tests/ -x -q` — all pass
- [x] Backfilled existing data — `SELECT COUNT(*) ... WHERE synthesis_doc_id NOT IN document_sources` returns 0
- [ ] Open GUI, verify no duplicate synthesis docs appear in activity view

🤖 Generated with [Claude Code](https://claude.com/claude-code)