### PR TITLE
fix: Remove 69 unused imports and deprecated execute_claude_sync usage

### DIFF
--- a/emdx/commands/cascade.py
+++ b/emdx/commands/cascade.py
@@ -15,7 +15,6 @@ Key concepts:
 import re
 import time
 from datetime import datetime
-from pathlib import Path
 from typing import Optional
 
 import typer
@@ -25,7 +24,7 @@ from rich.table import Table
 from ..config.constants import EMDX_LOG_DIR
 from ..database.documents import get_document, save_document
 from ..database import cascade as cascade_db
-from ..services.claude_executor import execute_claude_detached, execute_claude_sync
+from ..services.claude_executor import execute_claude_detached, execute_cli_sync
 from ..database.connection import db_connection
 
 console = Console()
@@ -174,10 +173,11 @@ def _process_stage(doc: dict, stage: str, cascade_run_id: int = None) -> tuple[b
     timeout = 1800 if stage == "planned" else 300
 
     try:
-        result = execute_claude_sync(
+        result = execute_cli_sync(
             task=prompt,
             execution_id=execution_id,
             log_file=log_file,
+            cli_tool="claude",
             doc_id=str(doc_id),
             timeout=timeout,
         )

--- a/emdx/commands/maintain.py
+++ b/emdx/commands/maintain.py
@@ -18,14 +18,13 @@ from typing import TYPE_CHECKING, Optional
 import typer
 
 if TYPE_CHECKING:
-    import psutil
+    pass
 from rich import box
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.prompt import Confirm
 
 from ..applications import MaintenanceApplication
-from ..config.settings import get_db_path
 from ..utils.output import console
 
 logger = logging.getLogger(__name__)

--- a/emdx/commands/prime.py
+++ b/emdx/commands/prime.py
@@ -10,8 +10,6 @@ from datetime import datetime
 from typing import Optional
 
 from rich.console import Console
-from rich.panel import Panel
-from rich.text import Text
 
 from ..database import db
 from ..utils.git import get_git_project

--- a/emdx/commands/recipe.py
+++ b/emdx/commands/recipe.py
@@ -9,7 +9,6 @@ instructions for Claude to follow via `emdx delegate`.
 """
 
 import subprocess
-import sys
 from pathlib import Path
 from typing import List, Optional
 

--- a/emdx/commands/status.py
+++ b/emdx/commands/status.py
@@ -13,7 +13,6 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from rich.console import Console
-from rich.text import Text
 
 from ..database import db
 from ..models.tasks import (

--- a/emdx/commands/tags.py
+++ b/emdx/commands/tags.py
@@ -24,7 +24,6 @@ from emdx.models.tags import (
 )
 from emdx.services.auto_tagger import AutoTagger
 from emdx.ui.formatting import format_tags
-from emdx.utils.emoji_aliases import normalize_tag_to_emoji
 from emdx.utils.output import console
 from emdx.utils.text_formatting import truncate_title
 

--- a/emdx/config/cli_config.py
+++ b/emdx/config/cli_config.py
@@ -5,7 +5,7 @@ that can be used to execute agent tasks.
 """
 
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional
 

--- a/emdx/config/settings.py
+++ b/emdx/config/settings.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 # Re-export constants for backward compatibility
-from .constants import DEFAULT_CLAUDE_MODEL, EMDX_CONFIG_DIR
+from .constants import EMDX_CONFIG_DIR
 
 
 def get_db_path() -> Path:

--- a/emdx/database/cascade.py
+++ b/emdx/database/cascade.py
@@ -11,7 +11,7 @@ main documents table for efficiency (only ~1% of docs use cascade).
 """
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from ..utils.datetime_utils import parse_datetime
 from .connection import db_connection

--- a/emdx/database/search.py
+++ b/emdx/database/search.py
@@ -2,7 +2,6 @@
 Search functionality for emdx documents using FTS5
 """
 
-import re
 from typing import Any, Optional
 
 from ..utils.datetime_utils import parse_datetime

--- a/emdx/services/claude_executor.py
+++ b/emdx/services/claude_executor.py
@@ -21,9 +21,8 @@ from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
-from ..config.cli_config import CliTool, get_cli_config, DEFAULT_ALLOWED_TOOLS
-from ..config.settings import DEFAULT_CLAUDE_MODEL
-from ..utils.environment import ensure_claude_in_path, validate_execution_environment
+from ..config.cli_config import DEFAULT_ALLOWED_TOOLS
+from ..utils.environment import ensure_claude_in_path
 from ..utils.structured_logger import ProcessType, StructuredLogger
 from .cli_executor import get_cli_executor
 

--- a/emdx/services/cli_executor/base.py
+++ b/emdx/services/cli_executor/base.py
@@ -5,7 +5,6 @@ This module defines the abstract interface that all CLI executors must implement
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 

--- a/emdx/services/similarity.py
+++ b/emdx/services/similarity.py
@@ -453,7 +453,6 @@ class SimilarityService:
             return []
 
         import numpy as np
-        from scipy.sparse import csr_matrix
 
         # Compute full similarity matrix (sparse operation, very fast)
         if progress_callback:

--- a/emdx/services/unified_executor.py
+++ b/emdx/services/unified_executor.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from ..config.cli_config import CliTool, get_default_cli_tool, DEFAULT_ALLOWED_TOOLS
+from ..config.cli_config import DEFAULT_ALLOWED_TOOLS
 from ..config.constants import EMDX_LOG_DIR
 from ..models.executions import create_execution, update_execution_status
 from ..utils.environment import get_subprocess_env

--- a/emdx/ui/activity/activity_data.py
+++ b/emdx/ui/activity/activity_data.py
@@ -5,7 +5,7 @@ Produces typed ActivityItem subclasses from activity_items.py.
 
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import List, Set, Tuple
 
 from emdx.utils.datetime_utils import parse_datetime
 

--- a/emdx/ui/activity/activity_view.py
+++ b/emdx/ui/activity/activity_view.py
@@ -13,7 +13,7 @@ and cursor tracking by node reference — eliminating scroll jumping.
 import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import List, Optional
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, ScrollableContainer

--- a/emdx/ui/activity/group_picker.py
+++ b/emdx/ui/activity/group_picker.py
@@ -6,11 +6,10 @@ or creating a new group.
 """
 
 import logging
-from typing import Callable, Optional
+from typing import Optional
 
 from textual import events
 from textual.app import ComposeResult
-from textual.containers import Horizontal
 from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Input, Static

--- a/emdx/ui/activity_browser.py
+++ b/emdx/ui/activity_browser.py
@@ -4,7 +4,6 @@ import logging
 from typing import Optional
 
 from textual.app import ComposeResult
-from textual.containers import Vertical
 from textual.widget import Widget
 from textual.widgets import Static
 

--- a/emdx/ui/browser_container.py
+++ b/emdx/ui/browser_container.py
@@ -8,7 +8,7 @@ import logging
 from rich.markup import escape
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Container, Vertical
+from textual.containers import Container
 from textual.reactive import reactive
 from textual.widget import Widget
 

--- a/emdx/ui/cascade/cascade_browser.py
+++ b/emdx/ui/cascade/cascade_browser.py
@@ -13,7 +13,6 @@ from emdx.services.cascade_service import (
     get_document,
     list_documents_at_stage,
     monitor_execution_completion,
-    update_cascade_stage,
 )
 from emdx.services.document_service import save_document
 from emdx.services.execution_service import create_execution

--- a/emdx/ui/cascade/document_list.py
+++ b/emdx/ui/cascade/document_list.py
@@ -9,7 +9,6 @@ from textual.widgets import DataTable, Static
 
 from emdx.services.cascade_service import (
     get_child_info,
-    get_document_pr_url,
     list_documents_at_stage,
 )
 

--- a/emdx/ui/command_palette/palette_commands.py
+++ b/emdx/ui/command_palette/palette_commands.py
@@ -8,7 +8,7 @@ import logging
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/emdx/ui/command_palette/palette_presenter.py
+++ b/emdx/ui/command_palette/palette_presenter.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Set
 
-from .palette_commands import CommandContext, CommandRegistry, PaletteCommand, get_command_registry
+from .palette_commands import CommandContext, PaletteCommand, get_command_registry
 
 logger = logging.getLogger(__name__)
 

--- a/emdx/ui/command_palette/palette_screen.py
+++ b/emdx/ui/command_palette/palette_screen.py
@@ -8,7 +8,6 @@ via keyboard-driven fuzzy search.
 import asyncio
 import logging
 import traceback
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 from textual.app import ComposeResult
@@ -20,7 +19,7 @@ from textual.widgets import Input, ListView, ListItem, Static
 
 from emdx.config.constants import EMDX_CONFIG_DIR
 from .palette_commands import CommandContext
-from .palette_presenter import PalettePresenter, PaletteResultItem, PaletteState, ResultType
+from .palette_presenter import PalettePresenter, PaletteResultItem, PaletteState
 
 logger = logging.getLogger(__name__)
 

--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -8,7 +8,7 @@ operations while this widget focuses on display and user interaction.
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Protocol
+from typing import Any, Dict, Optional, Protocol
 
 from textual.app import ComposeResult
 from textual.binding import Binding

--- a/emdx/ui/live_log_writer.py
+++ b/emdx/ui/live_log_writer.py
@@ -17,7 +17,6 @@ This replaces scattered log handling code across:
 """
 
 import logging
-from typing import Optional
 
 from textual.widgets import RichLog
 

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -27,7 +27,7 @@ from emdx.services.log_stream import LogStream, LogStreamSubscriber
 
 from .log_browser_display import LogBrowserDisplayMixin
 from .log_browser_filtering import LogBrowserFilteringMixin
-from .log_browser_navigation import LogBrowserHost, LogBrowserNavigationMixin
+from .log_browser_navigation import LogBrowserNavigationMixin
 from .modals import HelpMixin
 
 logger = logging.getLogger(__name__)

--- a/emdx/ui/preview_mode_manager.py
+++ b/emdx/ui/preview_mode_manager.py
@@ -12,7 +12,7 @@ Each switch_to_X method handles the complete lifecycle:
 
 import logging
 from enum import Enum
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Tuple
 
 from textual.containers import ScrollableContainer, Vertical
 from textual.widgets import RichLog

--- a/emdx/ui/theme_selector.py
+++ b/emdx/ui/theme_selector.py
@@ -6,13 +6,13 @@ Provides a modal dialog for selecting and previewing themes.
 
 from textual import events
 from textual.app import ComposeResult
-from textual.containers import Vertical, Horizontal
+from textual.containers import Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Static, Label, OptionList
 from textual.widgets.option_list import Option
 
 from emdx.config.ui_config import get_theme, set_theme
-from emdx.ui.themes import get_theme_display_info, get_theme_names
+from emdx.ui.themes import get_theme_display_info
 
 
 class ThemeSelectorScreen(ModalScreen):

--- a/emdx/utils/title_normalization.py
+++ b/emdx/utils/title_normalization.py
@@ -5,7 +5,6 @@ agent numbers, etc. to enable automatic supersede detection.
 """
 
 import re
-from typing import Optional
 
 
 def normalize_title(title: str) -> str:

--- a/tests/test_cascade_metadata.py
+++ b/tests/test_cascade_metadata.py
@@ -1,7 +1,5 @@
 """Tests for cascade metadata extraction and the new cascade database module."""
 
-import os
-import sqlite3
 import tempfile
 from pathlib import Path
 
@@ -327,7 +325,7 @@ class TestForeignKeyCascadeDelete:
     def test_cascade_delete_removes_metadata(self, setup_test_db):
         """Test that deleting a document removes its cascade metadata."""
         from emdx.database import cascade as cascade_db
-        from emdx.database.documents import save_document, delete_document
+        from emdx.database.documents import save_document
 
         doc_id = save_document("Test", "Content")
         cascade_db.update_cascade_stage(doc_id, "idea")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,7 +151,6 @@ class TestTrailingHelpConversion:
     def test_trailing_help_conversion(self):
         """Test that run() converts trailing 'help' to '--help'."""
         import sys
-        from unittest.mock import patch
 
         # Test the conversion logic directly
         original_argv = sys.argv.copy()

--- a/tests/test_commands_core.py
+++ b/tests/test_commands_core.py
@@ -1,12 +1,9 @@
 """Tests for core CRUD commands (save, view, edit, delete, restore, etc.)."""
 
 import re
-import tempfile
 from datetime import datetime
-from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 
-import typer
 from typer.testing import CliRunner
 
 from emdx.commands.core import app, get_input_content, generate_title, InputContent

--- a/tests/test_commands_groups.py
+++ b/tests/test_commands_groups.py
@@ -1,7 +1,6 @@
 """Tests for group management CLI commands."""
 
 import re
-from datetime import datetime
 from unittest.mock import Mock, patch
 
 from typer.testing import CliRunner

--- a/tests/test_commands_trash.py
+++ b/tests/test_commands_trash.py
@@ -1,10 +1,9 @@
 """Tests for trash management commands (list, restore, purge)."""
 
 import re
-from datetime import datetime, timedelta
-from unittest.mock import patch, MagicMock
+from datetime import datetime
+from unittest.mock import patch
 
-import typer
 from typer.testing import CliRunner
 
 from emdx.commands.trash import app

--- a/tests/test_document_merger.py
+++ b/tests/test_document_merger.py
@@ -1,6 +1,5 @@
 """Tests for the document merger service with TF-IDF pre-filtering."""
 
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_execution_monitor.py
+++ b/tests/test_execution_monitor.py
@@ -10,9 +10,8 @@ NOTE: The source has a bug at lines 262-263 where `pid` should be `execution.pid
 in the except handlers. Tests are written to work with the existing code.
 """
 
-import pytest
 from datetime import datetime, timezone, timedelta
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, MagicMock
 
 import psutil
 

--- a/tests/test_execution_system_comprehensive.py
+++ b/tests/test_execution_system_comprehensive.py
@@ -13,9 +13,6 @@ This script tests all the improvements made to the execution system:
 
 import subprocess
 import time
-import os
-import sys
-from pathlib import Path
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -1,10 +1,8 @@
 """Tests for lazy loading CLI commands."""
 
 import sys
-from unittest.mock import MagicMock, patch
 
 import click
-import pytest
 from typer.testing import CliRunner
 
 from emdx.utils.lazy_group import (

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,9 +1,7 @@
 """Tests for database/search.py FTS5 full-text search functionality."""
 
 import sqlite3
-import tempfile
 from datetime import datetime, timedelta
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,7 +1,5 @@
 """Tests for the TF-IDF similarity service."""
 
-import json
-import tempfile
 from pathlib import Path
 from unittest.mock import patch
 

--- a/tests/test_unified_executor.py
+++ b/tests/test_unified_executor.py
@@ -1,6 +1,5 @@
 """Tests for the UnifiedExecutor service."""
 
-import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
## Summary

- Remove all 69 unused imports detected by ruff (F401/F811)
- Replace deprecated `execute_claude_sync()` with `execute_cli_sync()` in `cascade.py`
- 42 files cleaned up across commands, config, database, services, ui, and tests

## Test plan

- [x] `ruff check --select F401,F811` reports 0 errors
- [x] Full test suite passes: 797 passed, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)