### PR TITLE
fix: Prevent inflated access_count from internal get_document() calls (Issue #6101)

### DIFF
--- a/emdx/commands/cascade.py
+++ b/emdx/commands/cascade.py
@@ -318,7 +318,7 @@ def _run_auto(doc_id: int, start_stage: str, stop_stage: str):
     pr_url = None
 
     for stage in stages_to_process:
-        doc = get_document(str(current_doc_id))
+        doc = get_document(str(current_doc_id), track_access=False)
         if not doc:
             console.print(f"[red]Document #{current_doc_id} not found[/red]")
             _update_cascade_run(cascade_run_id, status='failed', error_message=f"Document {current_doc_id} not found")
@@ -448,7 +448,7 @@ def process(
 
     # Get document to process
     if doc_id:
-        doc = get_document(str(doc_id))
+        doc = get_document(str(doc_id), track_access=False)
         if not doc:
             console.print(f"[red]Document #{doc_id} not found[/red]")
             raise typer.Exit(1)
@@ -580,7 +580,7 @@ def advance(
         emdx cascade advance 123
         emdx cascade advance 123 --to done
     """
-    doc = get_document(str(doc_id))
+    doc = get_document(str(doc_id), track_access=False)
     if not doc:
         console.print(f"[red]Document #{doc_id} not found[/red]")
         raise typer.Exit(1)
@@ -614,7 +614,7 @@ def remove(
     Sets the stage to NULL, removing it from cascade processing
     but keeping the document in the knowledge base.
     """
-    doc = get_document(str(doc_id))
+    doc = get_document(str(doc_id), track_access=False)
     if not doc:
         console.print(f"[red]Document #{doc_id} not found[/red]")
         raise typer.Exit(1)
@@ -667,7 +667,7 @@ def synthesize(
     # Build combined content
     combined_content = f"# Synthesized from {len(docs)} documents\n\n"
     for doc in docs:
-        full_doc = get_document(str(doc["id"]))
+        full_doc = get_document(str(doc["id"]), track_access=False)
         combined_content += f"## From: {full_doc['title']}\n\n"
         combined_content += full_doc["content"]
         combined_content += "\n\n---\n\n"

--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -777,7 +777,7 @@ def delete(
         not_found = []
 
         for identifier in identifiers:
-            doc = get_document(identifier)
+            doc = get_document(identifier, track_access=False)
             if doc:
                 docs_to_delete.append(doc)
             else:

--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -114,7 +114,7 @@ def _resolve_task(task: str, pr: bool = False) -> str:
     except ValueError:
         return task
 
-    doc = get_document(doc_id)
+    doc = get_document(doc_id, track_access=False)
     if not doc:
         sys.stderr.write(f"delegate: document #{doc_id} not found, treating as text\n")
         return task
@@ -171,7 +171,7 @@ def _load_doc_context(doc_id: int, prompt: Optional[str]) -> str:
     If prompt provided: "Document #id (title):\n\n{content}\n\n---\n\nTask: {prompt}"
     If no prompt: "Execute the following document:\n\n# {title}\n\n{content}"
     """
-    doc = get_document(doc_id)
+    doc = get_document(doc_id, track_access=False)
     if not doc:
         sys.stderr.write(f"delegate: document #{doc_id} not found\n")
         raise typer.Exit(1)
@@ -187,7 +187,7 @@ def _load_doc_context(doc_id: int, prompt: Optional[str]) -> str:
 
 def _print_doc_content(doc_id: int) -> None:
     """Print a document's content to stdout."""
-    doc = get_document(doc_id)
+    doc = get_document(doc_id, track_access=False)
     if doc:
         sys.stdout.write(doc.get("content", ""))
         sys.stdout.write("\n")
@@ -363,7 +363,7 @@ def _run_parallel(
         # Run a synthesis task that combines all outputs
         combined = []
         for i, doc_id in enumerate(doc_ids):
-            doc = get_document(doc_id)
+            doc = get_document(doc_id, track_access=False)
             if doc:
                 combined.append(f"## Task {i + 1}: {tasks[i][:80]}\n\n{doc.get('content', '')}")
 
@@ -501,7 +501,7 @@ def _run_chain(
         doc_ids.append(doc_id)
 
         # Read output for next step
-        doc = get_document(doc_id)
+        doc = get_document(doc_id, track_access=False)
         if doc:
             previous_output = doc.get("content", "")
 

--- a/emdx/commands/gist.py
+++ b/emdx/commands/gist.py
@@ -194,7 +194,7 @@ def create(
         raise typer.Exit(1)
 
     # Get the document
-    doc = get_document(identifier)
+    doc = get_document(identifier, track_access=False)
     if not doc:
         console.print(f"[red]Error: Document '{identifier}' not found[/red]")
         raise typer.Exit(1)

--- a/emdx/commands/groups.py
+++ b/emdx/commands/groups.py
@@ -94,7 +94,7 @@ def add(
 
         for doc_id in doc_ids:
             # Verify document exists
-            doc = get_document(str(doc_id))
+            doc = get_document(str(doc_id), track_access=False)
             if not doc:
                 not_found.append(doc_id)
                 continue
@@ -112,7 +112,7 @@ def add(
                 f"#{group_id} ({group['name']}):[/green]"
             )
             for doc_id in added:
-                doc = get_document(str(doc_id))
+                doc = get_document(str(doc_id), track_access=False)
                 console.print(f"   [dim]#{doc_id}: {doc['title'][:40]} ({role})[/dim]")
 
         if already_in:

--- a/emdx/commands/recipe.py
+++ b/emdx/commands/recipe.py
@@ -28,7 +28,7 @@ def _find_recipe(id_or_name: str) -> Optional[dict]:
     # Try as numeric ID first
     try:
         doc_id = int(id_or_name)
-        doc = get_document(doc_id)
+        doc = get_document(doc_id, track_access=False)
         if doc:
             return doc
     except ValueError:

--- a/emdx/commands/tags.py
+++ b/emdx/commands/tags.py
@@ -43,7 +43,7 @@ def _add_tags_impl(
         db.ensure_schema()
 
         # Check if document exists
-        doc = get_document(str(doc_id))
+        doc = get_document(str(doc_id), track_access=False)
         if not doc:
             console.print(f"[red]Error: Document #{doc_id} not found[/red]")
             raise typer.Exit(1)
@@ -154,7 +154,7 @@ def remove(
         db.ensure_schema()
 
         # Check if document exists
-        doc = get_document(str(doc_id))
+        doc = get_document(str(doc_id), track_access=False)
         if not doc:
             console.print(f"[red]Error: Document #{doc_id} not found[/red]")
             raise typer.Exit(1)
@@ -377,7 +377,7 @@ def batch(
 
             for doc_id, tag_list in eligible_docs[:sample_size]:
                 # Get document title
-                doc = get_document(str(doc_id))
+                doc = get_document(str(doc_id), track_access=False)
                 title = truncate_title(doc['title'])
 
                 console.print(f"  [dim]#{doc_id}[/dim] {title}")

--- a/emdx/database/__init__.py
+++ b/emdx/database/__init__.py
@@ -114,30 +114,32 @@ class SQLiteDatabase:
 
             return doc_id
 
-    def get_document(self, identifier):
+    def get_document(self, identifier, track_access=True):
         """Get a document by ID or title."""
         if not self._uses_custom_path:
-            return get_document(identifier)
+            return get_document(identifier, track_access=track_access)
 
         # Isolated mode
         with self._connection.get_connection() as conn:
             identifier_str = str(identifier)
             if identifier_str.isdigit():
-                conn.execute(
-                    "UPDATE documents SET accessed_at = CURRENT_TIMESTAMP, "
-                    "access_count = access_count + 1 WHERE id = ? AND is_deleted = FALSE",
-                    (int(identifier_str),),
-                )
+                if track_access:
+                    conn.execute(
+                        "UPDATE documents SET accessed_at = CURRENT_TIMESTAMP, "
+                        "access_count = access_count + 1 WHERE id = ? AND is_deleted = FALSE",
+                        (int(identifier_str),),
+                    )
                 cursor = conn.execute(
                     "SELECT * FROM documents WHERE id = ? AND is_deleted = FALSE",
                     (int(identifier_str),),
                 )
             else:
-                conn.execute(
-                    "UPDATE documents SET accessed_at = CURRENT_TIMESTAMP, "
-                    "access_count = access_count + 1 WHERE LOWER(title) = LOWER(?) AND is_deleted = FALSE",
-                    (identifier_str,),
-                )
+                if track_access:
+                    conn.execute(
+                        "UPDATE documents SET accessed_at = CURRENT_TIMESTAMP, "
+                        "access_count = access_count + 1 WHERE LOWER(title) = LOWER(?) AND is_deleted = FALSE",
+                        (identifier_str,),
+                    )
                 cursor = conn.execute(
                     "SELECT * FROM documents WHERE LOWER(title) = LOWER(?) AND is_deleted = FALSE",
                     (identifier_str,),

--- a/emdx/services/document_merger.py
+++ b/emdx/services/document_merger.py
@@ -253,8 +253,8 @@ class DocumentMerger:
             MergeStrategy with recommended approach
         """
         # Get both documents
-        doc1 = get_document(str(doc1_id))
-        doc2 = get_document(str(doc2_id))
+        doc1 = get_document(str(doc1_id), track_access=False)
+        doc2 = get_document(str(doc2_id), track_access=False)
         
         if not doc1 or not doc2:
             raise ValueError("One or both documents not found")
@@ -460,7 +460,7 @@ class DocumentMerger:
         Returns:
             List of tuples (doc_id, title, similarity_score)
         """
-        doc = get_document(str(doc_id))
+        doc = get_document(str(doc_id), track_access=False)
         if not doc:
             return []
 

--- a/emdx/ui/activity/activity_items.py
+++ b/emdx/ui/activity/activity_items.py
@@ -125,7 +125,7 @@ class DocumentItem(ActivityItem):
         if not doc_db:
             return "", "PREVIEW"
 
-        doc = doc_db.get_document(self.doc_id)
+        doc = doc_db.get_document(self.doc_id, track_access=False)
         if doc:
             content = doc.get("content", "")
             title = doc.get("title", "Untitled")
@@ -292,7 +292,7 @@ class CascadeStageItem(ActivityItem):
     async def get_preview_content(self, doc_db) -> tuple[str, str]:
         """Get stage execution output."""
         if self.doc_id and doc_db:
-            doc = doc_db.get_document(self.doc_id)
+            doc = doc_db.get_document(self.doc_id, track_access=False)
             if doc:
                 return doc.get("content", ""), f"{self.type_icon} #{self.doc_id}"
 
@@ -476,7 +476,7 @@ class AgentExecutionItem(ActivityItem):
 
         # If we have an output doc, show it
         if self.doc_id and doc_db:
-            doc = doc_db.get_document(self.doc_id)
+            doc = doc_db.get_document(self.doc_id, track_access=False)
             if doc:
                 return doc.get("content", ""), f"{self.type_icon} #{self.doc_id}"
 

--- a/emdx/ui/activity/activity_view.py
+++ b/emdx/ui/activity/activity_view.py
@@ -478,7 +478,7 @@ class ActivityView(HelpMixin, Widget):
         # For documents, show content
         if item.doc_id and HAS_DOCS:
             try:
-                doc = doc_db.get_document(item.doc_id)
+                doc = doc_db.get_document(item.doc_id, track_access=False)
                 if doc:
                     content = doc.get("content", "")
                     title = doc.get("title", "Untitled")
@@ -562,7 +562,7 @@ class ActivityView(HelpMixin, Widget):
             return
 
         try:
-            doc = doc_db.get_document(item.doc_id)
+            doc = doc_db.get_document(item.doc_id, track_access=False)
             if not doc:
                 header.update(f"📄 #{item.doc_id}")
                 return
@@ -970,7 +970,7 @@ class ActivityView(HelpMixin, Widget):
             return
 
         try:
-            doc = doc_db.get_document(item.doc_id)
+            doc = doc_db.get_document(item.doc_id, track_access=False)
             if not doc:
                 self._show_notification("Document not found", is_error=True)
                 return
@@ -1029,7 +1029,7 @@ class ActivityView(HelpMixin, Widget):
             return
 
         try:
-            doc = doc_db.get_document(item.doc_id) if HAS_DOCS else None
+            doc = doc_db.get_document(item.doc_id, track_access=False) if HAS_DOCS else None
             doc_title = doc.get("title", "Untitled") if doc else "Untitled"
 
             group_name = f"{doc_title[:30]} Group"
@@ -1161,7 +1161,7 @@ class ActivityView(HelpMixin, Widget):
 
         # Fallback - just show doc in preview
         if HAS_DOCS and doc_db:
-            doc = doc_db.get_document(doc_id)
+            doc = doc_db.get_document(doc_id, track_access=False)
             if doc:
                 content = doc.get("content", "")
                 title = doc.get("title", "Untitled")

--- a/emdx/ui/cascade/cascade_browser.py
+++ b/emdx/ui/cascade/cascade_browser.py
@@ -67,7 +67,7 @@ class CascadeBrowser(Widget):
         stage, doc_id = event.stage, event.doc_id
 
         if doc_id:
-            doc = get_document(str(doc_id))
+            doc = get_document(str(doc_id), track_access=False)
             if not doc:
                 self._update_status(f"[red]Document #{doc_id} not found[/red]")
                 return

--- a/emdx/ui/cascade/cascade_view.py
+++ b/emdx/ui/cascade/cascade_view.py
@@ -231,7 +231,7 @@ class CascadeView(Widget):
         log_widget.display = False
         content.clear()
 
-        doc = get_document(doc_id)
+        doc = get_document(doc_id, track_access=False)
         if not doc:
             header.update("[bold]Preview[/bold]")
             content.write("[dim]Document not found[/dim]")
@@ -518,7 +518,7 @@ class CascadeView(Widget):
 
         parts = []
         for did in selected_ids:
-            doc = get_document(str(did))
+            doc = get_document(str(did), track_access=False)
             if doc:
                 parts.append(f"=== Document #{did}: {doc['title']} ===\n{doc['content']}")
 

--- a/emdx/ui/modals.py
+++ b/emdx/ui/modals.py
@@ -351,7 +351,7 @@ class DocumentPreviewModal(ModalScreen):
         try:
             from emdx.services.document_service import get_document
 
-            self._doc_data = get_document(self.doc_id)
+            self._doc_data = get_document(self.doc_id, track_access=False)
             if not self._doc_data:
                 self.query_one("#preview-title", Static).update(f"Document #{self.doc_id} not found")
                 return

--- a/emdx/ui/presenters/document_browser_presenter.py
+++ b/emdx/ui/presenters/document_browser_presenter.py
@@ -399,7 +399,7 @@ class DocumentBrowserPresenter:
             if doc_id in self._doc_cache:
                 doc = self._doc_cache[doc_id]
             else:
-                doc = get_document(doc_id)
+                doc = get_document(doc_id, track_access=False)
                 if doc is None:
                     return None
 

--- a/tests/test_commands_core.py
+++ b/tests/test_commands_core.py
@@ -505,7 +505,7 @@ class TestDeleteCommand:
         """Delete multiple documents at once."""
         mock_db.ensure_schema = Mock()
 
-        def side_effect(identifier):
+        def side_effect(identifier, track_access=True):
             docs = {
                 "1": {"id": 1, "title": "Doc 1", "project": None, "created_at": datetime(2024, 1, 1), "access_count": 0},
                 "2": {"id": 2, "title": "Doc 2", "project": None, "created_at": datetime(2024, 1, 2), "access_count": 0},

--- a/tests/test_commands_delegate.py
+++ b/tests/test_commands_delegate.py
@@ -57,7 +57,7 @@ class TestResolveTask:
         result = _resolve_task("42")
         assert "Hello world" in result
         assert "Test Doc" in result
-        mock_get.assert_called_once_with(42)
+        mock_get.assert_called_once_with(42, track_access=False)
 
     @patch("emdx.commands.delegate.get_document")
     def test_numeric_id_with_pr_adds_instructions(self, mock_get):

--- a/tests/test_commands_recipe.py
+++ b/tests/test_commands_recipe.py
@@ -24,7 +24,7 @@ class TestFindRecipe:
         result = _find_recipe("42")
         assert result is not None
         assert result["id"] == 42
-        mock_get.assert_called_once_with(42)
+        mock_get.assert_called_once_with(42, track_access=False)
 
     @patch("emdx.commands.recipe.get_document")
     def test_numeric_id_not_found_searches_tags(self, mock_get):


### PR DESCRIPTION
## Summary

- Add `track_access: bool = True` parameter to `get_document()` in both the core function and the `SQLiteDatabase` wrapper
- Pass `track_access=False` at ~35 internal call sites (delegate, cascade, tags, TUI, services, etc.)
- Only `emdx view` and `emdx edit` keep `track_access=True` — the only genuine user-facing reads

## Problem

`access_count` was artificially inflated because `get_document()` incremented it on every call — including internal/programmatic fetches from delegate pipelines, cascade stages, merge analysis, tag operations, and TUI preview panels. A doc scrolled past in the TUI or processed by a delegate chain would accumulate hundreds of phantom "views." The gems report showed docs like "Parallel Analysis (Reusable)" with 2,541 "views" that were entirely programmatic.

## Test plan

- [x] All 780 tests pass (`poetry run python -m pytest tests/ -x -q`)
- [ ] `emdx view <id>` — verify access_count still increments
- [ ] Run a delegate task — output doc should not have inflated access_count from internal reads during synthesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)