### PR TITLE
docs: Restructure README for onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,9 @@
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-**Parallel task orchestration and knowledge capture for Claude Code.**
+**A searchable knowledge base that captures everything you do — and lets you delegate work to Claude agents at scale.**
 
-Run multiple Claude agents in parallel, discover tasks dynamically, and automatically capture everything to a searchable knowledge base.
-
-## What Makes EMDX Different
-
-EMDX is designed for one workflow: **using Claude Code to get things done at scale**.
-
-- Run 10 tasks in parallel with 5 worker slots
-- Discover tasks from shell commands at runtime
-- Every output automatically indexed and searchable
-- Semantic search across your entire history
-
-```bash
-# Run parallel code analysis
-emdx delegate "Review auth module" "Check error handling" "Audit SQL queries" -j 3
-
-# Discover tasks dynamically from git branches
-emdx delegate --each "git branch -r | grep feature" --do "Review branch {{item}}"
-```
+EMDX is a CLI tool that stores notes, research, decisions, and AI outputs in a local SQLite database with full-text search. It's also deeply integrated with Claude Code: you can delegate tasks to agents, run them in parallel, and every result automatically lands in your knowledge base — searchable forever.
 
 ## Installation
 
@@ -33,331 +16,288 @@ emdx delegate --each "git branch -r | grep feature" --do "Review branch {{item}}
 # Install with uv (recommended)
 uv tool install emdx
 
-# With optional extras
-uv tool install 'emdx[ai]'           # Semantic search, embeddings, Claude Q&A
-uv tool install 'emdx[similarity]'    # TF-IDF, MinHash duplicate detection
-uv tool install 'emdx[all]'           # Everything (AI + similarity + Google)
-
 # Or install with pip
 pip install emdx
-pip install 'emdx[all]'
+
+# Verify
+emdx --help
+```
+
+<details>
+<summary>Optional extras and development setup</summary>
+
+```bash
+# Optional extras
+uv tool install 'emdx[ai]'           # Semantic search, embeddings, Claude Q&A
+uv tool install 'emdx[similarity]'    # TF-IDF, MinHash duplicate detection
+uv tool install 'emdx[all]'           # Everything
 
 # Development (from source)
 git clone https://github.com/arockwell/emdx.git
 cd emdx
 uv sync                               # or: poetry install --all-extras
+uv run pytest                          # or: poetry run pytest
 ```
 
-## Quick Start: `emdx delegate`
+</details>
 
-`emdx delegate` is the single command for all AI execution. Results print to stdout AND persist to the knowledge base.
+## Quick Start
+
+### Save something
+
+EMDX stores documents — any text you want to keep.
 
 ```bash
-# Single task
-emdx delegate "analyze the auth module"
+# Save a file
+emdx save README.md
 
-# Parallel tasks (up to 10 concurrent)
+# Save a note
+emdx save "Remember: the auth bug is in token refresh" --title "Auth Bug Note"
+
+# Pipe command output
+docker ps | emdx save --title "Running containers"
+
+# Save and tag it for organization
+emdx save meeting-notes.md --tags "meeting,active"
+```
+
+### Find it later
+
+```bash
+# Full-text search
+emdx find "auth bug"
+
+# Filter by tags
+emdx find --tags "meeting,active"
+
+# Combine text and tags
+emdx find "docker" --tags "ops"
+
+# View a specific document
+emdx view 42
+
+# See recent documents
+emdx recent
+```
+
+### Organize with tags
+
+Tags use emoji under the hood, but you type plain text:
+
+```bash
+# Add tags to a document
+emdx tag 42 gameplan active
+
+# See all tags in use
+emdx tags
+
+# Search by tags
+emdx find --tags "gameplan,success"
+```
+
+| Alias | Emoji | Typical use |
+|-------|-------|-------------|
+| `gameplan` | 🎯 | Plans and strategy |
+| `analysis` | 🔍 | Research and investigation |
+| `active` | 🚀 | Currently working on |
+| `done` | ✅ | Completed |
+| `blocked` | 🚧 | Stuck or waiting |
+| `success` | 🎉 | Worked as intended |
+| `failed` | ❌ | Didn't work |
+
+Run `emdx legend` for the full alias list.
+
+## Delegating Work to Claude
+
+This is where EMDX gets powerful. `emdx delegate` sends tasks to Claude Code agents, and everything they produce is automatically saved to your knowledge base.
+
+### Single task
+
+```bash
+emdx delegate "analyze the auth module for security issues"
+```
+
+The agent runs, saves its output, and the result prints to stdout. The document is also persisted — you can `emdx find "auth"` to find it later.
+
+### Parallel tasks
+
+Run multiple tasks concurrently. Each gets its own agent.
+
+```bash
 emdx delegate "check auth" "review tests" "scan for XSS"
 
