### PR TITLE
fix(security): Prevent command injection in delegate --each

### DIFF
--- a/tests/test_commands_delegate.py
+++ b/tests/test_commands_delegate.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import patch
 
-from emdx.commands.delegate import _slugify_title, _resolve_task, PR_INSTRUCTION
+import click.exceptions
+import pytest
+
+from emdx.commands.delegate import _slugify_title, _resolve_task, _run_discovery, PR_INSTRUCTION
 
 
 class TestSlugifyTitle:
@@ -90,3 +93,83 @@ class TestPRInstruction:
 
     def test_pr_instruction_mentions_pr_create(self):
         assert "gh pr create" in PR_INSTRUCTION
+
+
+class TestRunDiscovery:
+    """Tests for _run_discovery — security-critical command execution.
+
+    The key security property is that shell=False + shlex.split() prevents
+    command injection. Shell metacharacters like ; && || | > < ` $() are
+    NOT interpreted by a shell - they're passed as literal arguments.
+    """
+
+    def test_simple_command_works(self):
+        """Basic command execution should work."""
+        result = _run_discovery("echo one two three")
+        assert result == ["one two three"]
+
+    def test_multiline_output(self):
+        """Should split output into lines."""
+        result = _run_discovery("printf 'a\\nb\\nc'")
+        assert result == ["a", "b", "c"]
+
+    def test_empty_lines_filtered(self):
+        """Empty lines should be filtered out."""
+        result = _run_discovery("printf 'a\\n\\nb\\n\\n'")
+        assert result == ["a", "b"]
+
+    def test_shell_injection_via_semicolon_prevented(self):
+        """Shell injection via semicolon should fail safely.
+
+        With shell=True this would execute 'touch /tmp/pwned'.
+        With shell=False + shlex.split(), the semicolon and 'touch' become
+        arguments to echo, so this outputs 'hello; touch /tmp/pwned'.
+        """
+        result = _run_discovery("echo hello; touch /tmp/pwned")
+        # The semicolon is NOT interpreted as a command separator
+        assert "hello" in result[0]
+        assert "touch" in result[0]  # Literal 'touch' in the echo output
+
+    def test_shell_injection_via_backticks_prevented(self):
+        """Shell injection via backticks should be treated as literal."""
+        # With shell=False, backticks are just literal characters
+        result = _run_discovery("echo '`whoami`'")
+        assert result == ["`whoami`"]
+
+    def test_shell_injection_via_dollar_parens_prevented(self):
+        """Shell injection via $() should be treated as literal."""
+        result = _run_discovery("echo '$(whoami)'")
+        assert result == ["$(whoami)"]
+
+    def test_command_not_found_exits(self):
+        """Non-existent command should exit cleanly."""
+        with pytest.raises(click.exceptions.Exit):
+            _run_discovery("nonexistent_command_xyz123")
+
+    def test_malformed_quotes_exits(self):
+        """Malformed quotes should be caught by shlex."""
+        with pytest.raises(click.exceptions.Exit):
+            _run_discovery("echo 'unclosed")
+
+    def test_no_items_exits(self):
+        """Empty output should exit."""
+        with pytest.raises(click.exceptions.Exit):
+            _run_discovery("echo ''")
+
+    def test_fd_style_command(self):
+        """Typical discovery commands like fd should work."""
+        # Use a simple substitute since fd may not be installed
+        result = _run_discovery("ls -1 /tmp")
+        # Just verify it returns a list (contents vary)
+        assert isinstance(result, list)
+
+    def test_uses_shell_false(self):
+        """Verify shell=False prevents pipe interpretation.
+
+        With shell=True, 'echo hello | cat' would pipe through cat.
+        With shell=False, it tries to echo the literal string '| cat'.
+        """
+        result = _run_discovery("echo hello | cat")
+        # The pipe is NOT interpreted - it becomes part of echo's arguments
+        assert "|" in result[0]
+        assert "cat" in result[0]


### PR DESCRIPTION
## Summary

- Fixes critical command injection vulnerability in `_run_discovery()` function (delegate.py:141)
- The `--each` flag was passing user input directly to `subprocess.run()` with `shell=True`
- Attack example: `emdx delegate --each "; rm -rf ~" --do "task"` would execute arbitrary commands

## Changes

- Use `shlex.split()` to safely parse commands into argument lists
- Use `shell=False` to prevent shell interpretation of metacharacters
- Add proper error handling for malformed commands and missing executables
- Add 11 comprehensive tests covering injection prevention scenarios

## Security Impact

Shell metacharacters like `; && || | > < \` $()` are now treated as literal arguments rather than being interpreted by a shell. This prevents:
- Command chaining via `;` or `&&`
- Command substitution via `` `...` `` or `$(...)`
- Pipe injection via `|`
- Redirect injection via `>` or `<`

## Test Plan

- [x] All 28 delegate tests pass
- [x] New injection prevention tests verify the fix
- [x] Typical discovery commands like `fd -e py src/` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)