### PR TITLE
feat(ci): Add release automation workflow (Issue #DEBT-23)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.13'
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: latest
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Build package
+      run: poetry build
+
+    - name: Extract version from tag
+      id: get_version
+      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+    - name: Extract changelog for this version
+      id: changelog
+      run: |
+        # Extract the changelog section for this version
+        version="${{ steps.get_version.outputs.VERSION }}"
+        changelog=$(awk -v ver="$version" '
+          /^## \[/ {
+            if (found) exit
+            if ($0 ~ "\\[" ver "\\]") found=1
+          }
+          found && !/^## \['"$version"'\]/ { print }
+        ' CHANGELOG.md)
+
+        # Write to file for multiline output
+        echo "$changelog" > changelog_body.txt
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        skip-existing: true
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        body_path: changelog_body.txt
+        files: |
+          dist/*
+        generate_release_notes: false


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that triggers on `v*` tag pushes
- Build package using `poetry build`
- Publish to PyPI using trusted publishing (OIDC - no API token needed)
- Create GitHub release with changelog notes extracted from CHANGELOG.md
- Attach built distribution files to the release

## Test plan
- [ ] Review workflow syntax for correctness
- [ ] Verify permissions are correct for OIDC publishing
- [ ] Test by creating a release tag after merge

## Notes
Uses PyPI trusted publishing which requires configuring the repository as a trusted publisher in PyPI settings. This is more secure than API tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)