-# Control concurrency
+# Control concurrency (5 tasks, 3 slots)
 emdx delegate "t1" "t2" "t3" "t4" "t5" -j 3
 
-# Combine parallel outputs into one summary
-emdx delegate --synthesize "analyze auth" "analyze api" "analyze database"
-
-# Set a title for tracking
-emdx delegate -T "Security Audit" "check XSS" "check SQL injection" "check CSRF"
+# Combine outputs into a single summary
+emdx delegate --synthesize "analyze auth" "analyze api" "analyze db"
 ```
 
-### Sequential Pipelines
+### Sequential pipelines
 
-Chain tasks where each step receives the previous output:
+Chain tasks so each step sees the previous output:
 
 ```bash
-# Analyze, then plan, then implement
 emdx delegate --chain "analyze the problem" "design a solution" "implement it"
-
-# Chain with PR creation at the end
-emdx delegate --chain --pr "analyze the issue" "implement the fix"
 ```
 
-### Dynamic Task Discovery
+### Dynamic discovery
 
-Discover tasks at runtime from shell commands:
+Find items at runtime, then process each one:
 
 ```bash
+# Review every Python file in src/
+emdx delegate --each "fd -e py src/" --do "Review {{item}} for issues"
+
 # Review all feature branches
-emdx delegate --each "git branch -r | grep feature" --do "Review branch {{item}}"
-
-# Analyze all Python files in a directory
-emdx delegate --each "fd -e py src" --do "Analyze {{item}}"
-
-# Process all open PRs
-emdx delegate --each "gh pr list --json number -q '.[].number'" --do "Review PR #{{item}}"
+emdx delegate --each "git branch -r | grep feature" --do "Review {{item}}"
 ```
 
-### Document Context and PR Creation
+### Use documents as input
 
 ```bash
-# Use a document as input context
+# Pass a doc as context alongside a task
 emdx delegate --doc 42 "implement the plan described here"
 
-# Have the agent create a PR
-emdx delegate --pr "fix the auth bug"
+# Or just run a document directly by ID
+emdx delegate 42
+```
 
-# Worktree isolation (clean git environment)
-emdx delegate --worktree --pr "fix the null pointer in auth"
+### Code changes with PRs
 
-# Combine: doc context + chain + worktree + PR
+```bash
+# Agent makes changes and opens a PR
+emdx delegate --pr "fix the null pointer in auth"
+
+# Isolate changes in a git worktree
+emdx delegate --worktree --pr "fix X"
+
+# All flags compose together
 emdx delegate --doc 42 --chain --worktree --pr "analyze" "implement"
 ```
 
-### Run from Document IDs
+## Searching Your Knowledge Base
+
+As your knowledge base grows, EMDX gives you several ways to find things.
+
+### Full-text search
+
+Built on SQLite FTS5 — fast and works out of the box:
 
 ```bash
-# Use previous emdx documents as task prompts
-emdx delegate 5350 5351 5352
+emdx find "authentication"
+emdx find "docker" --project myapp
 ```
 
-## Cascade: Ideas to Code
+### Semantic search
 
-Transform ideas through stages to working code: idea → prompt → analyzed → planned → done (PR).
-
-```bash
-# Add an idea to the cascade
-emdx cascade add "Add dark mode toggle to settings"
-
-# Check status
-emdx cascade status
-
-# Process stages (each advances the document)
-emdx cascade process idea --sync
-emdx cascade process prompt --sync
-emdx cascade process analyzed --sync
-emdx cascade process planned --sync  # Creates code and PR
-
-# Or run continuously
-emdx cascade run
-```
-
-## Workflow System
-
-For complex multi-stage execution beyond what `delegate` offers:
+Find documents by meaning, not just keywords (requires `emdx[ai]` extra):
 
 ```bash
