### PR TITLE
chore: add dependabot and renovate configuration (Issue #DEBT-16)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+# Dependabot configuration for automated dependency updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Python/Poetry dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Group minor/patch updates together to reduce PR noise
+      python-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Keep major updates separate for careful review
+      python-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Group all action updates together
+      actions:
+        patterns:
+          - "*"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate configuration for emdx - alternative to Dependabot with more features",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    "group:allNonMajor"
+  ],
+  "timezone": "America/Los_Angeles",
+  "schedule": ["before 10am on monday"],
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 5,
+  "packageRules": [
+    {
+      "description": "Python dependencies",
+      "matchManagers": ["poetry", "pip_requirements"],
+      "labels": ["dependencies", "python"],
+      "groupName": "python dependencies (non-major)",
+      "groupSlug": "python-minor",
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Python major updates - separate PRs",
+      "matchManagers": ["poetry", "pip_requirements"],
+      "labels": ["dependencies", "python"],
+      "matchUpdateTypes": ["major"],
+      "groupName": null
+    },
+    {
+      "description": "GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "labels": ["dependencies", "github-actions"],
+      "groupName": "github actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "Auto-merge patch updates for well-tested packages",
+      "matchPackageNames": [
+        "pytest",
+        "pytest-cov",
+        "black",
+        "ruff",
+        "mypy"
+      ],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "description": "Dev dependencies - lower priority",
+      "matchDepTypes": ["devDependencies", "dev"],
+      "prPriority": -1
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security", "dependencies"],
+    "enabled": true
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 10am on the first day of the month"]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for automated dependency updates via GitHub's native Dependabot
- Add `.github/renovate.json` as an alternative with more advanced features

## Dependabot Configuration
- **pip ecosystem**: Weekly checks (Mondays 9am PT)
  - Groups minor/patch updates together
  - Keeps major updates in separate PRs
  - Labels: `dependencies`, `python`
- **GitHub Actions**: Weekly checks (Mondays 9am PT)
  - Groups all action updates
  - Labels: `dependencies`, `github-actions`
- Semantic commit prefixes: `chore(deps)`

## Renovate Configuration (Alternative)
Provides additional features if the Renovate GitHub App is installed:
- Auto-merge for patch updates of well-tested dev tools (pytest, black, ruff, mypy)
- Monthly lock file maintenance
- Security vulnerability alerts with `security` label
- More flexible dependency grouping

## Why Both?
- **Dependabot**: Built into GitHub, zero setup required, reliable
- **Renovate**: More flexible configuration, auto-merge, lock file maintenance (requires GitHub App installation)

Teams can choose which to enable based on their needs. Dependabot works out of the box.

## Test plan
- [ ] Verify dependabot.yml syntax is valid (GitHub will validate on merge)
- [ ] Verify renovate.json syntax is valid via JSON schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)