### PR TITLE
fix(delegate): Execution timeout + non-blocking I/O (#442)

### DIFF
--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -240,7 +240,7 @@ def _run_single(
         title=doc_title,
         output_instruction=output_instruction,
         working_dir=working_dir or str(Path.cwd()),
-        timeout_seconds=300,
+        timeout_seconds=600,
         model=model,
     )
 


### PR DESCRIPTION
## Summary
- Add `select()`-based non-blocking I/O to the Popen streaming loop in `UnifiedExecutor`, preventing infinite hangs when subprocesses produce no output
- Enforce deadline-based timeout that kills hung subprocesses after `config.timeout_seconds`
- Increase default delegate timeout from 300s → 600s (implementation tasks need more time)
- Add `try/except` fallback for `select()` with mocked pipes in unit tests

## Root cause
The Popen `readline()` loop blocked indefinitely when a `claude --print` subprocess hung waiting for an API slot. With no timeout enforcement, the entire delegate (and all ThreadPoolExecutor workers) would freeze permanently. This was the primary cause of the "fix wave" hanging issue.

## Test plan
- [x] All 795 tests pass (7 skipped)
- [x] `test_unified_executor.py` — all 14 tests pass with select() fallback
- [x] Manual test: `emdx delegate --worktree "Say A" "Say B" "Say C"` works
- [x] Manual test: single delegate completes within timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)