### PR TITLE
fix(config): Centralize hardcoded timeout values and model names

### DIFF
--- a/emdx/commands/cascade.py
+++ b/emdx/commands/cascade.py
@@ -22,7 +22,11 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from ..config.constants import EMDX_LOG_DIR
+from ..config.constants import (
+    CASCADE_IMPLEMENTATION_TIMEOUT,
+    CASCADE_STAGE_TIMEOUT,
+    EMDX_LOG_DIR,
+)
 from ..database.documents import get_document, save_document
 from ..database import cascade as cascade_db
 from ..services.claude_executor import execute_claude_detached, execute_claude_sync
@@ -171,7 +175,7 @@ def _process_stage(doc: dict, stage: str, cascade_run_id: int = None) -> tuple[b
         execution_id = cursor.lastrowid
 
     # Implementation stage needs longer timeout
-    timeout = 1800 if stage == "planned" else 300
+    timeout = CASCADE_IMPLEMENTATION_TIMEOUT if stage == "planned" else CASCADE_STAGE_TIMEOUT
 
     try:
         result = execute_claude_sync(

--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -37,6 +37,7 @@ from typing import List, Optional
 
 import typer
 
+from ..config.constants import DISCOVERY_COMMAND_TIMEOUT
 from ..database.documents import get_document
 from ..services.unified_executor import ExecutionConfig, UnifiedExecutor
 
@@ -146,7 +147,7 @@ def _run_discovery(command: str) -> List[str]:
             shell=True,
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=DISCOVERY_COMMAND_TIMEOUT,
         )
         if result.returncode != 0:
             sys.stderr.write(f"delegate: discovery failed: {result.stderr.strip()}\n")
@@ -161,7 +162,7 @@ def _run_discovery(command: str) -> List[str]:
         return lines
 
     except subprocess.TimeoutExpired:
-        sys.stderr.write("delegate: discovery command timed out after 30s\n")
+        sys.stderr.write(f"delegate: discovery command timed out after {DISCOVERY_COMMAND_TIMEOUT}s\n")
         raise typer.Exit(1)
 
 

--- a/emdx/commands/gist.py
+++ b/emdx/commands/gist.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 import typer
 
+from emdx.config.constants import GITHUB_AUTH_TIMEOUT
 from emdx.database import db
 from emdx.models.documents import get_document
 from emdx.utils.output import console
@@ -39,7 +40,7 @@ def get_github_auth() -> Optional[str]:
             capture_output=True,
             text=True,
             check=True,
-            timeout=10  # Prevent hanging
+            timeout=GITHUB_AUTH_TIMEOUT  # Prevent hanging
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()

--- a/emdx/commands/maintain.py
+++ b/emdx/commands/maintain.py
@@ -25,6 +25,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.prompt import Confirm
 
 from ..applications import MaintenanceApplication
+from ..config.constants import PROCESS_KILL_TIMEOUT, PROCESS_TERMINATE_TIMEOUT
 from ..config.settings import get_db_path
 from ..utils.output import console
 
@@ -766,12 +767,12 @@ def _cleanup_processes(dry_run: bool, max_runtime_hours: int = 2) -> Optional[st
                 # Try graceful termination first
                 proc.terminate()
                 try:
-                    proc.wait(timeout=3)
+                    proc.wait(timeout=PROCESS_TERMINATE_TIMEOUT)
                     terminated += 1
                 except psutil.TimeoutExpired:
                     # Force kill if terminate didn't work
                     proc.kill()
-                    proc.wait(timeout=1)
+                    proc.wait(timeout=PROCESS_KILL_TIMEOUT)
                     killed += 1
             except psutil.NoSuchProcess:
                 # Process already gone - count as success

--- a/emdx/config/__init__.py
+++ b/emdx/config/__init__.py
@@ -1,6 +1,12 @@
 """Configuration module for emdx."""
 
-from .settings import get_db_path
+from .settings import (
+    get_db_path,
+    get_env_info,
+    get_env_var,
+    validate_all_env_vars,
+    validate_env_var,
+)
 
 # Re-export commonly used constants
 from .constants import (
@@ -12,9 +18,18 @@ from .constants import (
     DEFAULT_RECENT_LIMIT,
     DEFAULT_BROWSE_LIMIT,
     DEFAULT_BATCH_LIMIT,
-    # Timeouts
+    # Timeouts - Agent execution
     EXECUTION_TIMEOUT_SECONDS,
     STALE_EXECUTION_TIMEOUT_SECONDS,
+    CASCADE_IMPLEMENTATION_TIMEOUT,
+    CASCADE_STAGE_TIMEOUT,
+    # Timeouts - Subprocess
+    CLI_VERSION_CHECK_TIMEOUT,
+    CLI_AUTH_CHECK_TIMEOUT,
+    DISCOVERY_COMMAND_TIMEOUT,
+    GITHUB_AUTH_TIMEOUT,
+    PROCESS_TERMINATE_TIMEOUT,
+    PROCESS_KILL_TIMEOUT,
     DEFAULT_REFRESH_INTERVAL_SECONDS,
     # Concurrency
     DEFAULT_MAX_CONCURRENT_STAGES,
@@ -34,12 +49,23 @@ from .constants import (
     EXECUTION_HISTORY_DAYS,
     # Task defaults
     DEFAULT_TASK_PRIORITY,
-    # Claude model
+    # Claude models
     DEFAULT_CLAUDE_MODEL,
+    CLAUDE_MODEL_OPUS,
+    CLAUDE_MODEL_SONNET,
+    DEFAULT_ASK_MODEL,
+    CURSOR_MODEL_OPUS,
+    CURSOR_MODEL_SONNET,
+    # Environment
+    ENV_VAR_DEFINITIONS,
 )
 
 __all__ = [
     "get_db_path",
+    "get_env_var",
+    "get_env_info",
+    "validate_env_var",
+    "validate_all_env_vars",
     # Paths
     "EMDX_CONFIG_DIR",
     "EMDX_LOG_DIR",
@@ -48,9 +74,18 @@ __all__ = [
     "DEFAULT_RECENT_LIMIT",
     "DEFAULT_BROWSE_LIMIT",
     "DEFAULT_BATCH_LIMIT",
-    # Timeouts
+    # Timeouts - Agent execution
     "EXECUTION_TIMEOUT_SECONDS",
     "STALE_EXECUTION_TIMEOUT_SECONDS",
+    "CASCADE_IMPLEMENTATION_TIMEOUT",
+    "CASCADE_STAGE_TIMEOUT",
+    # Timeouts - Subprocess
+    "CLI_VERSION_CHECK_TIMEOUT",
+    "CLI_AUTH_CHECK_TIMEOUT",
+    "DISCOVERY_COMMAND_TIMEOUT",
+    "GITHUB_AUTH_TIMEOUT",
+    "PROCESS_TERMINATE_TIMEOUT",
+    "PROCESS_KILL_TIMEOUT",
     "DEFAULT_REFRESH_INTERVAL_SECONDS",
     # Concurrency
     "DEFAULT_MAX_CONCURRENT_STAGES",
@@ -70,6 +105,13 @@ __all__ = [
     "EXECUTION_HISTORY_DAYS",
     # Task defaults
     "DEFAULT_TASK_PRIORITY",
-    # Claude model
+    # Claude models
     "DEFAULT_CLAUDE_MODEL",
+    "CLAUDE_MODEL_OPUS",
+    "CLAUDE_MODEL_SONNET",
+    "DEFAULT_ASK_MODEL",
+    "CURSOR_MODEL_OPUS",
+    "CURSOR_MODEL_SONNET",
+    # Environment
+    "ENV_VAR_DEFINITIONS",
 ]

--- a/emdx/config/cli_config.py
+++ b/emdx/config/cli_config.py
@@ -9,6 +9,13 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional
 
+from .constants import (
+    CLAUDE_MODEL_OPUS,
+    CLAUDE_MODEL_SONNET,
+    CURSOR_MODEL_OPUS,
+    CURSOR_MODEL_SONNET,
+)
+
 
 # Default tools allowed for Claude CLI execution
 # These are the standard tools that most agents need for basic operations
@@ -77,7 +84,7 @@ CLI_CONFIGS: Dict[CliTool, CliConfig] = {
         default_output_format="stream-json",
         requires_verbose_for_stream=True,
         model_flag="--model",
-        default_model="claude-opus-4-5-20251101",
+        default_model=CLAUDE_MODEL_OPUS,
         supports_allowed_tools=True,
         allowed_tools_flag="--allowedTools",
         force_flag=None,
@@ -107,19 +114,19 @@ CLI_CONFIGS: Dict[CliTool, CliConfig] = {
 # Use these aliases for portable commands that work with either CLI
 MODEL_ALIASES: Dict[str, Dict[str, str]] = {
     "opus": {
-        "claude": "claude-opus-4-5-20251101",
-        "cursor": "opus-4.5",
+        "claude": CLAUDE_MODEL_OPUS,
+        "cursor": CURSOR_MODEL_OPUS,
     },
     "sonnet": {
-        "claude": "claude-sonnet-4-5-20250929",
-        "cursor": "sonnet-4.5",
+        "claude": CLAUDE_MODEL_SONNET,
+        "cursor": CURSOR_MODEL_SONNET,
     },
     "auto": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": CLAUDE_MODEL_SONNET,
         "cursor": "auto",
     },
     "fast": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": CLAUDE_MODEL_SONNET,
         "cursor": "auto",
     },
 }
@@ -174,17 +181,17 @@ def get_available_models(cli_tool: CliTool) -> List[str]:
     """
     if cli_tool == CliTool.CLAUDE:
         return [
-            "claude-opus-4-5-20251101",
-            "claude-sonnet-4-5-20250929",
+            CLAUDE_MODEL_OPUS,
+            CLAUDE_MODEL_SONNET,
             "opus",
             "sonnet",
         ]
     elif cli_tool == CliTool.CURSOR:
         return [
             "auto",
-            "opus-4.5",
+            CURSOR_MODEL_OPUS,
             "opus-4.5-thinking",
-            "sonnet-4.5",
+            CURSOR_MODEL_SONNET,
             "sonnet-4.5-thinking",
             "gpt-5.2",
             "gemini-3-pro",

--- a/emdx/config/constants.py
+++ b/emdx/config/constants.py
@@ -33,9 +33,21 @@ DEFAULT_BATCH_LIMIT = 100  # Large batch operations, document loading
 EXECUTION_TIMEOUT_SECONDS = 3600  # 1 hour - max time for agent execution
 STALE_EXECUTION_TIMEOUT_SECONDS = 1800  # 30 minutes - when to consider execution stale
 
+# Stage-specific execution timeouts
+CASCADE_IMPLEMENTATION_TIMEOUT = 1800  # 30 minutes - implementation stage (writes code)
+CASCADE_STAGE_TIMEOUT = 300  # 5 minutes - analysis/planning stages
+
 # Process monitoring
 MAX_PROCESS_RUNTIME_HOURS = 2  # Hours before a process is considered stuck
 EXECUTION_STALE_TIMEOUT_MINUTES = 30  # Minutes before execution marked stale
+
+# Subprocess timeouts (for quick CLI commands)
+CLI_VERSION_CHECK_TIMEOUT = 5  # Version/status checks
+CLI_AUTH_CHECK_TIMEOUT = 10  # Authentication verification
+DISCOVERY_COMMAND_TIMEOUT = 30  # Shell discovery commands (--each)
+GITHUB_AUTH_TIMEOUT = 10  # gh auth token retrieval
+PROCESS_TERMINATE_TIMEOUT = 3  # Graceful termination wait
+PROCESS_KILL_TIMEOUT = 1  # Force kill wait
 
 # UI refresh intervals
 DEFAULT_REFRESH_INTERVAL_SECONDS = 5  # UI auto-refresh interval
@@ -190,4 +202,58 @@ DEFAULT_STAGE_RUNS = 1  # Default number of runs per stage
 # CLAUDE MODEL CONFIGURATION
 # =============================================================================
 
-DEFAULT_CLAUDE_MODEL = "claude-opus-4-5-20251101"
+# Primary model names (canonical form)
+CLAUDE_MODEL_OPUS = "claude-opus-4-5-20251101"
+CLAUDE_MODEL_SONNET = "claude-sonnet-4-5-20250929"
+
+# Default model for general use
+DEFAULT_CLAUDE_MODEL = CLAUDE_MODEL_OPUS
+
+# Default model for ask/Q&A service (uses sonnet for speed/cost)
+DEFAULT_ASK_MODEL = CLAUDE_MODEL_SONNET
+
+# Cursor model equivalents
+CURSOR_MODEL_OPUS = "opus-4.5"
+CURSOR_MODEL_SONNET = "sonnet-4.5"
+
+
+# =============================================================================
+# ENVIRONMENT VARIABLES
+# =============================================================================
+
+# Critical environment variables that affect behavior
+ENV_VAR_DEFINITIONS = {
+    "EMDX_CLI_TOOL": {
+        "description": "CLI tool to use for agent execution",
+        "valid_values": ["claude", "cursor"],
+        "default": "claude",
+    },
+    "EMDX_SAFE_MODE": {
+        "description": "Enable safe mode (skip risky operations)",
+        "valid_values": ["0", "1", "true", "false", "yes", "no"],
+        "default": "0",
+    },
+    "EMDX_TEST_DB": {
+        "description": "Path to test database (for testing only)",
+        "valid_values": None,  # Any path is valid
+        "default": None,
+    },
+    "ANTHROPIC_API_KEY": {
+        "description": "API key for Anthropic Claude",
+        "valid_values": None,  # Any string
+        "default": None,
+        "sensitive": True,
+    },
+    "CURSOR_API_KEY": {
+        "description": "API key for Cursor",
+        "valid_values": None,
+        "default": None,
+        "sensitive": True,
+    },
+    "GITHUB_TOKEN": {
+        "description": "GitHub personal access token for gist operations",
+        "valid_values": None,
+        "default": None,
+        "sensitive": True,
+    },
+}

--- a/emdx/config/settings.py
+++ b/emdx/config/settings.py
@@ -2,9 +2,10 @@
 
 import os
 from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 # Re-export constants for backward compatibility
-from .constants import DEFAULT_CLAUDE_MODEL, EMDX_CONFIG_DIR
+from .constants import DEFAULT_CLAUDE_MODEL, EMDX_CONFIG_DIR, ENV_VAR_DEFINITIONS
 
 
 def get_db_path() -> Path:
@@ -19,3 +20,108 @@ def get_db_path() -> Path:
 
     EMDX_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     return EMDX_CONFIG_DIR / "knowledge.db"
+
+
+def validate_env_var(name: str, value: Optional[str]) -> Tuple[bool, Optional[str]]:
+    """Validate a single environment variable value.
+
+    Args:
+        name: The environment variable name.
+        value: The current value (or None if not set).
+
+    Returns:
+        Tuple of (is_valid, error_message).
+    """
+    if name not in ENV_VAR_DEFINITIONS:
+        return True, None  # Unknown vars are always valid
+
+    definition = ENV_VAR_DEFINITIONS[name]
+    valid_values = definition.get("valid_values")
+    default = definition.get("default")
+
+    # If not set and has no default, that's not an error (optional)
+    if value is None:
+        return True, None
+
+    # If valid_values is None, any value is valid
+    if valid_values is None:
+        return True, None
+
+    # Check against valid values
+    if value.lower() not in [v.lower() for v in valid_values]:
+        return False, f"Invalid value '{value}' for {name}. Valid values: {valid_values}"
+
+    return True, None
+
+
+def validate_all_env_vars() -> List[str]:
+    """Validate all EMDX environment variables.
+
+    Returns:
+        List of error messages (empty if all valid).
+    """
+    errors = []
+    for name in ENV_VAR_DEFINITIONS:
+        value = os.environ.get(name)
+        is_valid, error = validate_env_var(name, value)
+        if not is_valid:
+            errors.append(error)
+    return errors
+
+
+def get_env_var(name: str, validate: bool = True) -> Optional[str]:
+    """Get an environment variable with optional validation.
+
+    Args:
+        name: The environment variable name.
+        validate: Whether to validate the value against known definitions.
+
+    Returns:
+        The environment variable value, or None if not set.
+
+    Raises:
+        ValueError: If validate=True and the value is invalid.
+    """
+    value = os.environ.get(name)
+
+    if validate and value is not None:
+        is_valid, error = validate_env_var(name, value)
+        if not is_valid:
+            raise ValueError(error)
+
+    # Return value or default
+    if value is None and name in ENV_VAR_DEFINITIONS:
+        return ENV_VAR_DEFINITIONS[name].get("default")
+
+    return value
+
+
+def get_env_info() -> Dict[str, Dict]:
+    """Get information about all EMDX environment variables.
+
+    Returns:
+        Dictionary mapping env var names to their info including:
+        - description: What the variable does
+        - value: Current value (masked for sensitive vars)
+        - valid: Whether the current value is valid
+        - default: The default value if not set
+    """
+    info = {}
+    for name, definition in ENV_VAR_DEFINITIONS.items():
+        value = os.environ.get(name)
+        is_valid, _ = validate_env_var(name, value)
+
+        # Mask sensitive values
+        display_value = value
+        if value and definition.get("sensitive"):
+            display_value = value[:4] + "..." if len(value) > 4 else "***"
+
+        info[name] = {
+            "description": definition.get("description", ""),
+            "value": display_value,
+            "is_set": value is not None,
+            "valid": is_valid,
+            "default": definition.get("default"),
+            "sensitive": definition.get("sensitive", False),
+        }
+    return info

--- a/emdx/services/ask_service.py
+++ b/emdx/services/ask_service.py
@@ -20,6 +20,7 @@ except ImportError:
     anthropic = None  # type: ignore[assignment]
     HAS_ANTHROPIC = False
 
+from ..config.constants import DEFAULT_ASK_MODEL
 from ..database import db
 
 logger = logging.getLogger(__name__)
@@ -38,7 +39,7 @@ class Answer:
 class AskService:
     """Answer questions using your knowledge base."""
 
-    DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
+    DEFAULT_MODEL = DEFAULT_ASK_MODEL
     MIN_EMBEDDINGS_FOR_SEMANTIC = 50  # Use semantic only if we have enough coverage
 
     def __init__(self, model: Optional[str] = None):

--- a/emdx/services/cli_executor/claude.py
+++ b/emdx/services/cli_executor/claude.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from ...config.cli_config import CLI_CONFIGS, CliTool, resolve_model_alias
+from ...config.constants import CLI_VERSION_CHECK_TIMEOUT
 from .base import CliCommand, CliExecutor, CliResult
 
 logger = logging.getLogger(__name__)
@@ -196,7 +197,7 @@ class ClaudeCliExecutor(CliExecutor):
                 ["claude", "--version"],
                 capture_output=True,
                 text=True,
-                timeout=5,
+                timeout=CLI_VERSION_CHECK_TIMEOUT,
             )
             if result.returncode == 0:
                 info["version"] = result.stdout.strip()

--- a/emdx/services/cli_executor/cursor.py
+++ b/emdx/services/cli_executor/cursor.py
@@ -7,6 +7,7 @@ import subprocess
 from typing import Any, Dict, List, Optional
 
 from ...config.cli_config import CLI_CONFIGS, CliTool, resolve_model_alias
+from ...config.constants import CLI_AUTH_CHECK_TIMEOUT, CLI_VERSION_CHECK_TIMEOUT
 from .base import CliCommand, CliExecutor, CliResult
 
 logger = logging.getLogger(__name__)
@@ -239,7 +240,7 @@ class CursorCliExecutor(CliExecutor):
                 ["cursor", "agent", "--version"],
                 capture_output=True,
                 text=True,
-                timeout=5,
+                timeout=CLI_VERSION_CHECK_TIMEOUT,
             )
             if result.returncode == 0:
                 info["version"] = result.stdout.strip()
@@ -252,7 +253,7 @@ class CursorCliExecutor(CliExecutor):
                 ["cursor", "agent", "status"],
                 capture_output=True,
                 text=True,
-                timeout=10,
+                timeout=CLI_AUTH_CHECK_TIMEOUT,
             )
             if "Not logged in" in result.stdout:
                 info["warnings"].append(

--- a/emdx/utils/environment.py
+++ b/emdx/utils/environment.py
@@ -7,7 +7,11 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from emdx.config.constants import EMDX_CONFIG_DIR
+from emdx.config.constants import (
+    CLI_AUTH_CHECK_TIMEOUT,
+    CLI_VERSION_CHECK_TIMEOUT,
+    EMDX_CONFIG_DIR,
+)
 from emdx.utils.output import console
 
 
@@ -93,7 +97,7 @@ class EnvironmentValidator:
                             version_cmd,
                             capture_output=True,
                             text=True,
-                            timeout=5
+                            timeout=CLI_VERSION_CHECK_TIMEOUT
                         )
                         if result.returncode == 0:
                             self.info[f"{cmd}_version"] = result.stdout.strip()
@@ -185,7 +189,7 @@ class EnvironmentValidator:
                     ["claude", "--version"],
                     capture_output=True,
                     text=True,
-                    timeout=5
+                    timeout=CLI_VERSION_CHECK_TIMEOUT
                 )
                 if result.returncode != 0:
                     self.warnings.append("ANTHROPIC_API_KEY not set and claude might not work")
@@ -204,7 +208,7 @@ class EnvironmentValidator:
                 ["cursor", "agent", "status"],
                 capture_output=True,
                 text=True,
-                timeout=10
+                timeout=CLI_AUTH_CHECK_TIMEOUT
             )
             if "Not logged in" in result.stdout:
                 self.warnings.append(


### PR DESCRIPTION
## Summary

- Centralized 15+ hardcoded timeout values into `emdx/config/constants.py`
- Centralized model name strings that were duplicated across 5 files
- Added environment variable validation for critical config vars

## Changes

### New Timeout Constants
- `CASCADE_IMPLEMENTATION_TIMEOUT` (30 min) - for planned stage execution
- `CASCADE_STAGE_TIMEOUT` (5 min) - for analysis/planning stages
- `CLI_VERSION_CHECK_TIMEOUT` (5 sec) - CLI version queries
- `CLI_AUTH_CHECK_TIMEOUT` (10 sec) - authentication verification
- `DISCOVERY_COMMAND_TIMEOUT` (30 sec) - shell discovery commands
- `GITHUB_AUTH_TIMEOUT` (10 sec) - gh auth token retrieval
- `PROCESS_TERMINATE_TIMEOUT` (3 sec) - graceful termination wait
- `PROCESS_KILL_TIMEOUT` (1 sec) - force kill wait

### New Model Constants
- `CLAUDE_MODEL_OPUS`, `CLAUDE_MODEL_SONNET` - canonical Claude model names
- `CURSOR_MODEL_OPUS`, `CURSOR_MODEL_SONNET` - Cursor model equivalents
- `DEFAULT_ASK_MODEL` - default model for Q&A service (uses sonnet for speed/cost)

### Environment Variable Validation
- `ENV_VAR_DEFINITIONS` - metadata for all EMDX environment variables
- `validate_env_var()` - validate single env var value
- `validate_all_env_vars()` - validate all EMDX env vars
- `get_env_var()` - get env var with optional validation
- `get_env_info()` - get info about all EMDX env vars

## Test plan

- [x] All 797 tests pass
- [x] Imports verified in all modified files
- [x] No hardcoded duplicates remain in updated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)