### PR TITLE
fix(delegate): parallel log filename race condition causes wrong doc IDs

### DIFF
--- a/emdx/services/unified_executor.py
+++ b/emdx/services/unified_executor.py
@@ -9,6 +9,7 @@ Uses stream-json output format by default for real-time log streaming.
 
 import json
 import logging
+import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -223,8 +224,9 @@ class UnifiedExecutor:
                 cli_tool=config.cli_tool,
             )
 
-        timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
-        log_file = self.log_dir / f"unified-{config.cli_tool}-{timestamp}.log"
+        timestamp = datetime.now().strftime('%Y%m%d%H%M%S%f')
+        thread_id = threading.get_ident()
+        log_file = self.log_dir / f"unified-{config.cli_tool}-{timestamp}-{thread_id}.log"
 
         exec_id = create_execution(
             doc_id=config.doc_id,


### PR DESCRIPTION
## Summary
- Parallel `emdx delegate` tasks (e.g. `-j 7`) all generated identical log filenames due to second-level timestamp granularity
- Each thread's `open(file, 'w')` truncated previous output, so `extract_output_doc_id()` returned the same doc ID for all tasks
- Fixed by adding microsecond precision (`%f`) and thread ID to log filenames, guaranteeing uniqueness under parallel execution

## Test plan
- [x] Verified 7-parallel delegate returns 7 distinct, correct results (previously returned same doc ID for all)
- [x] Verified 7 unique log files created (previously only 1)
- [x] Single delegate still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)