### PR TITLE
fix(tui): Fix activity browser auto-refresh + logging overhaul

### DIFF
--- a/emdx/services/mail_service.py
+++ b/emdx/services/mail_service.py
@@ -114,7 +114,6 @@ class MailService:
         """
         try:
             cmd = ["gh"] + args
-            logger.debug(f"Running gh command: {' '.join(cmd)}")
 
             result = subprocess.run(
                 cmd,

--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -159,7 +159,7 @@ class DocumentBrowser(HelpMixin, Widget):
                     
     async def on_mount(self) -> None:
         """Initialize the document browser."""
-        logger.info("DocumentBrowser mounted - LHS split implementation")
+        logger.debug("DocumentBrowser mounted")
 
         # Initialize preview mode manager
         from .preview_mode_manager import PreviewModeManager
@@ -366,7 +366,7 @@ class DocumentBrowser(HelpMixin, Widget):
                     return False
 
         # Document not in current list - try searching for it
-        logger.info(f"Document #{doc_id} not in current list, searching...")
+        logger.debug(f"Document #{doc_id} not in current list, searching")
         await self.presenter.search(f"#{doc_id}")
         return False
 
@@ -462,7 +462,7 @@ class DocumentBrowser(HelpMixin, Widget):
         
     def action_save_and_exit_edit(self) -> None:
         """Save document and exit edit mode (called by VimEditTextArea)."""
-        logger.info("action_save_and_exit_edit called")
+        logger.debug("action_save_and_exit_edit called")
         try:
             # Use call_after_refresh to avoid timing issues
             self.call_after_refresh(self._async_save_and_exit_edit_mode)
@@ -477,13 +477,13 @@ class DocumentBrowser(HelpMixin, Widget):
             
     def _async_exit_edit_mode(self) -> None:
         """Async wrapper for exit_edit_mode."""
-        logger.info("_async_exit_edit_mode called")
+        logger.debug("_async_exit_edit_mode")
         import asyncio
         asyncio.create_task(self.exit_edit_mode())
         
     def _async_save_and_exit_edit_mode(self) -> None:
         """Async wrapper for save_and_exit_edit_mode."""
-        logger.info("_async_save_and_exit_edit_mode called")
+        logger.debug("_async_save_and_exit_edit_mode")
         import asyncio
         asyncio.create_task(self.save_and_exit_edit_mode())
         
@@ -507,7 +507,7 @@ class DocumentBrowser(HelpMixin, Widget):
                 # Save new document via presenter
                 doc_id = await self.presenter.save_new_document(title, content)
                 if doc_id:
-                    logger.info(f"Created new document with ID: {doc_id}")
+                    logger.debug(f"Created doc #{doc_id}")
                     self.new_document_mode = False
                 else:
                     self._update_vim_status("ERROR: Failed to save document")
@@ -521,7 +521,7 @@ class DocumentBrowser(HelpMixin, Widget):
                     if not success:
                         self._update_vim_status("ERROR: Failed to update document")
                         return
-                    logger.info(f"Updated document ID: {self.editing_doc_id}")
+                    logger.debug(f"Updated doc #{self.editing_doc_id}")
 
             # Exit edit mode and reload documents
             await self.exit_edit_mode()

--- a/emdx/ui/inputs.py
+++ b/emdx/ui/inputs.py
@@ -6,9 +6,8 @@ Input widgets for EMDX TUI.
 from textual import events
 from textual.widgets import Input
 
-# Set up logging using shared utility
 from ..utils.logging_utils import setup_tui_logging
-logger, key_logger = setup_tui_logging(__name__)
+logger, _key_logger = setup_tui_logging(__name__)
 
 
 class TitleInput(Input):

--- a/emdx/ui/modals.py
+++ b/emdx/ui/modals.py
@@ -12,9 +12,7 @@ from textual.containers import ScrollableContainer, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import RichLog, Static
 
-# Set up logging for debugging
 logger = logging.getLogger(__name__)
-key_logger = logging.getLogger("key_events")
 
 
 class KeybindingsHelpScreen(ModalScreen):

--- a/emdx/ui/run_browser.py
+++ b/emdx/ui/run_browser.py
@@ -3,9 +3,8 @@
 Run the new browser container.
 """
 
-# Set up logging using shared utility
 from ..utils.logging_utils import setup_tui_logging
-logger, key_logger = setup_tui_logging(__name__)
+logger, _key_logger = setup_tui_logging(__name__)
 
 
 def run_browser(theme: str | None = None):

--- a/emdx/ui/vim_editor.py
+++ b/emdx/ui/vim_editor.py
@@ -82,10 +82,6 @@ class VimEditor(Vertical):
         self.edit_container.mount(self.line_numbers)
         self.edit_container.mount(self.text_area)
 
-        logger.debug(f"🔍 VimEditor.on_mount: Components mounted")
-        logger.debug(f"🔍 VimEditor.on_mount: TextArea text length: {len(self.text_area.text)}")
-        logger.debug(f"🔍 VimEditor.on_mount: First 50 chars of text: {repr(self.text_area.text[:50])}")
-
         # Note: Explicit scroll_to(0, 0) disabled - causes first line visibility issues
         
         # Focus the text area and initialize line numbers
@@ -114,7 +110,6 @@ class VimEditor(Vertical):
         max_digits = len(str(total_lines))
         # Minimum 3 chars (like vim), add 2 for padding
         width = max(3, max_digits) + 2
-        logger.debug(f"🔢 Line number width calculation: total_lines={total_lines}, max_digits={max_digits}, width={width}")
         return width
     
     def _update_line_number_width(self):
@@ -127,7 +122,6 @@ class VimEditor(Vertical):
             self.line_numbers.styles.width = line_number_width
             self.line_numbers.styles.min_width = line_number_width
             self.line_numbers.styles.max_width = line_number_width
-            logger.debug(f"line_number_width updated to {line_number_width}")
     
     def _initialize_editor(self):
         """Initialize editor after mounting - focus and set up line numbers."""
@@ -177,10 +171,7 @@ class VimEditor(Vertical):
             self.line_numbers.set_line_numbers(current_line, total_lines, self.text_area)
             self._update_line_number_width()
             if hasattr(self.text_area, '_update_line_numbers'):
-                logger.debug(f"🔢 Calling text area's _update_line_numbers()")
                 self.text_area._update_line_numbers()
-
-            logger.debug(f"🔢 VimEditor _initialize_editor completed successfully")
             
         except Exception as e:
             logger.error(f"Error initializing vim editor: {e}")


### PR DESCRIPTION
## Summary

- **Fix auto-refresh**: Mail service was calling `gh issue list` every 1-second refresh tick (~800ms per call, no caching), blocking the entire activity data refresh pipeline. Added 30-second cache TTL.
- **Fix 82GB log file**: Root logger was set to `DEBUG` with no rotation. Rewrote `logging_utils` with `RotatingFileHandler` (5MB max, 2 backups), root at `WARNING`, emdx.* at `INFO`.
- **Remove dev scaffolding**: Stripped keystroke-by-keystroke logging, widget tree dumps, palette debug file writes, and emoji-prefixed debug noise across 10 files (net -95 lines).

## Test plan

- [ ] Launch TUI (`poetry run emdx gui`), verify Activity Browser refreshes within seconds
- [ ] Run a delegate task, confirm it appears in Activity Browser without manual `r` press
- [ ] Check `~/.config/emdx/tui_debug.log` stays small after a few minutes of use
- [ ] Verify edit mode still works (vim keybindings functional despite logging removal)
- [ ] Confirm mail items still appear in Activity Browser (cached, updates every 30s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)