### PR TITLE
refactor: Remove emdx legend command — delete 131 LOC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,6 @@ poetry run emdx recent
 # Add tags using intuitive aliases (auto-converts to emojis)
 poetry run emdx tag 42 gameplan active urgent
 poetry run emdx tag list  # List all tags
-poetry run emdx tag legend  # View emoji legend and aliases
 ```
 
 ## 🎯 Claude Code Integration - MANDATORY INSTRUCTIONS

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ emdx find --tags "gameplan,success"
 | `success` | 🎉 | Worked as intended |
 | `failed` | ❌ | Didn't work |
 
-Run `emdx legend` for the full alias list.
+Run `emdx tag list` to see all tags in use.
 
 ## Delegating Work to Claude
 

--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -145,17 +145,6 @@ emdx tag list
 emdx tag list --sort name
 ```
 
-### **emdx tag legend**
-View emoji legend with text aliases.
-
-```bash
-# Show complete emoji legend with text aliases
-emdx tag legend
-
-# This helps you remember that:
-# gameplan = 🎯, active = 🚀, bug = 🐛, etc.
-```
-
 ### **emdx tag rename**
 Rename tags globally across all documents.
 
@@ -697,7 +686,7 @@ EMDX_SAFE_MODE=1 emdx delegate "task"  # Will show disabled message
 
 **Always available commands:**
 - `save`, `find`, `view`, `edit`, `delete` - Document management
-- `tag` (add, remove, list, rename, merge, legend, batch) - Tag management
+- `tag` (add, remove, list, rename, merge, batch) - Tag management
 - `list`, `recent`, `stats` - Information commands
 - `gui`, `prime`, `status` - Interface and overview
 - `ai` (ask, search, context) - AI-powered features

--- a/emdx/commands/tags.py
+++ b/emdx/commands/tags.py
@@ -24,7 +24,7 @@ from emdx.models.tags import (
 )
 from emdx.services.auto_tagger import AutoTagger
 from emdx.ui.formatting import format_tags
-from emdx.utils.emoji_aliases import generate_legend, normalize_tag_to_emoji
+from emdx.utils.emoji_aliases import normalize_tag_to_emoji
 from emdx.utils.output import console
 from emdx.utils.text_formatting import truncate_title
 
