### PR TITLE
fix(logging): Replace silent exception handlers with proper logging (Issue #DEBT-5)

### DIFF
--- a/emdx/__init__.py
+++ b/emdx/__init__.py
@@ -3,6 +3,7 @@ emdx - Documentation Index Management System
 """
 
 import hashlib
+import sys
 import time
 from pathlib import Path
 
@@ -15,13 +16,14 @@ def _generate_build_id():
         # Get current file modification time
         current_file = Path(__file__)
         mtime = current_file.stat().st_mtime
-        
+
         # Create hash from timestamp and version
         build_data = f"{__version__}-{mtime}-{time.time()}"
         build_hash = hashlib.md5(build_data.encode()).hexdigest()[:8]
         return f"{__version__}-{build_hash}"
-    except Exception:
-        # Fallback to timestamp if file ops fail
+    except Exception as e:
+        # Fallback to timestamp if file ops fail (logging not yet configured)
+        print(f"emdx: build ID generation fallback: {e}", file=sys.stderr)
         return f"{__version__}-{int(time.time())}"
 
 __build_id__ = _generate_build_id()

--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -29,6 +29,7 @@ Dynamic discovery:
     emdx delegate --each "fd -e py src/" --do "Review {{item}}"
 """
 
+import logging
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -36,6 +37,8 @@ from pathlib import Path
 from typing import List, Optional
 
 import typer
+
+logger = logging.getLogger(__name__)
 
 from ..database.documents import get_document
 from ..services.unified_executor import ExecutionConfig, UnifiedExecutor
@@ -61,8 +64,8 @@ def _safe_update_task(task_id: Optional[int], **kwargs) -> None:
     try:
         from ..models.tasks import update_task
         update_task(task_id, **kwargs)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Failed to update task %s: %s", task_id, e)
 
 
 def _safe_update_execution(exec_id: Optional[int], **kwargs) -> None:
@@ -72,8 +75,8 @@ def _safe_update_execution(exec_id: Optional[int], **kwargs) -> None:
     try:
         from ..models.executions import update_execution
         update_execution(exec_id, **kwargs)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Failed to update execution %s: %s", exec_id, e)
 
 
 PR_INSTRUCTION = (

--- a/emdx/commands/prime.py
+++ b/emdx/commands/prime.py
@@ -5,9 +5,12 @@ This is the key command for making Claude use emdx natively.
 It outputs priming context that should be injected at session start.
 """
 
+import logging
 import typer
 from datetime import datetime
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 from rich.console import Console
 from rich.panel import Panel
@@ -331,9 +334,9 @@ def _get_cascade_status() -> dict:
             for stage, count in cursor.fetchall():
                 if stage in status:
                     status[stage] = count
-    except Exception:
+    except Exception as e:
         # cascade_stage column may not exist in older databases
-        pass
+        logger.debug("Failed to get cascade status (column may not exist): %s", e)
 
     return status
 

--- a/emdx/commands/status.py
+++ b/emdx/commands/status.py
@@ -8,9 +8,12 @@ Provides a quick overview of:
 - Cascade queue
 """
 
+import logging
 import typer
 from datetime import datetime, timedelta
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 from rich.console import Console
 from rich.text import Text
@@ -34,7 +37,8 @@ def _parse_timestamp(value) -> Optional[datetime]:
         return value
     try:
         return datetime.fromisoformat(str(value).replace('Z', '+00:00')).replace(tzinfo=None)
-    except Exception:
+    except Exception as e:
+        logger.debug("Failed to parse timestamp '%s': %s", value, e)
         return None
 
 
@@ -213,9 +217,9 @@ def _show_cascade_status():
             console.print("  " + " → ".join(parts))
             console.print("  [dim]Run [cyan]emdx cascade process <stage>[/cyan] to advance[/dim]")
             console.print()
-    except Exception:
+    except Exception as e:
         # cascade_stage column may not exist in older databases
-        pass
+        logger.debug("Failed to show cascade queue (column may not exist): %s", e)
 
 
 def status(

--- a/emdx/config/ui_config.py
+++ b/emdx/config/ui_config.py
@@ -6,8 +6,11 @@ Config is stored in ~/.config/emdx/ui_config.json
 """
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from .constants import EMDX_CONFIG_DIR
 
@@ -58,9 +61,9 @@ def save_ui_config(config: dict[str, Any]) -> None:
     path = get_ui_config_path()
     try:
         path.write_text(json.dumps(config, indent=2) + "\n")
-    except OSError:
-        # Silently fail - config is non-critical
-        pass
+    except OSError as e:
+        # Config is non-critical but log for debugging
+        logger.debug("Failed to save UI config to %s: %s", path, e)
 
 
 def get_theme() -> str:

--- a/emdx/ui/command_palette/palette_presenter.py
+++ b/emdx/ui/command_palette/palette_presenter.py
@@ -262,7 +262,8 @@ class PalettePresenter:
                 ]
             return []
         except ValueError:
-            pass
+            # Query is not a numeric ID - continue with semantic search
+            logger.debug("Query '%s' is not a document ID, trying semantic search", query)
 
         # Check for similar: prefix
         if query.startswith("similar:"):

--- a/emdx/ui/command_palette/palette_screen.py
+++ b/emdx/ui/command_palette/palette_screen.py
@@ -34,8 +34,8 @@ def _debug_log(msg: str) -> None:
         DEBUG_LOG.parent.mkdir(parents=True, exist_ok=True)
         with open(DEBUG_LOG, "a") as f:
             f.write(f"{msg}\n")
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Failed to write to debug log: %s", e)
 
 
 class PaletteResultWidget(ListItem):

--- a/emdx/ui/text_areas.py
+++ b/emdx/ui/text_areas.py
@@ -166,8 +166,8 @@ class VimEditTextArea(TextArea):
             logger.error(f"Error in VimEditTextArea.on_key: {e}", exc_info=True)
             try:
                 self.app_instance._update_vim_status(f"Error: {str(e)[:50]}")
-            except Exception:
-                pass
+            except Exception as status_err:
+                logger.debug("Failed to update vim status after error: %s", status_err)
     
     def _handle_normal_mode(self, event: events.Key) -> None:
         """Handle keys in NORMAL mode."""

--- a/emdx/utils/logging_utils.py
+++ b/emdx/utils/logging_utils.py
@@ -20,6 +20,7 @@ with auto-configuration (e.g., for modules that may run standalone).
 """
 
 import logging
+import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -107,6 +108,7 @@ def setup_tui_logging(module_name: str) -> tuple[logging.Logger, logging.Logger]
 
         return main_logger, key_logger
 
-    except Exception:
-        # Fallback if logging setup fails
+    except Exception as e:
+        # Fallback if logging setup fails - use stderr since logging is broken
+        print(f"emdx: TUI logging setup failed: {e}", file=sys.stderr)
         return logging.getLogger(module_name), logging.getLogger("key_events")


### PR DESCRIPTION
## Summary
- Fixed all instances of `except Exception: pass` patterns across the emdx/ directory
- Added proper logging with context about what failed
- Preserved intentional "never fail" semantics while adding visibility for debugging

## Files Changed (9 files)

### Commands (database operations, command execution)
- **emdx/commands/delegate.py**: Added logging for failed task/execution updates
- **emdx/commands/status.py**: Added logging for timestamp parsing and cascade queue errors
- **emdx/commands/prime.py**: Added logging for cascade status column errors

### Config (file I/O)
- **emdx/config/ui_config.py**: Added logging for failed config file writes

### Core
- **emdx/__init__.py**: Print to stderr on build ID fallback (logging not yet configured)
- **emdx/utils/logging_utils.py**: Print to stderr when logging setup fails

### UI Components
- **emdx/ui/command_palette/palette_screen.py**: Log debug file write failures
- **emdx/ui/command_palette/palette_presenter.py**: Log non-numeric document ID queries
- **emdx/ui/text_areas.py**: Log vim status update failures after errors

## Approach
- Used `logger.debug()` for expected/non-critical failures (flow control, optional features)
- Used `print(..., file=sys.stderr)` where logging isn't available (module init, logging setup)
- All log messages include context: what failed, relevant IDs/values, and the error

## Test plan
- [x] All 797 tests pass (7 skipped)
- [ ] Manual verification: Check debug logs after triggering error conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)