### PR TITLE
fix(security): Prevent command injection in delegate --each (Issue #6230)

### DIFF
--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -2,7 +2,13 @@
 
 import sqlite3
 
-from emdx.database.migrations import get_schema_version, migration_001_add_tags
+import pytest
+
+from emdx.database.migrations import (
+    get_schema_version,
+    migration_001_add_tags,
+    _validate_column_name,
+)
 
 
 class TestSimpleMigrations:
@@ -44,3 +50,50 @@ class TestSimpleMigrations:
         assert len(MIGRATIONS) > 0
         assert all(len(m) == 3 for m in MIGRATIONS)  # version, description, function
         assert all(callable(m[2]) for m in MIGRATIONS)  # functions are callable
+
+
+class TestColumnNameValidation:
+    """Tests for _validate_column_name — prevents SQL injection in dynamic column names."""
+
+    def test_valid_simple_name(self):
+        assert _validate_column_name("name") == "name"
+
+    def test_valid_snake_case(self):
+        assert _validate_column_name("created_at") == "created_at"
+
+    def test_valid_with_numbers(self):
+        assert _validate_column_name("column_1") == "column_1"
+
+    def test_valid_starting_with_underscore(self):
+        assert _validate_column_name("_internal") == "_internal"
+
+    def test_valid_uppercase(self):
+        assert _validate_column_name("ID") == "ID"
+
+    def test_rejects_sql_injection_semicolon(self):
+        with pytest.raises(ValueError):
+            _validate_column_name("name; DROP TABLE users--")
+
+    def test_rejects_spaces(self):
+        with pytest.raises(ValueError):
+            _validate_column_name("column name")
+
+    def test_rejects_hyphens(self):
+        with pytest.raises(ValueError):
+            _validate_column_name("column-name")
+
+    def test_rejects_starting_with_number(self):
+        with pytest.raises(ValueError):
+            _validate_column_name("1column")
+
+    def test_rejects_parentheses(self):
+        with pytest.raises(ValueError):
+            _validate_column_name("name()")
+
+    def test_rejects_quotes(self):
+        with pytest.raises(ValueError):
+            _validate_column_name("name'")
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError):
+            _validate_column_name("")


### PR DESCRIPTION
## Summary

- Fix critical command injection vulnerability in `emdx delegate --each`
- Add defense-in-depth SQL column name validation in migrations

## Security Fixes

### Command Injection (CRITICAL → RESOLVED)

The `--each` flag previously passed user input directly to `subprocess.run()` with `shell=True`, allowing arbitrary command execution:

```bash
# Before: This would execute the malicious command
emdx delegate --each "; rm -rf ~" --do "ignored"
```

**Fix:**
- Added `SAFE_DISCOVERY_COMMANDS` allowlist: `fd`, `find`, `git`, `ls`, `rg`, `grep`, `eza`, `exa`
- Added `_validate_discovery_command()` with shlex parsing and metacharacter detection
- Changed to `shell=False` with argument list

### SQL Column Name Validation (MEDIUM)

Added `_validate_column_name()` function with regex validation for dynamic SQL column names in migrations. While column names come from hardcoded tuples (low risk), this adds defense-in-depth.

## Test plan

- [x] All 797 existing tests pass
- [x] 28 new security-focused tests added
- [x] Manual verification of allowlist behavior

## Breaking Change

The `--each` flag now only accepts commands from the safe allowlist. Users needing arbitrary commands should use shell pipes instead:
```bash
# Instead of: emdx delegate --each "custom_cmd" --do "..."
# Use: custom_cmd | xargs -I{} emdx delegate "{}"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)