### PR TITLE
refactor: Tier 1 command consolidation — trash subgroup, maintain nesting (#440)

### DIFF
--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -977,12 +977,6 @@ Show knowledge base statistics.
 ```bash
 # Overall statistics
 emdx stats
-
-# Detailed project breakdown
-emdx project-stats
-
-# Show all projects
-emdx projects
 ```
 
 ### **emdx trash**
@@ -993,10 +987,10 @@ Manage deleted documents.
 emdx trash
 
 # Restore document from trash
-emdx restore 42
+emdx trash restore 42
 
-# Permanently delete (careful!)
-emdx trash --permanent
+# Permanently delete all trash (careful!)
+emdx trash purge --force
 ```
 
 ## 🎨 **Interactive Interface**

--- a/emdx/commands/analyze.py
+++ b/emdx/commands/analyze.py
@@ -41,10 +41,10 @@ def analyze(
     opportunities for improvement.
     
     Examples:
-        emdx analyze              # Show health overview with recommendations
-        emdx analyze --health     # Detailed health metrics
-        emdx analyze --duplicates # Find duplicate documents
-        emdx analyze --all        # Run all analyses
+        emdx maintain analyze              # Show health overview with recommendations
+        emdx maintain analyze --health     # Detailed health metrics
+        emdx maintain analyze --duplicates # Find duplicate documents
+        emdx maintain analyze --all        # Run all analyses
     """
     
     # If no specific analysis requested, show health overview

--- a/emdx/commands/maintain.py
+++ b/emdx/commands/maintain.py
@@ -1060,9 +1060,41 @@ def cleanup_temp_dirs(
 
 # Create typer app for this module
 app = typer.Typer()
-app.command()(maintain)
+
+
+@app.callback(invoke_without_command=True)
+def maintain_callback(
+    ctx: typer.Context,
+    auto: bool = typer.Option(False, "--auto", "-a", help="Automatically fix all issues"),
+    clean: bool = typer.Option(False, "--clean", "-c", help="Remove duplicates and empty documents"),
+    merge: bool = typer.Option(False, "--merge", "-m", help="Merge similar documents"),
+    tags: bool = typer.Option(False, "--tags", "-t", help="Auto-tag untagged documents"),
+    gc: bool = typer.Option(False, "--gc", "-g", help="Run garbage collection"),
+    dry_run: bool = typer.Option(True, "--execute/--dry-run", help="Execute actions (default: dry run)"),
+    threshold: float = typer.Option(0.7, "--threshold", help="Similarity threshold for merging"),
+) -> None:
+    """
+    Maintain your knowledge base — fix issues, optimize, and analyze.
+
+    Run with no subcommand for the maintenance wizard.
+
+    Subcommands:
+        cleanup      Clean up execution resources (branches, processes)
+        cleanup-dirs Clean up temporary directories
+        analyze      Analyze knowledge base health and patterns
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+    maintain(auto=auto, clean=clean, merge=merge, tags=tags, gc=gc,
+             dry_run=dry_run, threshold=threshold)
+
+
 app.command(name="cleanup")(cleanup_main)
 app.command(name="cleanup-dirs")(cleanup_temp_dirs)
+
+# Import and register analyze as a subcommand of maintain
+from emdx.commands.analyze import analyze as analyze_cmd
+app.command(name="analyze")(analyze_cmd)
 
 
 if __name__ == "__main__":

--- a/emdx/commands/trash.py
+++ b/emdx/commands/trash.py
@@ -1,0 +1,206 @@
+"""
+Trash management commands for emdx.
+
+Consolidates trash, restore, and purge into a subcommand group:
+    emdx trash           → list trash
+    emdx trash list      → list trash (explicit)
+    emdx trash restore   → restore documents
+    emdx trash purge     → permanently delete trash
+"""
+
+from typing import Optional
+
+import typer
+from rich.table import Table
+
+from emdx.database import db
+from emdx.models.documents import (
+    list_deleted_documents,
+    purge_deleted_documents,
+    restore_document,
+)
+from emdx.utils.output import console
+
+app = typer.Typer()
+
+
+@app.callback(invoke_without_command=True)
+def trash_callback(
+    ctx: typer.Context,
+    days: Optional[int] = typer.Option(
+        None, "--days", "-d", help="Show items deleted in last N days"
+    ),
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum results to return"),
+) -> None:
+    """Manage deleted documents (trash)."""
+    # If a subcommand was invoked, don't run the default list behavior
+    if ctx.invoked_subcommand is not None:
+        return
+    _list_trash(days=days, limit=limit)
+
+
+@app.command("list")
+def list_cmd(
+    days: Optional[int] = typer.Option(
+        None, "--days", "-d", help="Show items deleted in last N days"
+    ),
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum results to return"),
+) -> None:
+    """List all soft-deleted documents."""
+    _list_trash(days=days, limit=limit)
+
+
+def _list_trash(days: Optional[int] = None, limit: int = 50) -> None:
+    """Shared implementation for listing trash."""
+    try:
+        db.ensure_schema()
+
+        deleted_docs = list_deleted_documents(days=days, limit=limit)
+
+        if not deleted_docs:
+            if days:
+                console.print(f"[yellow]No documents deleted in the last {days} days[/yellow]")
+            else:
+                console.print("[yellow]No documents in trash[/yellow]")
+            return
+
+        if days:
+            console.print(f"\n[bold]🗑️  Documents deleted in the last {days} days:[/bold]\n")
+        else:
+            console.print(f"\n[bold]🗑️  Documents in trash ({len(deleted_docs)} items):[/bold]\n")
+
+        table = Table(show_header=True, header_style="bold cyan")
+        table.add_column("ID", style="cyan", width=6)
+        table.add_column("Title", style="white")
+        table.add_column("Project", style="green")
+        table.add_column("Deleted", style="red")
+        table.add_column("Views", style="yellow", justify="right")
+
+        for doc in deleted_docs:
+            table.add_row(
+                str(doc["id"]),
+                doc["title"][:50] + "..." if len(doc["title"]) > 50 else doc["title"],
+                doc["project"] or "[dim]None[/dim]",
+                doc["deleted_at"].strftime("%Y-%m-%d %H:%M"),
+                str(doc["access_count"]),
+            )
+
+        console.print(table)
+        console.print("\n[dim]💡 Use 'emdx trash restore <id>' to restore documents[/dim]")
+        console.print("[dim]💡 Use 'emdx trash purge' to permanently delete all items[/dim]")
+
+    except Exception as e:
+        console.print(f"[red]Error listing deleted documents: {e}[/red]")
+        raise typer.Exit(1) from e
+
+
+@app.command()
+def restore(
+    identifiers: Optional[list[str]] = typer.Argument(
+        default=None, help="Document ID(s) or title(s) to restore"
+    ),
+    all: bool = typer.Option(False, "--all", help="Restore all deleted documents"),
+) -> None:
+    """Restore soft-deleted document(s)."""
+    try:
+        db.ensure_schema()
+
+        if not identifiers and not all:
+            console.print("[red]Error: Provide document ID(s) to restore or use --all[/red]")
+            raise typer.Exit(1)
+
+        if all:
+            deleted_docs = list_deleted_documents()
+            if not deleted_docs:
+                console.print("[yellow]No documents to restore[/yellow]")
+                return
+
+            console.print(f"\n[bold]Will restore {len(deleted_docs)} document(s)[/bold]")
+            typer.confirm("Continue?", abort=True)
+
+            restored_count = 0
+            for doc in deleted_docs:
+                if restore_document(str(doc["id"])):
+                    restored_count += 1
+
+            console.print(f"\n[green]✅ Restored {restored_count} document(s)[/green]")
+        else:
+            restored = []
+            not_found = []
+
+            for identifier in identifiers:
+                if restore_document(identifier):
+                    restored.append(identifier)
+                else:
+                    not_found.append(identifier)
+
+            if restored:
+                console.print(f"\n[green]✅ Restored {len(restored)} document(s):[/green]")
+                for r in restored:
+                    console.print(f"  [dim]• {r}[/dim]")
+
+            if not_found:
+                console.print(f"\n[yellow]Could not restore {len(not_found)} document(s):[/yellow]")
+                for nf in not_found:
+                    console.print(f"  [dim]• {nf} (not found in trash)[/dim]")
+
+    except typer.Abort:
+        console.print("[yellow]Restore cancelled[/yellow]")
+        raise typer.Exit(0) from None
+    except Exception as e:
+        console.print(f"[red]Error restoring documents: {e}[/red]")
+        raise typer.Exit(1) from e
+
+
+@app.command()
+def purge(
+    older_than: Optional[int] = typer.Option(
+        None, "--older-than", help="Only purge items deleted more than N days ago"
+    ),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+) -> None:
+    """Permanently delete all items in trash."""
+    try:
+        db.ensure_schema()
+
+        if older_than:
+            deleted_docs = list_deleted_documents()
+            from datetime import datetime, timedelta
+
+            cutoff = datetime.now() - timedelta(days=older_than)
+            docs_to_purge = [d for d in deleted_docs if d["deleted_at"] < cutoff]
+            count = len(docs_to_purge)
+        else:
+            deleted_docs = list_deleted_documents()
+            count = len(deleted_docs)
+
+        if count == 0:
+            if older_than:
+                console.print(
+                    f"[yellow]No documents deleted more than {older_than} days ago[/yellow]"
+                )
+            else:
+                console.print("[yellow]No documents in trash to purge[/yellow]")
+            return
+
+        console.print(
+            f"\n[red bold]⚠️  WARNING: This will PERMANENTLY delete "
+            f"{count} document(s) from trash![/red bold]"
+        )
+        console.print("[red]This action cannot be undone![/red]\n")
+
+        if not force:
+            typer.confirm("Are you absolutely sure?", abort=True)
+
+        purged_count = purge_deleted_documents(older_than_days=older_than)
+
+        console.print(
+            f"\n[green]✅ Permanently deleted {purged_count} document(s) from trash[/green]"
+        )
+
+    except typer.Abort:
+        console.print("[yellow]Purge cancelled[/yellow]")
+        raise typer.Exit(0) from None
+    except Exception as e:
+        console.print(f"[red]Error purging documents: {e}[/red]")
+        raise typer.Exit(1) from e

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -100,13 +100,13 @@ register_lazy_commands(get_lazy_subcommands(), get_lazy_help())
 from emdx.commands.core import app as core_app
 from emdx.commands.browse import app as browse_app
 from emdx.commands.tags import app as tag_app
+from emdx.commands.trash import app as trash_app
 from emdx.commands.executions import app as executions_app
 from emdx.commands.tasks import app as tasks_app
 from emdx.commands.groups import app as groups_app
 from emdx.commands.prime import prime as prime_command
 from emdx.commands.status import status as status_command
 from emdx.ui.gui import gui as gui_command
-from emdx.commands.analyze import app as analyze_app
 from emdx.commands.maintain import app as maintain_app
 from emdx.commands.gist import app as gist_app
 
@@ -145,6 +145,9 @@ for command in gist_app.registered_commands:
 # Tag commands (subcommand group: emdx tag <subcommand>)
 app.add_typer(tag_app, name="tag", help="Manage document tags")
 
+# Trash commands (subcommand group: emdx trash <subcommand>)
+app.add_typer(trash_app, name="trash", help="Manage deleted documents")
+
 # Add executions as a subcommand group
 app.add_typer(executions_app, name="exec", help="Manage Claude executions")
 
@@ -154,13 +157,8 @@ app.add_typer(tasks_app, name="task", help="Task management")
 # Add groups as a subcommand group
 app.add_typer(groups_app, name="group", help="Organize documents into hierarchical groups")
 
-# Add analyze commands (maintain_app has multiple commands like cleanup, cleanup-dirs)
-for command in analyze_app.registered_commands:
-    app.registered_commands.append(command)
-
-# Add maintain commands (maintain_app has maintain, cleanup, cleanup-dirs)
-for command in maintain_app.registered_commands:
-    app.registered_commands.append(command)
+# Add maintain as a subcommand group (includes maintain, cleanup, cleanup-dirs, analyze)
+app.add_typer(maintain_app, name="maintain", help="Maintenance and analysis tools")
 
 # Add the prime command for Claude session priming
 app.command(name="prime")(prime_command)

--- a/tests/test_execution_system.py
+++ b/tests/test_execution_system.py
@@ -85,8 +85,8 @@ def test_maintenance_commands():
     commands = [
         # The maintain command help
         ["emdx", "maintain", "--help"],
-        # Analyze command help
-        ["emdx", "analyze", "--help"],
+        # Analyze command help (now under maintain)
+        ["emdx", "maintain", "analyze", "--help"],
         # Exec commands
         ["emdx", "exec", "--help"],
         ["emdx", "exec", "stats"],


### PR DESCRIPTION
## Summary
- **Remove broken `gist-list`** command (66 LOC deleted)
- **Consolidate trash operations** into `emdx trash` subgroup: `trash list`, `trash restore`, `trash purge`
- **Nest maintenance tools** under `emdx maintain`: `maintain cleanup`, `maintain cleanup-dirs`, `maintain analyze`
- **28 top-level commands** (down from 35, originally 42)

### Command mapping

| Old command | New command |
|---|---|
| `emdx gist-list` | **Removed** |
| `emdx trash` | `emdx trash` (unchanged, lists trash) |
| `emdx restore` | `emdx trash restore` |
| `emdx purge` | `emdx trash purge` |
| `emdx cleanup` | `emdx maintain cleanup` |
| `emdx cleanup-dirs` | `emdx maintain cleanup-dirs` |
| `emdx analyze` | `emdx maintain analyze` |

## Test plan
- [x] All 990 tests pass (6 skipped)
- [x] Updated test patches to use new module paths
- [x] Verified `emdx trash --help`, `emdx maintain --help` show correct subcommands
- [x] `emdx maintain` with no subcommand still runs interactive wizard
- [x] `emdx trash` with no subcommand still lists trash

🤖 Generated with [Claude Code](https://claude.com/claude-code)