### PR TITLE
fix(deps): remove unused dependencies and update ruff (Issue #DEBT-3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ python = "^3.11"
 typer = {extras = ["all"], version = "^0.15.0"}
 click = ">=8.1.0"  # Typer 0.15+ requires click 8.1+
 rich = "^13.0.0"
-python-dotenv = "^1.0.0"
 textual = "^4.0.0"
 psutil = "^7.0.0"
 
@@ -54,8 +53,7 @@ all = ["sentence-transformers", "scikit-learn", "numpy", "anthropic",
 pytest = "^7.0.0"
 pytest-cov = "^4.0.0"
 pytest-asyncio = "^0.21.0"
-black = "^23.0.0"
-ruff = "^0.1.0"
+ruff = "^0.15.0"
 mypy = "^1.0.0"
 pre-commit = "^3.0.0"
 
@@ -65,10 +63,6 @@ emdx = "emdx.main:run"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.black]
-line-length = 100
-target-version = ['py311']
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary
- Remove `python-dotenv` - declared in pyproject.toml but never imported anywhere in the codebase
- Update `ruff` version constraint from `^0.1.0` to `^0.15.0` (current version is 0.15.1)
- Remove `black` dependency since ruff handles formatting
- Remove `[tool.black]` config section

## Test plan
- [x] Verified `python-dotenv` has no imports via grep
- [x] Ran `poetry lock` and `poetry install` successfully
- [x] Ran `poetry run pytest tests/ -x` - **797 passed**, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)