### PR TITLE
fix: Add missing pyyaml dependency (Issue #474)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ rich = "^13.0.0"
 python-dotenv = "^1.0.0"
 textual = "^4.0.0"
 psutil = "^7.0.0"
+pyyaml = ">=6.0"
 
 # Optional heavy dependencies (declared but not installed by default)
 scikit-learn = {version = "^1.6.0", optional = true}


### PR DESCRIPTION
## Summary
- Adds `pyyaml>=6.0` to `pyproject.toml` dependencies, fixing `ModuleNotFoundError` when running `emdx save --auto-tag`

Closes #474

## Test plan
- [x] `poetry install` succeeds with new dependency
- [x] `import yaml` works in the installed environment
- [x] All 780 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)