### PR TITLE
fix(schema): Address migration/schema debt audit findings (Issue #6230)

### DIFF
--- a/emdx/database/groups.py
+++ b/emdx/database/groups.py
@@ -134,7 +134,17 @@ def update_group(group_id: int, **kwargs) -> bool:
 
     Returns:
         True if update succeeded
+
+    Security Note:
+        Field names are interpolated into SQL but protected by the allowed_fields
+        allowlist. Only columns explicitly listed below can be updated, preventing
+        SQL injection through kwargs. The allowlist pattern is safe because:
+        1. Field names come from a hardcoded set, not user input
+        2. Values are always parameterized (?)
+        3. New columns require explicit code changes to be updatable
     """
+    # SECURITY: This allowlist prevents SQL injection - only these field names
+    # can be interpolated into the SET clause. Values are always parameterized.
     allowed_fields = {
         "name", "description", "parent_group_id", "group_type",
         "project", "is_active",


### PR DESCRIPTION
## Summary

Addresses findings from the migration/schema debt audit (Document #6230):

- **Fix Execution dataclass out of sync with schema**: Added missing columns (`cascade_run_id`, `task_id`, `cost_usd`, `tokens_used`, `input_tokens`, `output_tokens`) from migrations 031 and 036
- **Fix heartbeat functionality broken post-migration 013**: `last_heartbeat` column was dropped, so updated `get_stale_executions()` to use `started_at` timestamps instead, and made `update_execution_heartbeat()` a no-op with documentation
- **Fix orphan-prone foreign keys**: Added migration 037 with ON DELETE CASCADE/SET NULL for:
  - `gists.document_id` → CASCADE
  - `gdocs.document_id` → CASCADE
  - `export_history.document_id` and `profile_id` → CASCADE
  - `cascade_runs.start_doc_id` and `current_doc_id` → SET NULL
- **Add security documentation**: Added comment to `groups.py` `update_group()` explaining the allowlist pattern for SQL injection prevention

## Test plan

- [x] Run execution monitor tests: `pytest tests/test_execution_monitor.py`
- [x] Run execution system tests: `pytest tests/test_execution_system.py`
- [x] Run migration tests: `pytest tests/test_migrations.py`
- [x] Run groups tests: `pytest tests/test_groups.py`
- [x] Run cascade metadata tests: `pytest tests/test_cascade_metadata.py`
- [x] Run database tests: `pytest tests/test_database.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)