-# List available workflows
-emdx workflow list
-
-# Run with inline tasks
-emdx workflow run task_parallel \
-  -t "Analyze authentication" \
-  -t "Analyze authorization" \
-  -t "Analyze data flow"
-
-# Use worktree isolation (each task gets its own git worktree)
-emdx workflow run parallel_fix \
-  -t "Fix auth bug" \
-  -t "Fix validation bug" \
-  --worktree --base-branch main
-
-# Control concurrency
-emdx workflow run task_parallel -t "t1" -t "t2" -t "t3" -j 2
-```
-
-### Execution Modes
-
-| Mode | Use Case |
-|------|----------|
-| `single` | One task, full attention |
-| `parallel` | Multiple independent tasks |
-| `iterative` | Sequential refinement |
-| `adversarial` | Multiple perspectives, then synthesis |
-| `dynamic` | Discover tasks at runtime |
-
-## Monitoring Executions
-
-```bash
-# List running executions
-emdx exec running
-
-# Follow logs
-emdx exec show 42
-
-# Health check
-emdx exec health
-
-# Kill a stuck execution
-emdx exec kill 42
-
-# Kill all running
-emdx exec killall
-```
-
-## Finding Information
-
-EMDX provides multiple ways to locate information, from quick keyword searches to semantic AI-powered discovery.
-
-### Quick Reference
-
-| I want to... | Command |
-|--------------|---------|
-| Search by keywords | `emdx find "auth bug"` |
-| Filter by tags | `emdx find --tags "active,gameplan"` |
-| Find by meaning/concept | `emdx ai search "rate limiting strategies"` |
-| Find docs similar to one | `emdx similar 42` |
-| Find docs matching text | `emdx similar-text "error handling pattern"` |
-| See recent work | `emdx recent` |
-| List all docs | `emdx list` |
-| List by project | `emdx list --project myapp` |
-| Read a specific doc | `emdx view 42` |
-| Ask a question | `emdx ai context "how does auth work?" \| claude` |
-| Browse interactively | `emdx gui` (interactive TUI - for human use, not AI agents) |
-
-### Keyword Search
-
-Fast full-text search using SQLite FTS5:
-
-```bash
-emdx find "authentication"           # Search for terms
-emdx find --tags "active"            # Filter by tags
-emdx find "security" --tags "analysis"  # Combine text and tags
-emdx find "api" --project myapp      # Filter by project
-```
-
-### Semantic Search
-
-Find documents by meaning, not just keywords:
-
-```bash
-# Build the index first (one-time)
+# Build the index (one-time)
 emdx ai index
 
 # Search by concept
 emdx ai search "how we handle rate limiting"
-emdx ai search "authentication flow"
-
-# Adjust threshold (lower = more results)
-emdx ai search "caching" --threshold 0.3
 ```
 
-### Similar Documents
-
-Find related content:
+### Q&A over your knowledge base
 
 ```bash
-emdx similar 42                      # Docs similar to #42
-emdx similar-text "retry logic with exponential backoff"
-```
-
-### Q&A Over Your Knowledge Base
-
-```bash
-# Using Claude CLI (recommended - uses Claude Max subscription)
+# Pipe relevant docs to Claude CLI (uses Claude Max, no API cost)
 emdx ai context "How does the workflow system work?" | claude
 
-# Using Claude API (requires ANTHROPIC_API_KEY)
+# Or use the API directly (requires ANTHROPIC_API_KEY)
 emdx ai ask "How did we solve the auth bug?"
 ```
 
-### Browsing
+### Similar documents
 
 ```bash
-emdx recent                          # Recently accessed
-emdx recent 20                       # Last 20
-emdx list                            # All documents
-emdx list --project myapp            # By project
-emdx view 42                         # Read specific doc
-emdx gui                             # Interactive TUI (for human use, not AI agents)
+emdx similar 42                                     # Docs similar to #42
+emdx similar-text "retry logic with exponential backoff"
 ```
 
-### For AI Agents
+## Going Further
 
-Recommended search strategy for Claude Code and other AI agents:
+### Cascade: ideas to code
+
+Transform raw ideas through stages — idea → prompt → analyzed → planned → done — with the final stage creating a PR.
 
 ```bash
-# 1. Start with semantic search for open-ended questions
-emdx ai search "authentication implementation"
-
-# 2. Use keyword search for specific terms or IDs
-emdx find "AUTH-123"
-
-# 3. Use tag filtering to narrow by status/type
-emdx find --tags "gameplan,active"    # Current plans
-emdx find --tags "analysis,done"      # Completed analyses
-
-# 4. Expand from a known good doc
-emdx similar 42
-
-# 5. Get synthesized answers
-emdx ai context "What patterns do we use for error handling?" | claude
+emdx cascade add "Add dark mode toggle to settings"
+emdx cascade status
+emdx cascade run          # Process all stages automatically
 ```
 
-### Session Start
+See [Cascade documentation](docs/cascade.md) for details.
 
-At the start of each session, get current work context:
+### Workflow system
+
+For complex multi-stage execution with custom configurations:
 
 ```bash
-# Full priming context
-emdx prime
-
-# Quick status overview
-emdx status
+emdx workflow run task_parallel \
+  -t "Analyze authentication" \
+  -t "Analyze authorization" \
+  -t "Analyze data flow"
 ```
 
-### Emoji Tags
+See [Workflow documentation](docs/workflows.md) for execution modes (parallel, iterative, adversarial, dynamic).
 
-Type text aliases instead of emoji:
-
-| Type | Get | Use for |
-|------|-----|---------|
-| `gameplan` | 🎯 | Strategic plans |
-| `analysis` | 🔍 | Investigations |
-| `active` | 🚀 | In progress |
-| `done` | ✅ | Completed |
-| `blocked` | 🚧 | Waiting |
-| `success` | 🎉 | Worked |
-| `failed` | ❌ | Didn't work |
+### Monitoring executions
 
 ```bash
