### PR TITLE
fix(cli): Standardize CLI interfaces (Issue #DEBT-8)

### DIFF
--- a/emdx/commands/analyze.py
+++ b/emdx/commands/analyze.py
@@ -735,7 +735,7 @@ def _collect_projects_data() -> Dict[str, Any]:
 
 
 # Create typer app for this module
-app = typer.Typer()
+app = typer.Typer(help="Analyze documents and extract insights")
 app.command()(analyze)
 
 

--- a/emdx/commands/browse.py
+++ b/emdx/commands/browse.py
@@ -13,7 +13,7 @@ from emdx.utils.datetime_utils import format_datetime as _format_datetime
 from emdx.utils.text_formatting import truncate_title
 from emdx.utils.output import console
 
-app = typer.Typer()
+app = typer.Typer(help="Browse and list documents with statistics")
 
 
 @app.command()

--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -39,7 +39,7 @@ from emdx.utils.emoji_aliases import expand_alias_string
 from emdx.utils.text_formatting import truncate_title
 from emdx.utils.output import console
 
-app = typer.Typer()
+app = typer.Typer(help="Core CRUD operations for documents")
 
 
 @dataclass
@@ -318,8 +318,8 @@ def save(
                             (doc_id, gist_id_str, gist_url, public),
                         )
                         conn.commit()
-                except Exception:
-                    pass  # Non-fatal — gist was still created
+                except Exception as e:
+                    console.print(f"   [dim]Warning: Failed to record gist in database: {e}[/dim]")
 
                 console.print(f"   [green]Gist:[/green] {gist_url}")
 

--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -61,8 +61,8 @@ def _safe_update_task(task_id: Optional[int], **kwargs) -> None:
     try:
         from ..models.tasks import update_task
         update_task(task_id, **kwargs)
-    except Exception:
-        pass
+    except Exception as e:
+        sys.stderr.write(f"delegate: failed to update task {task_id}: {e}\n")
 
 
 def _safe_update_execution(exec_id: Optional[int], **kwargs) -> None:
@@ -72,8 +72,8 @@ def _safe_update_execution(exec_id: Optional[int], **kwargs) -> None:
     try:
         from ..models.executions import update_execution
         update_execution(exec_id, **kwargs)
-    except Exception:
-        pass
+    except Exception as e:
+        sys.stderr.write(f"delegate: failed to update execution {exec_id}: {e}\n")
 
 
 PR_INSTRUCTION = (

--- a/emdx/commands/executions.py
+++ b/emdx/commands/executions.py
@@ -24,7 +24,7 @@ from ..models.executions import (
 from ..utils.text_formatting import truncate_description
 from ..utils.output import console
 
-app = typer.Typer()
+app = typer.Typer(help="Manage and monitor task executions")
 
 
 def tail_log_subprocess(log_path: Path, follow: bool = False, lines: int = 50) -> None:

--- a/emdx/commands/gist.py
+++ b/emdx/commands/gist.py
@@ -16,7 +16,7 @@ from emdx.database import db
 from emdx.models.documents import get_document
 from emdx.utils.output import console
 
-app = typer.Typer()
+app = typer.Typer(help="GitHub Gist integration")
 
 
 def get_github_auth() -> Optional[str]:

--- a/emdx/commands/maintain.py
+++ b/emdx/commands/maintain.py
@@ -1055,7 +1055,7 @@ def cleanup_temp_dirs(
 
 
 # Create typer app for this module
-app = typer.Typer()
+app = typer.Typer(help="Database maintenance and cleanup operations")
 
 
 @app.callback(invoke_without_command=True)

--- a/emdx/commands/prime.py
+++ b/emdx/commands/prime.py
@@ -339,5 +339,5 @@ def _get_cascade_status() -> dict:
 
 
 # Create typer app for the command
-app = typer.Typer()
+app = typer.Typer(help="Output priming context for Claude session injection")
 app.command()(prime)

--- a/emdx/commands/status.py
+++ b/emdx/commands/status.py
@@ -258,5 +258,5 @@ def status(
 
 
 # Create typer app for the command
-app = typer.Typer()
+app = typer.Typer(help="Show delegate activity and project status")
 app.command()(status)

--- a/emdx/commands/trash.py
+++ b/emdx/commands/trash.py
@@ -21,7 +21,7 @@ from emdx.models.documents import (
 )
 from emdx.utils.output import console
 
-app = typer.Typer()
+app = typer.Typer(help="Manage deleted documents (trash)")
 
 
 @app.callback(invoke_without_command=True)


### PR DESCRIPTION
## Summary
- Add help text to 9 Typer app instances that were missing documentation
- Fix 3 silent failures (`except Exception: pass`) to log errors instead of silently swallowing them

## Changes

### Help Text Added to Typer Apps

| File | Help Text |
|------|-----------|
| `core.py` | "Core CRUD operations for documents" |
| `trash.py` | "Manage deleted documents (trash)" |
| `browse.py` | "Browse and list documents with statistics" |
| `gist.py` | "GitHub Gist integration" |
| `executions.py` | "Manage and monitor task executions" |
| `status.py` | "Show delegate activity and project status" |
| `prime.py` | "Output priming context for Claude session injection" |
| `analyze.py` | "Analyze documents and extract insights" |
| `maintain.py` | "Database maintenance and cleanup operations" |

### Silent Failures Fixed

| File | Location | Fix |
|------|----------|-----|
| `delegate.py` | `_safe_update_task` | Now logs to stderr: `delegate: failed to update task {id}: {error}` |
| `delegate.py` | `_safe_update_execution` | Now logs to stderr: `delegate: failed to update execution {id}: {error}` |
| `core.py` | gist recording | Now shows user warning: `Warning: Failed to record gist in database: {error}` |

### doc_id Parameter Analysis

The mixed `int`/`str` types are intentional by design:
- Commands accepting both ID and title (view, edit, delete, gist): use `str` type with `identifier` naming
- Commands accepting only ID (tags, cascade, tasks, groups): use `int` type with `doc_id` naming

No changes needed - the current design supports flexible lookup by either ID or title.

## Test plan
- [x] All 797 tests pass
- [x] Verify `emdx --help` shows new help text for subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)