### PR TITLE
test: strengthen weak assertions in test suite (Issue #DEBT-22)

### DIFF
--- a/tests/test_commands_status.py
+++ b/tests/test_commands_status.py
@@ -23,6 +23,10 @@ class TestParseTimestamp:
         result = _parse_timestamp("2026-01-15T10:30:00Z")
         assert result is not None
         assert result.year == 2026
+        assert result.month == 1
+        assert result.day == 15
+        assert result.hour == 10
+        assert result.minute == 30
 
     def test_invalid_string_returns_none(self):
         assert _parse_timestamp("not a date") is None

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -534,10 +534,10 @@ class TestSearchEdgeCases:
 
         db.save_document("C++ Programming", "Learn C++ basics", "project1")
 
-        # Note: FTS5 handles special characters differently
-        # Search for just "C" should match
-        results = search_documents("C")
-        assert len(results) >= 0  # May or may not match depending on tokenizer
+        # Search for the full term "Programming" which should definitely match
+        results = search_documents("Programming")
+        assert len(results) == 1
+        assert results[0]["title"] == "C++ Programming"
 
     def test_search_with_phrase(self, mock_db_connection):
         """Test phrase search with FTS5."""
@@ -546,10 +546,10 @@ class TestSearchEdgeCases:
         db.save_document("Python Programming", "Learn Python web development", "project1")
         db.save_document("Web Development", "Learn web programming with Python", "project1")
 
-        # FTS5 phrase search with quotes
+        # FTS5 phrase search with quotes - should match first doc with exact phrase
         results = search_documents('"Python web"')
-        # Should match the first document which has "Python web" as a phrase
-        assert len(results) >= 0
+        assert len(results) == 1
+        assert results[0]["title"] == "Python Programming"
 
     def test_search_with_or_literal(self, mock_db_connection):
         """Test that 'OR' is treated as a literal word, not FTS operator.

--- a/tests/test_stream_json_parser.py
+++ b/tests/test_stream_json_parser.py
@@ -276,6 +276,11 @@ class TestParseStreamJsonLineRich:
         event = parse_stream_json_line_rich(json.dumps(obj))
         assert event.event_type == "status"
         assert event.timestamp is not None
+        assert event.timestamp.year == 2025
+        assert event.timestamp.month == 1
+        assert event.timestamp.day == 10
+        assert "[DEBUG]" in event.content
+        assert "Processing" in event.content
 
     def test_structured_logger_with_z_suffix(self):
         obj = {
@@ -287,6 +292,11 @@ class TestParseStreamJsonLineRich:
         event = parse_stream_json_line_rich(json.dumps(obj))
         assert event.event_type == "status"
         assert event.timestamp is not None
+        assert event.timestamp.year == 2025
+        assert event.timestamp.hour == 10
+        assert event.timestamp.minute == 30
+        assert "[INFO]" in event.content
+        assert "Done" in event.content
 
     def test_structured_logger_invalid_timestamp(self):
         obj = {
@@ -491,8 +501,10 @@ class TestParseAndFormatLiveLogs:
         obj = {"type": "system", "subtype": "init", "model": "test"}
         # System init becomes a status event, not skip
         lines = parse_and_format_live_logs(json.dumps(obj))
-        # Should have something since system init becomes status
-        assert len(lines) >= 0
+        # Should have status line with model info
+        assert len(lines) == 1
+        assert "Session started" in lines[0]
+        assert "test" in lines[0]  # model name
 
     def test_formats_text(self):
         obj = {


### PR DESCRIPTION
## Summary
- Fix test assertions that didn't validate behavior meaningfully
- Replace `assert len(X) >= 0` (always true) with actual content validation
- Strengthen timestamp parsing assertions to verify parsed values

## Test plan
- [x] All 797 tests pass with `poetry run pytest tests/ -x`
- [x] Modified tests now validate actual behavior instead of just existence

🤖 Generated with [Claude Code](https://claude.com/claude-code)