### PR TITLE
refactor(database): Eliminate duplicate SQL in SQLiteDatabase (#37)

### DIFF
--- a/emdx/database/__init__.py
+++ b/emdx/database/__init__.py
@@ -31,19 +31,17 @@ from . import cascade
 
 
 class SQLiteDatabase:
-    """Backward-compatible wrapper for the original SQLiteDatabase class.
+    """Backward-compatible wrapper providing both global and isolated database access.
 
-    IMPORTANT: When instantiated with a custom db_path, this class implements
-    its own database operations directly on that database, rather than delegating
-    to global functions (which would use the global db_connection singleton).
+    Two modes of operation:
 
-    This is critical for test isolation - tests create SQLiteDatabase instances
-    with temporary database paths, and those instances MUST NOT write to the
-    global database.
+    1. **Global mode** (no db_path): Delegates all operations to the canonical
+       functions in database/documents.py and database/search.py, which use the
+       global db_connection singleton. This avoids duplicating SQL.
 
-    When instantiated WITHOUT a db_path (the default), this class uses the
-    global db_connection singleton. This ensures that test isolation fixtures
-    that replace db_connection will affect this instance too.
+    2. **Isolated mode** (custom db_path): Uses its own DatabaseConnection with
+       self-contained SQL for complete test isolation. Tests create instances
+       with temporary paths that MUST NOT touch the global database.
     """
 
     def __init__(self, db_path=None):
@@ -55,79 +53,59 @@ class SQLiteDatabase:
             # No path: use global db_connection (allows test fixture override)
             self._connection = None  # Will use db_connection dynamically
             self._uses_global_connection = True
-        # Track if we're using a custom path (for test isolation)
         self._uses_custom_path = db_path is not None
 
     def _get_connection_instance(self):
-        """Get the appropriate DatabaseConnection instance.
-
-        Returns the global db_connection if no custom path was provided,
-        otherwise returns the instance's own connection.
-
-        IMPORTANT: We import from .connection module dynamically to ensure
-        test isolation fixtures that replace connection.db_connection work
-        correctly. A static reference to db_connection would capture the
-        object at import time, missing later replacements.
-        """
+        """Get the appropriate DatabaseConnection instance."""
         if self._uses_global_connection:
-            # Dynamic lookup to support test fixture patching
             from . import connection
             return connection.db_connection
         return self._connection
 
     @property
     def db_path(self):
-        """Get database path"""
+        """Get database path."""
         return self._get_connection_instance().db_path
 
     def get_connection(self):
-        """Get database connection - delegates to connection module"""
+        """Get database connection."""
         return self._get_connection_instance().get_connection()
 
     def ensure_schema(self):
-        """Ensure database schema - delegates to connection module"""
+        """Ensure database schema."""
         return self._get_connection_instance().ensure_schema()
 
-    # Document operations - use instance connection to ensure test isolation
-    def save_document(self, title, content, project=None, tags=None, parent_id=None):
-        """Save a document to the database.
+    # ── Document operations ──────────────────────────────────────────────
+    #
+    # Global mode: delegate to database/documents.py (single source of truth).
+    # Isolated mode: self-contained SQL against the instance's own database.
 
-        When using a custom db_path (e.g., in tests), this operates on the
-        instance's database, not the global one.
-        """
-        with self._get_connection_instance().get_connection() as conn:
+    def save_document(self, title, content, project=None, tags=None, parent_id=None):
+        """Save a document to the database."""
+        if not self._uses_custom_path:
+            return save_document(title, content, project, tags, parent_id)
+
+        # Isolated mode — self-contained SQL for test databases
+        with self._connection.get_connection() as conn:
             cursor = conn.execute(
-                """
-                INSERT INTO documents (title, content, project, parent_id)
-                VALUES (?, ?, ?, ?)
-                """,
+                "INSERT INTO documents (title, content, project, parent_id) VALUES (?, ?, ?, ?)",
                 (title, content, project, parent_id),
             )
             conn.commit()
             doc_id = cursor.lastrowid
 
-            # Add tags if provided (only for global db, not test dbs)
-            if tags and not self._uses_custom_path:
-                from emdx.models.tags import add_tags_to_document
-                add_tags_to_document(doc_id, tags)
-            elif tags and self._uses_custom_path:
-                # For test databases, add tags directly via SQL
+            if tags:
                 for tag_name in tags:
                     tag_name = tag_name.lower().strip()
-                    # Get or create tag
-                    cursor = conn.execute(
-                        "SELECT id FROM tags WHERE name = ?", (tag_name,)
-                    )
+                    cursor = conn.execute("SELECT id FROM tags WHERE name = ?", (tag_name,))
                     result = cursor.fetchone()
                     if result:
                         tag_id = result[0]
                     else:
                         cursor = conn.execute(
-                            "INSERT INTO tags (name, usage_count) VALUES (?, 0)",
-                            (tag_name,),
+                            "INSERT INTO tags (name, usage_count) VALUES (?, 0)", (tag_name,),
                         )
                         tag_id = cursor.lastrowid
-                    # Link tag to document
                     conn.execute(
                         "INSERT OR IGNORE INTO document_tags (document_id, tag_id) VALUES (?, ?)",
                         (doc_id, tag_id),
@@ -138,18 +116,16 @@ class SQLiteDatabase:
 
     def get_document(self, identifier):
         """Get a document by ID or title."""
-        with self._get_connection_instance().get_connection() as conn:
-            identifier_str = str(identifier)
+        if not self._uses_custom_path:
+            return get_document(identifier)
 
+        # Isolated mode
+        with self._connection.get_connection() as conn:
+            identifier_str = str(identifier)
             if identifier_str.isdigit():
-                # Update access tracking
                 conn.execute(
-                    """
-                    UPDATE documents
-                    SET accessed_at = CURRENT_TIMESTAMP,
-                        access_count = access_count + 1
-                    WHERE id = ? AND is_deleted = FALSE
-                    """,
+                    "UPDATE documents SET accessed_at = CURRENT_TIMESTAMP, "
+                    "access_count = access_count + 1 WHERE id = ? AND is_deleted = FALSE",
                     (int(identifier_str),),
                 )
                 cursor = conn.execute(
@@ -158,60 +134,49 @@ class SQLiteDatabase:
                 )
             else:
                 conn.execute(
-                    """
-                    UPDATE documents
-                    SET accessed_at = CURRENT_TIMESTAMP,
-                        access_count = access_count + 1
-                    WHERE LOWER(title) = LOWER(?) AND is_deleted = FALSE
-                    """,
+                    "UPDATE documents SET accessed_at = CURRENT_TIMESTAMP, "
+                    "access_count = access_count + 1 WHERE LOWER(title) = LOWER(?) AND is_deleted = FALSE",
                     (identifier_str,),
                 )
                 cursor = conn.execute(
                     "SELECT * FROM documents WHERE LOWER(title) = LOWER(?) AND is_deleted = FALSE",
                     (identifier_str,),
                 )
-
             conn.commit()
             row = cursor.fetchone()
             return dict(row) if row else None
 
     def list_documents(self, project=None, limit=50, include_archived=False):
         """List documents with optional filters."""
-        with self._get_connection_instance().get_connection() as conn:
+        if not self._uses_custom_path:
+            return list_documents(project, limit, include_archived)
+
+        # Isolated mode
+        with self._connection.get_connection() as conn:
             conditions = ["is_deleted = FALSE"]
             params = []
-
             if not include_archived:
                 conditions.append("archived_at IS NULL")
-
             if project:
                 conditions.append("project = ?")
                 params.append(project)
-
             where_clause = " AND ".join(conditions)
             params.append(limit)
-
             cursor = conn.execute(
-                f"""
-                SELECT id, title, project, created_at, access_count
-                FROM documents
-                WHERE {where_clause}
-                ORDER BY id DESC
-                LIMIT ?
-                """,
+                f"SELECT id, title, project, created_at, access_count "
+                f"FROM documents WHERE {where_clause} ORDER BY id DESC LIMIT ?",
                 params,
             )
             return [dict(row) for row in cursor.fetchall()]
 
     def update_document(self, doc_id, title, content):
         """Update a document."""
-        with self._get_connection_instance().get_connection() as conn:
+        if not self._uses_custom_path:
+            return update_document(doc_id, title, content)
+
+        with self._connection.get_connection() as conn:
             cursor = conn.execute(
-                """
-                UPDATE documents
-                SET title = ?, content = ?, updated_at = CURRENT_TIMESTAMP
-                WHERE id = ?
-                """,
+                "UPDATE documents SET title = ?, content = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
                 (title, content, doc_id),
             )
             conn.commit()
@@ -219,9 +184,11 @@ class SQLiteDatabase:
 
     def delete_document(self, identifier, hard_delete=False):
         """Delete a document (soft delete by default)."""
-        with self._get_connection_instance().get_connection() as conn:
-            identifier_str = str(identifier)
+        if not self._uses_custom_path:
+            return delete_document(identifier, hard_delete)
 
+        with self._connection.get_connection() as conn:
+            identifier_str = str(identifier)
             if hard_delete:
                 if identifier_str.isdigit():
                     cursor = conn.execute(
@@ -236,118 +203,91 @@ class SQLiteDatabase:
             else:
                 if identifier_str.isdigit():
                     cursor = conn.execute(
-                        """
-                        UPDATE documents
-                        SET is_deleted = TRUE, deleted_at = CURRENT_TIMESTAMP
-                        WHERE id = ? AND is_deleted = FALSE
-                        """,
+                        "UPDATE documents SET is_deleted = TRUE, deleted_at = CURRENT_TIMESTAMP "
+                        "WHERE id = ? AND is_deleted = FALSE",
                         (int(identifier_str),),
                     )
                 else:
                     cursor = conn.execute(
-                        """
-                        UPDATE documents
-                        SET is_deleted = TRUE, deleted_at = CURRENT_TIMESTAMP
-                        WHERE LOWER(title) = LOWER(?) AND is_deleted = FALSE
-                        """,
+                        "UPDATE documents SET is_deleted = TRUE, deleted_at = CURRENT_TIMESTAMP "
+                        "WHERE LOWER(title) = LOWER(?) AND is_deleted = FALSE",
                         (identifier_str,),
                     )
-
             conn.commit()
             return cursor.rowcount > 0
 
     def get_recent_documents(self, limit=10):
         """Get recently accessed documents."""
-        with self._get_connection_instance().get_connection() as conn:
+        if not self._uses_custom_path:
+            return get_recent_documents(limit)
+
+        with self._connection.get_connection() as conn:
             cursor = conn.execute(
-                """
-                SELECT id, title, project, accessed_at, access_count
-                FROM documents
-                WHERE is_deleted = FALSE
-                ORDER BY accessed_at DESC
-                LIMIT ?
-                """,
+                "SELECT id, title, project, accessed_at, access_count "
+                "FROM documents WHERE is_deleted = FALSE ORDER BY accessed_at DESC LIMIT ?",
                 (limit,),
             )
             return [dict(row) for row in cursor.fetchall()]
 
     def get_stats(self, project=None):
         """Get database statistics."""
-        with self._get_connection_instance().get_connection() as conn:
+        if not self._uses_custom_path:
+            return get_stats(project)
+
+        with self._connection.get_connection() as conn:
             if project:
                 cursor = conn.execute(
-                    """
-                    SELECT
-                        COUNT(*) as total_documents,
-                        SUM(access_count) as total_views,
-                        AVG(access_count) as avg_views
-                    FROM documents
-                    WHERE project = ? AND is_deleted = FALSE
-                    """,
+                    "SELECT COUNT(*) as total_documents, SUM(access_count) as total_views, "
+                    "AVG(access_count) as avg_views FROM documents "
+                    "WHERE project = ? AND is_deleted = FALSE",
                     (project,),
                 )
             else:
                 cursor = conn.execute(
-                    """
-                    SELECT
-                        COUNT(*) as total_documents,
-                        COUNT(DISTINCT project) as total_projects,
-                        SUM(access_count) as total_views,
-                        AVG(access_count) as avg_views
-                    FROM documents
-                    WHERE is_deleted = FALSE
-                    """
+                    "SELECT COUNT(*) as total_documents, COUNT(DISTINCT project) as total_projects, "
+                    "SUM(access_count) as total_views, AVG(access_count) as avg_views "
+                    "FROM documents WHERE is_deleted = FALSE"
                 )
             return dict(cursor.fetchone())
 
     def list_deleted_documents(self, days=None, limit=50):
         """List soft-deleted documents."""
-        with self._get_connection_instance().get_connection() as conn:
+        if not self._uses_custom_path:
+            return list_deleted_documents(days, limit)
+
+        with self._connection.get_connection() as conn:
             if days:
                 cursor = conn.execute(
-                    """
-                    SELECT id, title, project, deleted_at, access_count
-                    FROM documents
-                    WHERE is_deleted = TRUE
-                    AND deleted_at >= datetime('now', '-' || ? || ' days')
-                    ORDER BY deleted_at DESC
-                    LIMIT ?
-                    """,
+                    "SELECT id, title, project, deleted_at, access_count FROM documents "
+                    "WHERE is_deleted = TRUE AND deleted_at >= datetime('now', '-' || ? || ' days') "
+                    "ORDER BY deleted_at DESC LIMIT ?",
                     (days, limit),
                 )
             else:
                 cursor = conn.execute(
-                    """
-                    SELECT id, title, project, deleted_at, access_count
-                    FROM documents
-                    WHERE is_deleted = TRUE
-                    ORDER BY deleted_at DESC
-                    LIMIT ?
-                    """,
+                    "SELECT id, title, project, deleted_at, access_count FROM documents "
+                    "WHERE is_deleted = TRUE ORDER BY deleted_at DESC LIMIT ?",
                     (limit,),
                 )
             return [dict(row) for row in cursor.fetchall()]
 
     def restore_document(self, identifier):
         """Restore a soft-deleted document."""
-        with self._get_connection_instance().get_connection() as conn:
+        if not self._uses_custom_path:
+            return restore_document(identifier)
+
+        with self._connection.get_connection() as conn:
             identifier_str = str(identifier)
             if identifier_str.isdigit():
                 cursor = conn.execute(
-                    """
-                    UPDATE documents
-                    SET is_deleted = FALSE, deleted_at = NULL
-                    WHERE id = ? AND is_deleted = TRUE
-                    """,
+                    "UPDATE documents SET is_deleted = FALSE, deleted_at = NULL "
+                    "WHERE id = ? AND is_deleted = TRUE",
                     (int(identifier_str),),
                 )
             else:
                 cursor = conn.execute(
-                    """
-                    UPDATE documents
-                    SET is_deleted = FALSE, deleted_at = NULL
-                    WHERE LOWER(title) = LOWER(?) AND is_deleted = TRUE
-                    """,
+                    "UPDATE documents SET is_deleted = FALSE, deleted_at = NULL "
+                    "WHERE LOWER(title) = LOWER(?) AND is_deleted = TRUE",
                     (identifier_str,),
                 )
             conn.commit()
@@ -355,79 +295,64 @@ class SQLiteDatabase:
 
     def purge_deleted_documents(self, older_than_days=None):
         """Permanently delete soft-deleted documents."""
-        with self._get_connection_instance().get_connection() as conn:
+        if not self._uses_custom_path:
+            return purge_deleted_documents(older_than_days)
+
+        with self._connection.get_connection() as conn:
             if older_than_days:
                 cursor = conn.execute(
-                    """
-                    DELETE FROM documents
-                    WHERE is_deleted = TRUE
-                    AND deleted_at <= datetime('now', '-' || ? || ' days')
-                    """,
+                    "DELETE FROM documents WHERE is_deleted = TRUE "
+                    "AND deleted_at <= datetime('now', '-' || ? || ' days')",
                     (older_than_days,),
                 )
             else:
-                cursor = conn.execute(
-                    "DELETE FROM documents WHERE is_deleted = TRUE"
-                )
+                cursor = conn.execute("DELETE FROM documents WHERE is_deleted = TRUE")
             conn.commit()
             return cursor.rowcount
 
-    # Search operations - use instance connection
     def search_documents(self, query, project=None, limit=10, fuzzy=False,
                         created_after=None, created_before=None,
                         modified_after=None, modified_before=None):
         """Search documents using FTS."""
-        with self._get_connection_instance().get_connection() as conn:
-            # Handle wildcard query (list all)
+        if not self._uses_custom_path:
+            return search_documents(query, project, limit, fuzzy,
+                                    created_after, created_before,
+                                    modified_after, modified_before)
+
+        # Isolated mode — self-contained FTS search for test databases
+        with self._connection.get_connection() as conn:
             if query == "*":
                 conditions = ["d.is_deleted = FALSE"]
                 params = []
-
                 if project:
                     conditions.append("d.project = ?")
                     params.append(project)
-
                 where_clause = " AND ".join(conditions)
                 params.append(limit)
-
                 cursor = conn.execute(
-                    f"""
-                    SELECT d.id, d.title, d.content, d.project, d.created_at,
-                           d.updated_at, d.access_count, NULL as snippet
-                    FROM documents d
-                    WHERE {where_clause}
-                    ORDER BY d.id DESC
-                    LIMIT ?
-                    """,
+                    f"SELECT d.id, d.title, d.content, d.project, d.created_at, "
+                    f"d.updated_at, d.access_count, NULL as snippet "
+                    f"FROM documents d WHERE {where_clause} ORDER BY d.id DESC LIMIT ?",
                     params,
                 )
                 return [dict(row) for row in cursor.fetchall()]
 
-            # FTS search
             conditions = ["d.is_deleted = FALSE"]
             params = []
-
             if project:
                 conditions.append("d.project = ?")
                 params.append(project)
-
             where_clause = " AND ".join(conditions)
 
-            # Import escape function from search module
             from .search import escape_fts5_query
             safe_query = escape_fts5_query(query)
 
             cursor = conn.execute(
-                f"""
-                SELECT d.id, d.title, d.content, d.project, d.created_at,
-                       d.updated_at, d.access_count,
-                       snippet(documents_fts, 1, '<mark>', '</mark>', '...', 32) as snippet
-                FROM documents d
-                JOIN documents_fts fts ON d.id = fts.rowid
-                WHERE fts.documents_fts MATCH ? AND {where_clause}
-                ORDER BY rank
-                LIMIT ?
-                """,
+                f"SELECT d.id, d.title, d.content, d.project, d.created_at, "
+                f"d.updated_at, d.access_count, "
+                f"snippet(documents_fts, 1, '<mark>', '</mark>', '...', 32) as snippet "
+                f"FROM documents d JOIN documents_fts fts ON d.id = fts.rowid "
+                f"WHERE fts.documents_fts MATCH ? AND {where_clause} ORDER BY rank LIMIT ?",
                 [safe_query] + params + [limit],
             )
             return [dict(row) for row in cursor.fetchall()]

--- a/emdx/models/documents.py
+++ b/emdx/models/documents.py
@@ -1,72 +1,35 @@
-"""Document operations for emdx."""
+"""Document operations for emdx.
 
-from typing import Any, Optional
+Re-exports from emdx.database.documents — the canonical implementation.
+This module exists for backward compatibility; prefer importing directly
+from emdx.database.documents for new code.
+"""
 
-from emdx.config.constants import DEFAULT_BROWSE_LIMIT, DEFAULT_LIST_LIMIT
-from emdx.database import db
+# Re-export all document operations from the canonical sources
+from emdx.database.documents import (
+    delete_document,
+    get_document,
+    get_recent_documents,
+    get_stats,
+    list_deleted_documents,
+    list_documents,
+    purge_deleted_documents,
+    restore_document,
+    save_document,
+    update_document,
+)
+from emdx.database.search import search_documents
 
-
-def save_document(title: str, content: str, project: Optional[str] = None, tags: Optional[list[str]] = None, parent_id: Optional[int] = None) -> int:
-    """Save a document to the knowledge base"""
-    return db.save_document(title, content, project, tags, parent_id)
-
-
-def get_document(identifier: str) -> Optional[dict[str, Any]]:
-    """Get a document by ID or title"""
-    return db.get_document(identifier)
-
-
-def list_documents(project: Optional[str] = None, limit: int = DEFAULT_BROWSE_LIMIT, include_archived: bool = False) -> list[dict[str, Any]]:
-    """List documents with optional project filter"""
-    return db.list_documents(project, limit, include_archived=include_archived)
-
-
-def search_documents(
-    query: str,
-    project: Optional[str] = None,
-    limit: int = DEFAULT_LIST_LIMIT, 
-    fuzzy: bool = False,
-    created_after: Optional[str] = None,
-    created_before: Optional[str] = None,
-    modified_after: Optional[str] = None,
-    modified_before: Optional[str] = None
-) -> list[dict[str, Any]]:
-    """Search documents using FTS5 with optional date filters"""
-    return db.search_documents(query, project, limit, fuzzy, 
-                             created_after, created_before, 
-                             modified_after, modified_before)
-
-
-def update_document(doc_id: int, title: str, content: str) -> bool:
-    """Update a document"""
-    return db.update_document(doc_id, title, content)
-
-
-def delete_document(identifier: str, hard_delete: bool = False) -> bool:
-    """Delete a document by ID or title (soft delete by default)"""
-    return db.delete_document(identifier, hard_delete)
-
-
-def get_recent_documents(limit: int = DEFAULT_LIST_LIMIT) -> list[dict[str, Any]]:
-    """Get recently accessed documents"""
-    return db.get_recent_documents(limit)
-
-
-def get_stats(project: Optional[str] = None) -> dict[str, Any]:
-    """Get database statistics"""
-    return db.get_stats(project)
-
-
-def list_deleted_documents(days: Optional[int] = None, limit: int = DEFAULT_BROWSE_LIMIT) -> list[dict[str, Any]]:
-    """List soft-deleted documents"""
-    return db.list_deleted_documents(days, limit)
-
-
-def restore_document(identifier: str) -> bool:
-    """Restore a soft-deleted document"""
-    return db.restore_document(identifier)
-
-
-def purge_deleted_documents(older_than_days: Optional[int] = None) -> int:
-    """Permanently delete soft-deleted documents"""
-    return db.purge_deleted_documents(older_than_days)
+__all__ = [
+    "delete_document",
+    "get_document",
+    "get_recent_documents",
+    "get_stats",
+    "list_deleted_documents",
+    "list_documents",
+    "purge_deleted_documents",
+    "restore_document",
+    "save_document",
+    "search_documents",
+    "update_document",
+]


### PR DESCRIPTION
## Summary

- Eliminates duplicate SQL in `SQLiteDatabase` class by delegating to canonical functions in `database/documents.py`
- Converts `models/documents.py` from a parallel implementation to a thin re-export layer
- Net reduction of ~112 lines while maintaining full backward compatibility

## What changed

**`emdx/database/__init__.py` (SQLiteDatabase)**
- Global mode (default): delegates to canonical functions in `database/documents.py` and `database/search.py`
- Isolated mode (custom `db_path` for tests): retains self-contained SQL for test isolation

**`emdx/models/documents.py`**
- Converted from independent implementation to re-exports from `database/documents.py` and `database/search.py`
- All existing imports continue to work unchanged

## Test plan

- [x] All 899 existing tests pass
- [x] No changes to public API — all existing imports work
- [x] SQLiteDatabase test isolation preserved (custom db_path still uses self-contained SQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)