### PR TITLE
refactor(config): Centralize configuration constants (Issue #DEBT-7)

### DIFF
--- a/emdx/commands/cascade.py
+++ b/emdx/commands/cascade.py
@@ -22,7 +22,11 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from ..config.constants import EMDX_LOG_DIR
+from ..config.constants import (
+    EMDX_LOG_DIR,
+    CASCADE_TIMEOUT_SECONDS,
+    CASCADE_IMPLEMENTATION_TIMEOUT_SECONDS,
+)
 from ..database.documents import get_document, save_document
 from ..database import cascade as cascade_db
 from ..services.claude_executor import execute_claude_detached, execute_claude_sync
@@ -171,7 +175,7 @@ def _process_stage(doc: dict, stage: str, cascade_run_id: int = None) -> tuple[b
         execution_id = cursor.lastrowid
 
     # Implementation stage needs longer timeout
-    timeout = 1800 if stage == "planned" else 300
+    timeout = CASCADE_IMPLEMENTATION_TIMEOUT_SECONDS if stage == "planned" else CASCADE_TIMEOUT_SECONDS
 
     try:
         result = execute_claude_sync(

--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -37,6 +37,7 @@ from typing import List, Optional
 
 import typer
 
+from ..config.constants import DELEGATE_TIMEOUT_SECONDS, DISCOVERY_TIMEOUT_SECONDS
 from ..database.documents import get_document
 from ..services.unified_executor import ExecutionConfig, UnifiedExecutor
 
@@ -146,7 +147,7 @@ def _run_discovery(command: str) -> List[str]:
             shell=True,
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=DISCOVERY_TIMEOUT_SECONDS,
         )
         if result.returncode != 0:
             sys.stderr.write(f"delegate: discovery failed: {result.stderr.strip()}\n")
@@ -161,7 +162,7 @@ def _run_discovery(command: str) -> List[str]:
         return lines
 
     except subprocess.TimeoutExpired:
-        sys.stderr.write("delegate: discovery command timed out after 30s\n")
+        sys.stderr.write(f"delegate: discovery command timed out after {DISCOVERY_TIMEOUT_SECONDS}s\n")
         raise typer.Exit(1)
 
 
@@ -240,7 +241,7 @@ def _run_single(
         title=doc_title,
         output_instruction=output_instruction,
         working_dir=working_dir or str(Path.cwd()),
-        timeout_seconds=600,
+        timeout_seconds=DELEGATE_TIMEOUT_SECONDS,
         model=model,
     )
 

--- a/emdx/commands/gist.py
+++ b/emdx/commands/gist.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 import typer
 
+from emdx.config.constants import AUTH_CHECK_TIMEOUT_SECONDS
 from emdx.database import db
 from emdx.models.documents import get_document
 from emdx.utils.output import console
@@ -39,7 +40,7 @@ def get_github_auth() -> Optional[str]:
             capture_output=True,
             text=True,
             check=True,
-            timeout=10  # Prevent hanging
+            timeout=AUTH_CHECK_TIMEOUT_SECONDS  # Prevent hanging
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()

--- a/emdx/config/__init__.py
+++ b/emdx/config/__init__.py
@@ -16,6 +16,14 @@ from .constants import (
     EXECUTION_TIMEOUT_SECONDS,
     STALE_EXECUTION_TIMEOUT_SECONDS,
     DEFAULT_REFRESH_INTERVAL_SECONDS,
+    DEFAULT_TIMEOUT_SECONDS,
+    DELEGATE_TIMEOUT_SECONDS,
+    IMPLEMENTATION_TIMEOUT_SECONDS,
+    CASCADE_TIMEOUT_SECONDS,
+    CASCADE_IMPLEMENTATION_TIMEOUT_SECONDS,
+    DISCOVERY_TIMEOUT_SECONDS,
+    VERSION_CHECK_TIMEOUT_SECONDS,
+    AUTH_CHECK_TIMEOUT_SECONDS,
     # Concurrency
     DEFAULT_MAX_CONCURRENT_STAGES,
     DEFAULT_MAX_AGENT_ITERATIONS,
@@ -34,8 +42,23 @@ from .constants import (
     EXECUTION_HISTORY_DAYS,
     # Task defaults
     DEFAULT_TASK_PRIORITY,
-    # Claude model
+    # Claude models
     DEFAULT_CLAUDE_MODEL,
+    CLAUDE_OPUS_MODEL,
+    CLAUDE_SONNET_MODEL,
+    DEFAULT_CLAUDE_FAST_MODEL,
+    # Environment variables
+    ENV_ANTHROPIC_API_KEY,
+    ENV_EMDX_DATABASE_URL,
+    ENV_EMDX_TEST_DB,
+    ENV_EMDX_CLI_TOOL,
+    ENV_CURSOR_API_KEY,
+    # Environment validation
+    EnvValidationError,
+    validate_api_key,
+    validate_database_url,
+    get_required_env_vars,
+    get_optional_env_vars,
 )
 
 __all__ = [
@@ -52,6 +75,14 @@ __all__ = [
     "EXECUTION_TIMEOUT_SECONDS",
     "STALE_EXECUTION_TIMEOUT_SECONDS",
     "DEFAULT_REFRESH_INTERVAL_SECONDS",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "DELEGATE_TIMEOUT_SECONDS",
+    "IMPLEMENTATION_TIMEOUT_SECONDS",
+    "CASCADE_TIMEOUT_SECONDS",
+    "CASCADE_IMPLEMENTATION_TIMEOUT_SECONDS",
+    "DISCOVERY_TIMEOUT_SECONDS",
+    "VERSION_CHECK_TIMEOUT_SECONDS",
+    "AUTH_CHECK_TIMEOUT_SECONDS",
     # Concurrency
     "DEFAULT_MAX_CONCURRENT_STAGES",
     "DEFAULT_MAX_AGENT_ITERATIONS",
@@ -70,6 +101,21 @@ __all__ = [
     "EXECUTION_HISTORY_DAYS",
     # Task defaults
     "DEFAULT_TASK_PRIORITY",
-    # Claude model
+    # Claude models
     "DEFAULT_CLAUDE_MODEL",
+    "CLAUDE_OPUS_MODEL",
+    "CLAUDE_SONNET_MODEL",
+    "DEFAULT_CLAUDE_FAST_MODEL",
+    # Environment variables
+    "ENV_ANTHROPIC_API_KEY",
+    "ENV_EMDX_DATABASE_URL",
+    "ENV_EMDX_TEST_DB",
+    "ENV_EMDX_CLI_TOOL",
+    "ENV_CURSOR_API_KEY",
+    # Environment validation
+    "EnvValidationError",
+    "validate_api_key",
+    "validate_database_url",
+    "get_required_env_vars",
+    "get_optional_env_vars",
 ]

--- a/emdx/config/cli_config.py
+++ b/emdx/config/cli_config.py
@@ -9,6 +9,14 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional
 
+from .constants import (
+    CLAUDE_OPUS_MODEL,
+    CLAUDE_SONNET_MODEL,
+    ENV_ANTHROPIC_API_KEY,
+    ENV_CURSOR_API_KEY,
+    ENV_EMDX_CLI_TOOL,
+)
+
 
 # Default tools allowed for Claude CLI execution
 # These are the standard tools that most agents need for basic operations
@@ -77,13 +85,13 @@ CLI_CONFIGS: Dict[CliTool, CliConfig] = {
         default_output_format="stream-json",
         requires_verbose_for_stream=True,
         model_flag="--model",
-        default_model="claude-opus-4-5-20251101",
+        default_model=CLAUDE_OPUS_MODEL,
         supports_allowed_tools=True,
         allowed_tools_flag="--allowedTools",
         force_flag=None,
         workspace_flag=None,
         config_path="~/.claude/claude_cli.json",
-        api_key_env="ANTHROPIC_API_KEY",
+        api_key_env=ENV_ANTHROPIC_API_KEY,
     ),
     CliTool.CURSOR: CliConfig(
         binary=["cursor", "agent"],
@@ -99,7 +107,7 @@ CLI_CONFIGS: Dict[CliTool, CliConfig] = {
         force_flag="--force",
         workspace_flag="--workspace",
         config_path=None,
-        api_key_env="CURSOR_API_KEY",
+        api_key_env=ENV_CURSOR_API_KEY,
     ),
 }
 
@@ -107,19 +115,19 @@ CLI_CONFIGS: Dict[CliTool, CliConfig] = {
 # Use these aliases for portable commands that work with either CLI
 MODEL_ALIASES: Dict[str, Dict[str, str]] = {
     "opus": {
-        "claude": "claude-opus-4-5-20251101",
+        "claude": CLAUDE_OPUS_MODEL,
         "cursor": "opus-4.5",
     },
     "sonnet": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": CLAUDE_SONNET_MODEL,
         "cursor": "sonnet-4.5",
     },
     "auto": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": CLAUDE_SONNET_MODEL,
         "cursor": "auto",
     },
     "fast": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": CLAUDE_SONNET_MODEL,
         "cursor": "auto",
     },
 }
@@ -130,7 +138,7 @@ def get_default_cli_tool() -> CliTool:
 
     Checks EMDX_CLI_TOOL environment variable first.
     """
-    env_value = os.environ.get("EMDX_CLI_TOOL", "claude").lower()
+    env_value = os.environ.get(ENV_EMDX_CLI_TOOL, "claude").lower()
     try:
         return CliTool(env_value)
     except ValueError:
@@ -174,8 +182,8 @@ def get_available_models(cli_tool: CliTool) -> List[str]:
     """
     if cli_tool == CliTool.CLAUDE:
         return [
-            "claude-opus-4-5-20251101",
-            "claude-sonnet-4-5-20250929",
+            CLAUDE_OPUS_MODEL,
+            CLAUDE_SONNET_MODEL,
             "opus",
             "sonnet",
         ]

--- a/emdx/models/executions.py
+++ b/emdx/models/executions.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
+from ..config.constants import STALE_EXECUTION_TIMEOUT_SECONDS
 from ..database.connection import db_connection
 from ..utils.datetime_utils import parse_timestamp
 
@@ -247,11 +248,12 @@ def update_execution_heartbeat(exec_id: int) -> None:
         conn.commit()
 
 
-def get_stale_executions(timeout_seconds: int = 1800) -> List[Execution]:
+def get_stale_executions(timeout_seconds: int = STALE_EXECUTION_TIMEOUT_SECONDS) -> List[Execution]:
     """Get executions that haven't sent a heartbeat recently.
 
     Args:
-        timeout_seconds: Seconds after which an execution is considered stale (default 30 min)
+        timeout_seconds: Seconds after which an execution is considered stale
+                         (default from STALE_EXECUTION_TIMEOUT_SECONDS)
 
     Returns:
         List of stale executions

--- a/emdx/services/ask_service.py
+++ b/emdx/services/ask_service.py
@@ -20,6 +20,7 @@ except ImportError:
     anthropic = None  # type: ignore[assignment]
     HAS_ANTHROPIC = False
 
+from ..config.constants import DEFAULT_CLAUDE_FAST_MODEL
 from ..database import db
 
 logger = logging.getLogger(__name__)
@@ -38,7 +39,7 @@ class Answer:
 class AskService:
     """Answer questions using your knowledge base."""
 
-    DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
+    DEFAULT_MODEL = DEFAULT_CLAUDE_FAST_MODEL
     MIN_EMBEDDINGS_FOR_SEMANTIC = 50  # Use semantic only if we have enough coverage
 
     def __init__(self, model: Optional[str] = None):

--- a/emdx/services/cascade_service.py
+++ b/emdx/services/cascade_service.py
@@ -11,6 +11,10 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List
 
+from emdx.config.constants import (
+    CASCADE_TIMEOUT_SECONDS,
+    CASCADE_IMPLEMENTATION_TIMEOUT_SECONDS,
+)
 from emdx.database import cascade as cascade_db
 from emdx.database.connection import db_connection
 from emdx.database.documents import get_document
@@ -94,7 +98,7 @@ def monitor_execution_completion(
     from emdx.models.executions import get_execution, update_execution_status
 
     poll_interval = 2.0
-    max_wait = 1800 if stage == "planned" else 300
+    max_wait = CASCADE_IMPLEMENTATION_TIMEOUT_SECONDS if stage == "planned" else CASCADE_TIMEOUT_SECONDS
     start_time = time.time()
 
     while True:

--- a/emdx/services/claude_executor.py
+++ b/emdx/services/claude_executor.py
@@ -22,7 +22,7 @@ from typing import List, Optional
 logger = logging.getLogger(__name__)
 
 from ..config.cli_config import CliTool, get_cli_config, DEFAULT_ALLOWED_TOOLS
-from ..config.settings import DEFAULT_CLAUDE_MODEL
+from ..config.constants import DEFAULT_CLAUDE_MODEL, DEFAULT_TIMEOUT_SECONDS
 from ..utils.environment import ensure_claude_in_path, validate_execution_environment
 from ..utils.structured_logger import ProcessType, StructuredLogger
 from .cli_executor import get_cli_executor
@@ -230,7 +230,7 @@ def execute_cli_sync(
     allowed_tools: Optional[List[str]] = None,
     working_dir: Optional[str] = None,
     doc_id: Optional[str] = None,
-    timeout: int = 300,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
 ) -> dict:
     """Execute a task with specified CLI tool synchronously, waiting for completion.
 
@@ -246,7 +246,7 @@ def execute_cli_sync(
         allowed_tools: List of allowed tools (defaults to DEFAULT_ALLOWED_TOOLS)
         working_dir: Working directory for execution
         doc_id: Document ID (for logging)
-        timeout: Maximum seconds to wait (default 300 = 5 minutes)
+        timeout: Maximum seconds to wait (default from DEFAULT_TIMEOUT_SECONDS)
 
     Returns:
         Dict with 'success' (bool), 'output' (str) or 'error' (str), and 'exit_code' (int)
@@ -391,7 +391,7 @@ def execute_claude_sync(
     allowed_tools: Optional[List[str]] = None,
     working_dir: Optional[str] = None,
     doc_id: Optional[str] = None,
-    timeout: int = 300,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
 ) -> dict:
     """Execute a task with Claude synchronously, waiting for completion.
 
@@ -405,7 +405,7 @@ def execute_claude_sync(
         allowed_tools: List of allowed tools (defaults to DEFAULT_ALLOWED_TOOLS)
         working_dir: Working directory for execution
         doc_id: Document ID (for logging)
-        timeout: Maximum seconds to wait (default 300 = 5 minutes)
+        timeout: Maximum seconds to wait (default from DEFAULT_TIMEOUT_SECONDS)
 
     Returns:
         Dict with 'success' (bool) and 'output' (str) or 'error' (str)

--- a/emdx/services/execution_monitor.py
+++ b/emdx/services/execution_monitor.py
@@ -8,6 +8,7 @@ import psutil
 
 logger = logging.getLogger(__name__)
 
+from ..config.constants import STALE_EXECUTION_TIMEOUT_SECONDS
 from ..database.connection import db_connection
 from ..models.executions import (
     Execution,
@@ -20,11 +21,12 @@ from ..models.executions import (
 class ExecutionMonitor:
     """Monitor and manage execution lifecycle."""
     
-    def __init__(self, stale_timeout_seconds: int = 1800):
+    def __init__(self, stale_timeout_seconds: int = STALE_EXECUTION_TIMEOUT_SECONDS):
         """Initialize execution monitor.
-        
+
         Args:
-            stale_timeout_seconds: Seconds after which execution is considered stale (default 30 min)
+            stale_timeout_seconds: Seconds after which execution is considered stale
+                                   (default from STALE_EXECUTION_TIMEOUT_SECONDS)
         """
         self.stale_timeout = stale_timeout_seconds
     

--- a/emdx/services/unified_executor.py
+++ b/emdx/services/unified_executor.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from ..config.cli_config import CliTool, get_default_cli_tool, DEFAULT_ALLOWED_TOOLS
-from ..config.constants import EMDX_LOG_DIR
+from ..config.constants import EMDX_LOG_DIR, DEFAULT_TIMEOUT_SECONDS
 from ..models.executions import create_execution, update_execution_status
 from ..utils.environment import get_subprocess_env
 from .cli_executor import get_cli_executor
@@ -145,7 +145,7 @@ class ExecutionConfig:
     doc_id: Optional[int] = None
     output_instruction: Optional[str] = None
     allowed_tools: List[str] = field(default_factory=lambda: DEFAULT_ALLOWED_TOOLS.copy())
-    timeout_seconds: int = 300
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
     cli_tool: str = "claude"  # "claude" or "cursor"
     model: Optional[str] = None  # Override default model for the CLI
     verbose: bool = False  # Stream output in real-time

--- a/emdx/utils/environment.py
+++ b/emdx/utils/environment.py
@@ -7,7 +7,13 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from emdx.config.constants import EMDX_CONFIG_DIR
+from emdx.config.constants import (
+    EMDX_CONFIG_DIR,
+    ENV_ANTHROPIC_API_KEY,
+    ENV_CURSOR_API_KEY,
+    VERSION_CHECK_TIMEOUT_SECONDS,
+    AUTH_CHECK_TIMEOUT_SECONDS,
+)
 from emdx.utils.output import console
 
 
@@ -93,7 +99,7 @@ class EnvironmentValidator:
                             version_cmd,
                             capture_output=True,
                             text=True,
-                            timeout=5
+                            timeout=VERSION_CHECK_TIMEOUT_SECONDS
                         )
                         if result.returncode == 0:
                             self.info[f"{cmd}_version"] = result.stdout.strip()
@@ -176,7 +182,7 @@ class EnvironmentValidator:
             self.warnings.append("Claude config file not found - claude might not be properly configured")
 
         # Check ANTHROPIC_API_KEY
-        if os.environ.get("ANTHROPIC_API_KEY"):
+        if os.environ.get(ENV_ANTHROPIC_API_KEY):
             self.info["api_key"] = "set"
         else:
             # Check if claude works without explicit API key
@@ -185,17 +191,17 @@ class EnvironmentValidator:
                     ["claude", "--version"],
                     capture_output=True,
                     text=True,
-                    timeout=5
+                    timeout=VERSION_CHECK_TIMEOUT_SECONDS
                 )
                 if result.returncode != 0:
-                    self.warnings.append("ANTHROPIC_API_KEY not set and claude might not work")
+                    self.warnings.append(f"{ENV_ANTHROPIC_API_KEY} not set and claude might not work")
             except Exception as e:
                 self.warnings.append(f"Cannot verify claude installation: {e}")
 
     def _check_cursor_config(self) -> None:
         """Check Cursor-specific configuration."""
         # Check CURSOR_API_KEY
-        if os.environ.get("CURSOR_API_KEY"):
+        if os.environ.get(ENV_CURSOR_API_KEY):
             self.info["cursor_api_key"] = "set"
 
         # Check authentication status
@@ -204,7 +210,7 @@ class EnvironmentValidator:
                 ["cursor", "agent", "status"],
                 capture_output=True,
                 text=True,
-                timeout=10
+                timeout=AUTH_CHECK_TIMEOUT_SECONDS
             )
             if "Not logged in" in result.stdout:
                 self.warnings.append(


### PR DESCRIPTION
## Summary
- Centralize hardcoded timeout values scattered across 15+ locations into `emdx/config/constants.py`
- Centralize model name strings duplicated across 5+ files
- Add validation utilities for critical environment variables (ANTHROPIC_API_KEY, EMDX_DATABASE_URL)

## Changes

### New timeout constants
| Constant | Value | Description |
|----------|-------|-------------|
| `DEFAULT_TIMEOUT_SECONDS` | 300 | Standard task timeout (5 min) |
| `DELEGATE_TIMEOUT_SECONDS` | 600 | Delegate command timeout (10 min) |
| `IMPLEMENTATION_TIMEOUT_SECONDS` | 1800 | Code generation tasks (30 min) |
| `CASCADE_TIMEOUT_SECONDS` | 300 | Cascade stage timeout (5 min) |
| `CASCADE_IMPLEMENTATION_TIMEOUT_SECONDS` | 1800 | Cascade implementation stage (30 min) |
| `DISCOVERY_TIMEOUT_SECONDS` | 30 | Command discovery |
| `VERSION_CHECK_TIMEOUT_SECONDS` | 5 | CLI version checks |
| `AUTH_CHECK_TIMEOUT_SECONDS` | 10 | Authentication status checks |

### New model constants
- `CLAUDE_OPUS_MODEL` = "claude-opus-4-5-20251101"
- `CLAUDE_SONNET_MODEL` = "claude-sonnet-4-5-20250929" 
- `DEFAULT_CLAUDE_MODEL` (opus)
- `DEFAULT_CLAUDE_FAST_MODEL` (sonnet)

### New environment variable constants
- `ENV_ANTHROPIC_API_KEY`
- `ENV_EMDX_DATABASE_URL`
- `ENV_EMDX_TEST_DB`
- `ENV_EMDX_CLI_TOOL`
- `ENV_CURSOR_API_KEY`

### New validation utilities
- `validate_api_key(raise_on_missing=False)` - Validates ANTHROPIC_API_KEY
- `validate_database_url()` - Validates EMDX_DATABASE_URL if set
- `get_required_env_vars()` - Returns list of recommended env vars
- `get_optional_env_vars()` - Returns list of optional env vars
- `EnvValidationError` - Exception for missing required env vars

## Test plan
- [x] Run `poetry run pytest tests/ -x` - all 797 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)