### PR TITLE
feat(save): Add --gist, --secret, --public flags to emdx save (#416)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,11 @@ poetry run emdx save "Remember to fix the API" --title "API Note"
 # Save text via stdin (also works)
 echo "My document content" | poetry run emdx save --title "Doc"
 cat notes.txt | poetry run emdx save --title "Notes"
+
+# Save and create a gist in one step
+poetry run emdx save "share this" --title "Shared Note" --gist
+poetry run emdx save notes.md --secret --copy   # --secret implies --gist
+poetry run emdx save notes.md --public --open    # --public implies --gist
 ```
 
 ### Search and Browse

--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -28,12 +28,23 @@ echo "Gameplan content" | emdx save --title "Auth Gameplan" --tags "gameplan,act
 
 # Save from command output
 ls -la | emdx save --title "Directory Listing"
+
+# Save and create a secret gist
+echo "Shareable notes" | emdx save --title "Notes" --gist
+
+# Save and create a public gist, copy URL
+emdx save notes.md --public --copy
 ```
 
 **Options:**
 - `--title TEXT` - Custom title (auto-detected from filename if not provided)
 - `--tags TEXT` - Comma-separated tags using text aliases
 - `--project TEXT` - Override project detection
+- `--gist` / `--share` - Create a GitHub gist after saving
+- `--secret` - Create a secret gist (default; implies `--gist`)
+- `--public` - Create a public gist (implies `--gist`)
+- `--copy, -c` - Copy gist URL to clipboard
+- `--open, -o` - Open gist in browser
 
 ### **emdx find**
 Search documents with full-text and tag-based search.
@@ -794,17 +805,23 @@ emdx gui
 GitHub Gist integration.
 
 ```bash
-# Create public gist from document
-emdx gist create 42
+# Create secret gist from document
+emdx gist 42
 
-# Create private gist
-emdx gist create 42 --private
+# Create public gist
+emdx gist 42 --public
+
+# Create gist and copy URL to clipboard
+emdx gist 42 --copy
 
 # List your gists
-emdx gist list
+emdx gist gist-list
+```
 
-# Import gist to knowledge base
-emdx gist import <gist_id>
+**Tip:** Use `emdx save --gist` (or `--secret`/`--public`) to save and create a gist in one step:
+
+```bash
+echo "content" | emdx save --title "Share Me" --secret --copy
 ```
 
 ## 📧 **Mail** (`emdx mail`)


### PR DESCRIPTION
## Summary
- Add `--gist`/`--share`, `--secret`, `--public`, `--copy`/`-c`, `--open`/`-o` flags to `emdx save`
- `--secret` and `--public` imply `--gist`, so `emdx save "content" --title "Note" --secret` just works — no need to remember `--gist`
- Gist creation is a post-save step: if it fails, the save still succeeds
- Reuses all existing gist utilities from `emdx/commands/gist.py`

## Test plan
- [ ] `echo "test" | emdx save --title "Test" --gist` creates a secret gist
- [ ] `emdx save "hello" --title "Hello" --secret --copy` creates secret gist + copies URL
- [ ] `emdx save "hello" --title "Hello" --public --open` creates public gist + opens browser
- [ ] `emdx save "hello" --title "Hello" --public --secret` errors with conflict message
- [ ] `echo "normal" | emdx save --title "Normal"` still works unchanged (no gist)
- [ ] `GITHUB_TOKEN= emdx save "test" --title "No Auth" --gist` warns but save succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)