@@ -126,7 +126,7 @@ def _add_tags_impl(
 def tag_callback():
     """Manage document tags.
 
-    Subcommands: add, remove, list, rename, merge, legend, batch.
+    Subcommands: add, remove, list, rename, merge, batch.
 
     Shorthand: `emdx tag 42 gameplan active` is equivalent to `emdx tag add 42 gameplan active`.
     """
@@ -317,21 +317,6 @@ def merge(
         raise typer.Exit(0) from None
     except Exception as e:
         console.print(f"[red]Error merging tags: {e}[/red]")
-        raise typer.Exit(1) from e
-
-
-@app.command()
-def legend():
-    """Show emoji tag legend with text aliases."""
-    try:
-        from rich.markdown import Markdown
-
-        legend_content = generate_legend()
-        markdown = Markdown(legend_content)
-        console.print(markdown)
-
-    except Exception as e:
-        console.print(f"[red]Error displaying legend: {e}[/red]")
         raise typer.Exit(1) from e
 
 

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -248,7 +248,7 @@ def main(
 
 
 # Known subcommands of `emdx tag` — used for shorthand routing
-_TAG_SUBCOMMANDS = {"add", "remove", "list", "rename", "merge", "legend", "batch", "--help", "-h", "help"}
+_TAG_SUBCOMMANDS = {"add", "remove", "list", "rename", "merge", "batch", "--help", "-h", "help"}
 
 
 def run():

--- a/emdx/utils/emoji_aliases.py
+++ b/emdx/utils/emoji_aliases.py
@@ -271,65 +271,6 @@ def get_category_emojis() -> Dict[str, List[str]]:
     return categories
 
 
-def generate_legend() -> str:
-    """
-    Generate a markdown legend of all emoji aliases.
-    
-    Returns:
-        Markdown string with emoji legend
-    """
-    categories = get_category_emojis()
-    
-    legend_lines = [
-        "# EMDX Emoji Tag Legend",
-        "",
-        "Quick reference for emoji tags and their text aliases.",
-        "",
-    ]
-    
-    for category, emojis in categories.items():
-        legend_lines.append(f"## {category}")
-        legend_lines.append("")
-        
-        for emoji in emojis:
-            aliases = get_aliases_for_emoji(emoji)
-            if aliases:
-                # Show primary alias first, then others
-                primary = aliases[0]
-                others = aliases[1:] if len(aliases) > 1 else []
-                
-                line = f"- {emoji} = `{primary}`"
-                if others:
-                    other_list = ", ".join(f"`{alias}`" for alias in others)
-                    line += f" (also: {other_list})"
-                
-                legend_lines.append(line)
-        
-        legend_lines.append("")
-    
-    legend_lines.extend([
-        "## Usage Examples",
-        "",
-        "```bash",
-        "# Use text aliases for easier typing",
-        'emdx tag 123 gameplan active urgent',
-        "",
-        "# Mix aliases and emojis", 
-        'emdx tag 123 notes 🚀',
-        "",
-        "# Search by aliases",
-        'emdx find --tags \"gameplan,active\"',
-        "",
-        "# Save with tags using aliases",
-        'echo \"My plan\" | emdx save --title \"Strategy\" --tags \"gameplan,active\"',
-        "```",
-        "",
-        "**Note**: All text aliases are case-insensitive and automatically converted to emojis.",
-    ])
-    
-    return "\n".join(legend_lines)
-
-
 def suggest_aliases(partial: str) -> List[str]:
     """
     Suggest aliases based on partial input.

--- a/tests/test_commands_tags.py
+++ b/tests/test_commands_tags.py
@@ -53,7 +53,7 @@ class TestTagAddCommand:
         assert argv == ["emdx", "tag", "add", "42", "active"]
 
         # Other subcommands should not be rewritten
-        for subcmd in ("remove", "list", "rename", "merge", "legend", "batch"):
+        for subcmd in ("remove", "list", "rename", "merge", "batch"):
             argv = ["emdx", "tag", subcmd]
             _rewrite_tag_shorthand(argv)
             assert argv[2] == subcmd
@@ -296,18 +296,3 @@ class TestTagMergeCommand:
         ])
         assert result.exit_code != 0
         assert "No valid source tags" in _out(result)
-
-
-# ---------------------------------------------------------------------------
-# tag legend command
-# ---------------------------------------------------------------------------
-class TestTagLegendCommand:
-    """Tests for the tag legend command."""
-
-    @patch("emdx.commands.tags.generate_legend")
-    def test_legend(self, mock_legend):
-        """Legend command displays emoji legend."""
-        mock_legend.return_value = "# Emoji Legend\n- gameplan -> target"
-
-        result = runner.invoke(app, ["legend"])
-        assert result.exit_code == 0

--- a/tests/test_emoji_aliases.py
+++ b/tests/test_emoji_aliases.py
@@ -6,7 +6,6 @@ from emdx.utils.emoji_aliases import (
     REVERSE_ALIASES,
     expand_alias_string,
     expand_aliases,
-    generate_legend,
     get_aliases_for_emoji,
     get_all_aliases,
     get_category_emojis,
@@ -211,30 +210,6 @@ class TestGetCategoryEmojis:
         for cat, emojis in get_category_emojis().items():
             assert isinstance(emojis, list)
             assert len(emojis) > 0
-
-
-class TestGenerateLegend:
-    """Test generate_legend function."""
-
-    def test_contains_header(self):
-        legend = generate_legend()
-        assert "# EMDX Emoji Tag Legend" in legend
-
-    def test_contains_categories(self):
-        legend = generate_legend()
-        assert "## Document Types" in legend
-        assert "## Workflow Status" in legend
-        assert "## Outcomes" in legend
-
-    def test_contains_usage_examples(self):
-        legend = generate_legend()
-        assert "## Usage Examples" in legend
-        assert "emdx tag" in legend
-
-    def test_contains_emoji_entries(self):
-        legend = generate_legend()
-        assert "\U0001f3af" in legend
-        assert "`gameplan`" in legend
 
 
 class TestSuggestAliases:


### PR DESCRIPTION
## Summary

- Remove `emdx tag legend` command and `generate_legend()` function
- Remove from: tags.py, emoji_aliases.py, main.py subcommand set, CLAUDE.md, README.md, docs/cli-api.md
- Replace README reference with `emdx tag list` which serves the same discovery need
- Net: **-132 LOC** across 8 files

## Test plan
- [x] All 723 tests pass
- [x] No remaining references to `legend` in codebase
- [x] `emdx tag --help` no longer shows legend subcommand
- [x] `emdx tag list` still works for tag discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)