### PR TITLE
fix(tests): reduce time.sleep delays in test suite (Issue #DEBT-20)

### DIFF
--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -177,7 +177,7 @@ class TestGetDocument:
 
         doc_id = save_document("Accessed At Test", "Content")
         doc1 = get_document(doc_id)
-        time.sleep(0.05)
+        time.sleep(0.001)  # Minimal delay to ensure different timestamps
         doc2 = get_document(doc_id)
         # accessed_at should be updated (or at least not earlier)
         assert doc2["accessed_at"] >= doc1["accessed_at"]
@@ -219,7 +219,7 @@ class TestUpdateDocument:
 
         doc_id = save_document("Timestamp Test", "Content")
         doc_before = get_document(doc_id)
-        time.sleep(0.05)
+        time.sleep(0.001)  # Minimal delay to ensure different timestamps
         update_document(doc_id, "Timestamp Test v2", "New Content")
         doc_after = get_document(doc_id)
         assert doc_after["updated_at"] >= doc_before["updated_at"]
@@ -496,7 +496,7 @@ class TestGetRecentDocuments:
         id2 = save_document("New", "Content")
         # Access old one so its accessed_at is more recent
         get_document(id1)
-        time.sleep(0.05)
+        time.sleep(0.001)  # Minimal delay to ensure different timestamps
         get_document(id1)
 
         docs = get_recent_documents(limit=10)

--- a/tests/test_execution_system_comprehensive.py
+++ b/tests/test_execution_system_comprehensive.py
@@ -196,11 +196,15 @@ class ExecutionSystemTester:
                 self.tests_passed += 1
                 self.test_results.append(("Background execution", "✅ Passed"))
                 console.print("[green]✅ Background execution started[/green]")
-                
-                # Wait a bit for execution to start
-                time.sleep(2)
-                
-                # Check running executions
+
+                # Poll for execution to start (max 2s with early exit)
+                for _ in range(10):
+                    exit_code, stdout, stderr = self.run_command("emdx exec running")
+                    if "claude" in stdout.lower() or "running" in stdout.lower():
+                        break
+                    time.sleep(0.2)
+
+                # Check running executions (use last result from loop)
                 exit_code, stdout, stderr = self.run_command("emdx exec running")
                 if "claude" in stdout.lower() or "running" in stdout.lower():
                     self.tests_passed += 1


### PR DESCRIPTION
## Summary
- Reduced time.sleep() delays across 16 instances in the test suite
- Saves approximately 4.4 seconds per test run
- All 797 tests still pass

## Changes
| File | Change |
|------|--------|
| `test_documents.py` | 50ms → 1ms timestamp delays (3 instances) |
| `test_execution_system_comprehensive.py` | 2s blocking → polling loop with early exit |
| `test_file_watcher.py` | Optimized poll cycle waits, use `thread.join()` (11 instances) |

## Test plan
- [x] Run `poetry run pytest tests/ -x` - all 797 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)