### PR TITLE
fix(delegate): Fix NameError crashing synthesis in parallel delegate runs

### DIFF
--- a/emdx/utils/environment.py
+++ b/emdx/utils/environment.py
@@ -142,7 +142,7 @@ class EnvironmentValidator:
             self.warnings.append(f"EMDX config directory not found: {EMDX_CONFIG_DIR}")
         
         # Check log directory
-        log_dir = config_dir / "logs"
+        log_dir = EMDX_CONFIG_DIR / "logs"
         if not log_dir.exists():
             try:
                 log_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Fixed `NameError: name 'config_dir' is not defined` in `emdx/utils/environment.py:145` that crashed every synthesis execution during parallel delegate runs
- The `check_paths()` method referenced an undefined local variable `config_dir` instead of the module-level `EMDX_CONFIG_DIR` constant
- This caused all `emdx delegate --synthesize` and parallel `emdx delegate` runs to produce broken fallback synthesis documents with the error message embedded in the title

## Root Cause
Line 140 stores the config path into `self.info["config_dir"]` (a dict value), but line 145 tried to use a bare `config_dir` variable that was never defined in scope. The fix changes it to use `EMDX_CONFIG_DIR` which is the imported constant.

## Impact
Every parallel delegate run that triggered synthesis was affected. The synthesis agent would crash during environment validation, fall back to manual output concatenation, and produce documents titled `"Synthesis (error: name 'config_dir' is not defined) - <timestamp>"`.

## Test plan
- [x] Verified `validate_execution_environment()` no longer raises NameError
- [x] Full test suite passes (899 passed, 7 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)