### PR TITLE
fix(cli): Add help text and improve error visibility

### DIFF
--- a/emdx/commands/browse.py
+++ b/emdx/commands/browse.py
@@ -13,7 +13,7 @@ from emdx.utils.datetime_utils import format_datetime as _format_datetime
 from emdx.utils.text_formatting import truncate_title
 from emdx.utils.output import console
 
-app = typer.Typer()
+app = typer.Typer(help="Browse and analyze the knowledge base")
 
 
 @app.command()

--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -39,7 +39,7 @@ from emdx.utils.emoji_aliases import expand_alias_string
 from emdx.utils.text_formatting import truncate_title
 from emdx.utils.output import console
 
-app = typer.Typer()
+app = typer.Typer(help="Core document operations: save, find, view, edit, delete")
 
 
 @dataclass
@@ -318,8 +318,9 @@ def save(
                             (doc_id, gist_id_str, gist_url, public),
                         )
                         conn.commit()
-                except Exception:
-                    pass  # Non-fatal — gist was still created
+                except Exception as e:
+                    # Non-fatal — gist was still created, but warn user
+                    console.print(f"   [yellow]⚠ Could not record gist in database: {e}[/yellow]")
 
                 console.print(f"   [green]Gist:[/green] {gist_url}")
 

--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -61,8 +61,8 @@ def _safe_update_task(task_id: Optional[int], **kwargs) -> None:
     try:
         from ..models.tasks import update_task
         update_task(task_id, **kwargs)
-    except Exception:
-        pass
+    except Exception as e:
+        sys.stderr.write(f"delegate: task update failed for #{task_id}: {e}\n")
 
 
 def _safe_update_execution(exec_id: Optional[int], **kwargs) -> None:
@@ -72,8 +72,8 @@ def _safe_update_execution(exec_id: Optional[int], **kwargs) -> None:
     try:
         from ..models.executions import update_execution
         update_execution(exec_id, **kwargs)
-    except Exception:
-        pass
+    except Exception as e:
+        sys.stderr.write(f"delegate: execution update failed for #{exec_id}: {e}\n")
 
 
 PR_INSTRUCTION = (
@@ -526,7 +526,7 @@ def delegate(
     ),
     tags: Optional[List[str]] = typer.Option(
         None, "--tags", "-t",
-        help="Tags to apply to outputs (comma-separated)",
+        help="Tags to apply to outputs (comma-separated or multiple -t flags)",
     ),
     title: Optional[str] = typer.Option(
         None, "--title", "-T",

--- a/emdx/commands/executions.py
+++ b/emdx/commands/executions.py
@@ -24,7 +24,7 @@ from ..models.executions import (
 from ..utils.text_formatting import truncate_description
 from ..utils.output import console
 
-app = typer.Typer()
+app = typer.Typer(help="Monitor and manage delegate executions")
 
 
 def tail_log_subprocess(log_path: Path, follow: bool = False, lines: int = 50) -> None:

--- a/emdx/commands/gist.py
+++ b/emdx/commands/gist.py
@@ -16,7 +16,7 @@ from emdx.database import db
 from emdx.models.documents import get_document
 from emdx.utils.output import console
 
-app = typer.Typer()
+app = typer.Typer(help="GitHub Gist integration for sharing documents")
 
 
 def get_github_auth() -> Optional[str]:

--- a/emdx/commands/trash.py
+++ b/emdx/commands/trash.py
@@ -21,7 +21,7 @@ from emdx.models.documents import (
 )
 from emdx.utils.output import console
 
-app = typer.Typer()
+app = typer.Typer(help="Manage deleted documents (trash)")
 
 
 @app.callback(invoke_without_command=True)


### PR DESCRIPTION
## Summary
- Add help text to 5 Typer app instances that were missing it (browse, core, executions, gist, trash)
- Clarify tag input format in delegate command help text
- Fix 3 silent failures in critical paths to now show warnings/errors

## Test plan
- [x] All 797 tests pass
- [x] Verify help text appears in CLI output
- [x] Verify error messages now appear when operations fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)