-emdx tag 42 gameplan active
-emdx find --tags "gameplan,success"
-emdx legend  # Full alias reference
+emdx exec running          # List active executions
+emdx exec show 42          # Follow logs
+emdx exec health           # Health check
+emdx exec kill 42          # Kill a stuck execution
 ```
 
-## When to Use What
+### Interactive TUI
 
-| I want to... | Use this |
-|--------------|----------|
-| Run one or many tasks in parallel | `emdx delegate "t1" "t2" "t3"` |
-| Chain tasks sequentially | `emdx delegate --chain "analyze" "plan" "implement"` |
-| Discover tasks dynamically | `emdx delegate --each "command" --do "template"` |
-| Create a PR from a task | `emdx delegate --pr "fix the bug"` |
-| Isolate work in a worktree | `emdx delegate --worktree "fix X"` |
-| Run complex multi-stage work | `emdx workflow run workflow_name` |
-| Go from idea to PR autonomously | `emdx cascade add "idea"` |
-| Search by keywords | `emdx find "query"` |
+EMDX includes a full terminal UI for browsing, editing, and managing your knowledge base:
+
+```bash
+emdx gui
+```
+
+### Claude Code integration
+
+EMDX works as a Claude Code extension. At the start of each session:
+
+```bash
+emdx prime    # Get current work context
+emdx status   # Quick overview
+```
+
+## Quick Reference
+
+| I want to... | Command |
+|--------------|---------|
+| Save a file or note | `emdx save file.md` or `emdx save "text" --title "T"` |
+| Find by keyword | `emdx find "query"` |
+| Find by tag | `emdx find --tags "active"` |
+| View a document | `emdx view 42` |
+| Tag a document | `emdx tag 42 analysis active` |
+| Run an AI task | `emdx delegate "task"` |
+| Run tasks in parallel | `emdx delegate "t1" "t2" "t3"` |
+| Chain tasks | `emdx delegate --chain "analyze" "plan" "implement"` |
+| Discover + process items | `emdx delegate --each "cmd" --do "Review {{item}}"` |
+| Create a PR | `emdx delegate --pr "fix the bug"` |
 | Search by meaning | `emdx ai search "concept"` |
-| Find similar docs | `emdx similar 42` |
-| Ask questions | `emdx ai context "question" \| claude` |
-| Check running tasks | `emdx exec running` |
-| Kill stuck work | `emdx exec kill id` |
+| Ask a question | `emdx ai context "question" \| claude` |
+| Idea to PR pipeline | `emdx cascade add "idea"` |
 
 ## Documentation
 
-- [CLI Reference](docs/cli-api.md) - Complete command documentation
-- [Workflow System](docs/workflows.md) - Multi-stage execution patterns
-- [AI System](docs/ai-system.md) - Semantic search and Q&A
-- [Architecture](docs/architecture.md) - System design
-- [Development Setup](docs/development-setup.md) - Contributing guide
-
-## Development
-
-```bash
-uv sync                    # or: poetry install
-uv run emdx --help         # or: poetry run emdx --help
-uv run pytest              # or: poetry run pytest
-```
+- [CLI Reference](docs/cli-api.md) — Complete command documentation
+- [Workflow System](docs/workflows.md) — Multi-stage execution patterns
+- [Cascade](docs/cascade.md) — Idea-to-code pipeline
+- [AI System](docs/ai-system.md) — Semantic search and Q&A
+- [Architecture](docs/architecture.md) — System design
+- [Development Setup](docs/development-setup.md) — Contributing guide
 
 ## License
 
-MIT License - see LICENSE file.
+MIT License — see LICENSE file.


### PR DESCRIPTION
## Summary
Restructures the README from a reference manual into a learning path for new users.

**Before:** Led with parallel execution, buried save/find/tags halfway down, dumped all delegate flags at once.

**After:** Follows a natural onboarding flow:
1. What is this — knowledge base + Claude agents
2. Install — minimal, extras collapsed into `<details>`
3. Quick Start — save, find, tag (the core loop)
4. Delegate — single → parallel → chain → discovery → docs → PRs (progressive disclosure)
5. Search — full-text, semantic, Q&A, similar
6. Going Further — cascade, workflows, monitoring, TUI (links to docs/)
7. Quick Reference — cheat sheet table

## Test plan
- [ ] README renders correctly on GitHub
- [ ] All internal links resolve
- [ ] `<details>` block expands properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)