### PR TITLE
docs: Add Architecture Decision Records (ADRs) (Issue #DEBT-31)

### DIFF
--- a/docs/adr/001-sqlite-fts5-storage.md
+++ b/docs/adr/001-sqlite-fts5-storage.md
@@ -1,0 +1,87 @@
+# ADR-001: SQLite + FTS5 as Storage Layer
+
+## Status
+
+Accepted
+
+## Context
+
+EMDX is a knowledge base CLI tool designed for developers. It needs to store documents, tags, executions, and other metadata with the following requirements:
+
+- **Local-first**: No cloud dependencies or database server setup required
+- **Fast full-text search**: Users need to quickly find documents by content
+- **Portable**: Easy backup, sync, and transfer of the knowledge base
+- **Reliable**: ACID transactions with data integrity guarantees
+- **Simple deployment**: Single-file distribution, no external services
+
+We considered several alternatives:
+
+1. **PostgreSQL/MySQL**: Full-featured RDBMS with excellent search capabilities
+2. **Elasticsearch**: Purpose-built for full-text search
+3. **File-based storage** (JSON/YAML): Simple but limited query capabilities
+4. **SQLite without FTS**: Simpler but LIKE queries are slow for full-text search
+5. **SQLite with FTS5**: Embedded database with built-in full-text search
+
+## Decision
+
+We chose **SQLite with FTS5** (Full-Text Search version 5) as the storage layer.
+
+### Key implementation details:
+
+- **Single database file** at `~/.emdx/emdx.db`
+- **FTS5 virtual table** (`documents_fts`) synchronized with the main `documents` table
+- **WAL mode** for better concurrency during read-heavy workloads
+- **Foreign key constraints** for referential integrity
+- **Versioned migrations** for safe schema evolution (currently 36+ migrations)
+
+### Schema highlights:
+
+```sql
+-- Core document storage
+CREATE TABLE documents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    project TEXT,
+    created_at TEXT NOT NULL,
+    -- ... additional fields
+);
+
+-- Full-text search virtual table
+CREATE VIRTUAL TABLE documents_fts USING fts5(
+    title,
+    content,
+    project,
+    content='documents',
+    content_rowid='id'
+);
+```
+
+## Consequences
+
+### Positive
+
+- **Zero setup**: Users install EMDX and immediately have a working database
+- **Fast search**: FTS5 provides ranked full-text search with BM25 scoring
+- **Portable**: Single file can be backed up with `cp` or synced via cloud storage
+- **Reliable**: SQLite is battle-tested; ACID transactions prevent data corruption
+- **No dependencies**: No need to install or run a database server
+- **Good tooling**: SQLite has excellent ecosystem (DB Browser, CLI tools, libraries)
+
+### Negative
+
+- **Single-user**: SQLite doesn't support multiple writers efficiently (not a concern for EMDX's use case)
+- **Size limitations**: Very large knowledge bases (100k+ documents) may need different approach
+- **No replication**: Built-in replication requires external tools (also not a concern for local-first design)
+
+### Mitigations
+
+- **Concurrency**: WAL mode provides good read concurrency; EMDX's workload is read-heavy
+- **Performance**: Proper indexing and connection pooling keep queries fast
+- **Scaling**: If users outgrow SQLite, future versions could support PostgreSQL as an optional backend
+
+## References
+
+- [SQLite FTS5 Documentation](https://www.sqlite.org/fts5.html)
+- [SQLite is not a toy database](https://antonz.org/sqlite-is-not-a-toy-database/)
+- [EMDX Database Design](../database-design.md)

--- a/docs/adr/002-typer-cli-framework.md
+++ b/docs/adr/002-typer-cli-framework.md
@@ -1,0 +1,83 @@
+# ADR-002: Typer for CLI Framework
+
+## Status
+
+Accepted
+
+## Context
+
+EMDX requires a robust CLI framework to handle its command-line interface. The CLI is the primary interface for users, supporting commands like `save`, `find`, `view`, `delegate`, and many others. Requirements include:
+
+- **Type safety**: Python type hints for better IDE support and error catching
+- **Rich output**: Terminal formatting, colors, and tables for better UX
+- **Command organization**: Nested subcommands (e.g., `emdx tag list`, `emdx task create`)
+- **Auto-generated help**: Comprehensive `--help` output from function signatures
+- **Maintainability**: Easy to add new commands without boilerplate
+
+We considered several alternatives:
+
+1. **argparse**: Python standard library, verbose but no dependencies
+2. **Click**: Mature, decorator-based, widely used
+3. **Typer**: Built on Click, uses type hints, auto-completion support
+4. **Fire**: Auto-generates CLI from any Python object
+5. **Docopt**: Generates parser from docstring, less common
+
+## Decision
+
+We chose **Typer** as the CLI framework.
+
+### Key implementation details:
+
+- **Entry point** in `emdx/main.py` using `typer.Typer()`
+- **Command modules** in `emdx/commands/` (core.py, browse.py, tags.py, etc.)
+- **Rich integration** via `typer[all]` for enhanced output formatting
+- **Type hints** throughout for parameter validation and help generation
+
+### Example command pattern:
+
+```python
+import typer
+from typing import Optional, List
+
+app = typer.Typer(name="delegate", help="Delegate tasks to agents")
+
+@app.command()
+def run(
+    tasks: List[str] = typer.Argument(..., help="Tasks to execute"),
+    synthesize: bool = typer.Option(False, "--synthesize", "-s", help="Combine results"),
+    doc: Optional[int] = typer.Option(None, "--doc", "-d", help="Document ID for context"),
+    worktree: bool = typer.Option(False, "--worktree", "-w", help="Run in isolated worktree"),
+):
+    """Execute tasks with Claude agents."""
+    # Implementation...
+```
+
+## Consequences
+
+### Positive
+
+- **Minimal boilerplate**: Type hints serve double duty as documentation and validation
+- **Great IDE support**: Auto-completion, type checking, and inline documentation
+- **Rich integration**: Built-in support for progress bars, tables, and colors via Rich
+- **Click compatibility**: Can use Click features when needed (e.g., advanced callbacks)
+- **Shell completion**: Automatic shell completion scripts for bash/zsh/fish
+- **Consistent patterns**: All commands follow same structure, easy for contributors
+
+### Negative
+
+- **Dependency**: Adds typer + click + rich to dependency tree
+- **Learning curve**: Developers need to understand Typer conventions
+- **Magic behavior**: Some implicit behaviors (like argument vs option) can surprise newcomers
+
+### Mitigations
+
+- **Clear conventions**: CLAUDE.md documents command patterns for contributors
+- **Dependency management**: Poetry lockfile ensures reproducible installs
+- **Testing**: Commands are testable via typer.testing.CliRunner
+
+## References
+
+- [Typer Documentation](https://typer.tiangolo.com/)
+- [Click Documentation](https://click.palletsprojects.com/)
+- [Rich Documentation](https://rich.readthedocs.io/)
+- [EMDX CLI Reference](../cli-api.md)

--- a/docs/adr/003-textual-tui.md
+++ b/docs/adr/003-textual-tui.md
@@ -1,0 +1,131 @@
+# ADR-003: Textual for TUI
+
+## Status
+
+Accepted
+
+## Context
+
+EMDX needs a terminal user interface (TUI) for interactive document browsing, log viewing, and execution monitoring. The TUI (`emdx gui`) provides a rich, keyboard-driven experience for power users. Requirements include:
+
+- **Rich widgets**: Tables, trees, panels, and text viewers
+- **Vim-like navigation**: j/k movement, modal editing patterns
+- **Real-time updates**: Live log streaming, reactive UI updates
+- **Cross-platform**: Works consistently across macOS, Linux, and Windows terminals
+- **Modern features**: Mouse support, CSS-like styling, responsive layouts
+
+We considered several alternatives:
+
+1. **curses/ncurses**: Standard library, very low-level
+2. **urwid**: Established Python TUI library, callback-based
+3. **blessed/blessings**: Thin wrapper over curses with better API
+4. **Textual**: Modern, async, CSS-styled, from the Rich author
+5. **prompt_toolkit**: Good for prompts, less suited for full-screen apps
+
+## Decision
+
+We chose **Textual** as the TUI framework.
+
+### Key implementation details:
+
+- **Multi-modal browser** in `emdx/ui/browser_container.py`
+- **Specialized browsers**: DocumentBrowser, LogBrowser, ActivityView, CascadeBrowser
+- **Vim-style keybindings**: j/k navigation, g/G for top/bottom, modal selection
+- **Reactive data binding**: UI automatically updates when data changes
+- **Theme system** in `emdx/ui/themes.py` for visual customization
+
+### Component hierarchy:
+
+```
+App (emdx gui)
+└── BrowserContainer
+    ├── DocumentBrowser (default, press 'd')
+    │   ├── DocumentTable
+    │   ├── PreviewPanel
+    │   └── DetailsPanel
+    ├── LogBrowser (press 'l')
+    │   ├── ExecutionTable
+    │   ├── LogViewer (with streaming)
+    │   └── MetadataPanel
+    ├── ActivityView (press 'a')
+    │   ├── ActivityTree
+    │   └── ContextPanel
+    └── CascadeBrowser (press '4')
+        ├── Stage columns
+        └── Document controls
+```
+
+## Consequences
+
+### Positive
+
+- **Rich terminal UI**: Modern widgets with CSS-like styling
+- **Reactive updates**: `reactive` decorator automatically refreshes UI when data changes
+- **Event system**: Clean separation between key handling and business logic
+- **Cross-platform**: Consistent behavior across terminal emulators
+- **Async-ready**: Native async/await support for background operations
+- **Developer experience**: Hot reload, devtools, good debugging support
+- **Ecosystem**: Same author as Rich, shares styling concepts
+
+### Negative
+
+- **Relatively new**: Less battle-tested than curses/urwid (though maturing rapidly)
+- **Heavier dependency**: Larger than minimal curses wrapper
+- **Learning curve**: Custom widget model and CSS subset to learn
+- **Performance**: Can be slower than raw curses for extremely large datasets
+
+### Mitigations
+
+- **Pagination**: Large document lists use pagination, not full render
+- **Lazy loading**: Log viewer streams content rather than loading all at once
+- **Testing**: Textual provides testing tools for automated UI testing
+- **Fallback**: CLI commands remain fully functional without TUI
+
+## Key Patterns Used
+
+### Widget Composition
+
+```python
+class DocumentBrowser(Widget):
+    BINDINGS = [
+        Binding("j", "cursor_down", "Down"),
+        Binding("k", "cursor_up", "Up"),
+        Binding("e", "edit", "Edit"),
+        # ...
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield DocumentTable()
+        yield PreviewPanel()
+```
+
+### Reactive Properties
+
+```python
+class LogViewer(Widget):
+    content = reactive("")  # UI auto-updates when this changes
+
+    def watch_content(self, value: str) -> None:
+        """Called automatically when content changes."""
+        self.refresh()
+```
+
+### Event Bubbling
+
+```python
+class DocumentSelected(Message):
+    """Posted when a document is selected."""
+    def __init__(self, doc_id: int):
+        self.doc_id = doc_id
+        super().__init__()
+
+# Parent widgets can handle child events
+def on_document_selected(self, event: DocumentSelected) -> None:
+    self.preview.load(event.doc_id)
+```
+
+## References
+
+- [Textual Documentation](https://textual.textualize.io/)
+- [Textual GitHub](https://github.com/Textualize/textual)
+- [EMDX UI Architecture](../ui-architecture.md)

--- a/docs/adr/004-delegate-worktree-pattern.md
+++ b/docs/adr/004-delegate-worktree-pattern.md
@@ -1,0 +1,149 @@
+# ADR-004: Delegate/Worktree Pattern for Parallel Execution
+
+## Status
+
+Accepted
+
+## Context
+
+EMDX supports delegating tasks to Claude Code agents for parallel AI-assisted work. When multiple agents work simultaneously or when agents need to make code changes, they can conflict with each other and with the user's working directory. Requirements include:
+
+- **Parallel execution**: Run multiple agent tasks concurrently (up to 10)
+- **Isolation**: Agents shouldn't interfere with each other's file changes
+- **PR creation**: Agents should be able to create pull requests for their changes
+- **Clean state**: Each agent starts with a known-good codebase state
+- **Result persistence**: Agent outputs are saved to the knowledge base for future reference
+
+We considered several approaches:
+
+1. **Sequential execution**: Run tasks one at a time (simple but slow)
+2. **Shared directory**: All agents work in the same directory (fast but conflicts)
+3. **Docker containers**: Isolated environments (heavyweight, complex setup)
+4. **Git worktrees**: Lightweight directory copies sharing git history
+5. **Temporary clones**: Full repo copies (wastes disk space, slow)
+
+## Decision
+
+We chose **git worktrees** for isolation combined with **inline result output** for immediate feedback.
+
+### Key implementation details:
+
+**Worktree creation** (`emdx/utils/git.py`):
+```python
+def create_worktree(base_branch: str = "main") -> tuple[str, str]:
+    """Create a unique git worktree for isolated execution."""
+    timestamp = int(time.time())
+    random_suffix = random.randint(1000, 9999)
+    pid = os.getpid()
+    unique_id = f"{timestamp}-{pid}-{random_suffix}"
+    branch_name = f"worktree-{unique_id}"
+    worktree_dir = Path(repo_root).parent / f"emdx-worktree-{unique_id}"
+
+    subprocess.run(
+        ["git", "worktree", "add", "-b", branch_name, str(worktree_dir), base_branch],
+        check=True
+    )
+    return str(worktree_dir), branch_name
+```
+
+**Delegate command patterns** (`emdx/commands/delegate.py`):
+```bash
+# Parallel tasks (each in its own worktree if needed)
+emdx delegate "task1" "task2" "task3"
+
+# With worktree isolation explicitly
+emdx delegate --worktree "make risky changes"
+
+# With PR creation (implies --worktree)
+emdx delegate --pr "fix the auth bug"
+
+# Sequential pipeline (chain mode)
+emdx delegate --chain "analyze" "plan" "implement"
+```
+
+**Result handling**:
+- Results print to **stdout** (so calling Claude can read them inline)
+- Results also persist to **emdx knowledge base** (so they're searchable later)
+- Execution metadata tracked in database for monitoring
+
+## Consequences
+
+### Positive
+
+- **True isolation**: Each agent has its own working directory and branch
+- **No conflicts**: Parallel agents can't overwrite each other's changes
+- **Clean PRs**: Each task can create a focused, single-purpose PR
+- **Fast creation**: Worktrees are nearly instant (hardlinks, shared objects)
+- **Space efficient**: Worktrees share the git object database
+- **Inline results**: Results appear in stdout for immediate consumption by Claude
+- **Persistent results**: Results also saved to knowledge base for later reference
+
+### Negative
+
+- **Git dependency**: Requires working git repository
+- **Cleanup needed**: Worktrees must be cleaned up after completion
+- **Branch proliferation**: Many short-lived branches created
+- **Path complexity**: Agents must handle different working directories
+
+### Mitigations
+
+- **Automatic cleanup**: `cleanup_worktree()` removes worktrees on completion
+- **Unique naming**: Timestamp + PID + random ensures no collisions
+- **Branch cleanup**: Worktree branches can be deleted after PR merge
+- **Fallback**: Non-worktree mode available for read-only tasks
+
+## Execution Modes
+
+### Standard (no worktree)
+
+Best for read-only analysis tasks:
+```bash
+emdx delegate "analyze the auth module"
+```
+- Runs in current directory
+- No file changes expected
+- Fastest execution
+
+### Parallel
+
+Multiple tasks execute concurrently:
+```bash
+emdx delegate "task1" "task2" "task3" -j 5
+```
+- Up to 10 concurrent tasks
+- Each can have its own worktree if `--worktree` specified
+
+### Worktree-isolated
+
+For tasks that modify files:
+```bash
+emdx delegate --worktree "refactor the database layer"
+```
+- Fresh worktree based on specified branch
+- Changes isolated from main working directory
+
+### With PR
+
+For tasks that should create pull requests:
+```bash
+emdx delegate --pr "fix the auth bug"
+```
+- Implies `--worktree`
+- Agent instructed to create PR after changes
+- PR URL captured in output
+
+### Chain (Sequential Pipeline)
+
+Each step sees previous output:
+```bash
+emdx delegate --chain "analyze" "plan" "implement"
+```
+- Steps execute sequentially
+- Previous step's output available as context
+- Final step can use `--pr` for PR creation
+
+## References
+
+- [Git Worktrees Documentation](https://git-scm.com/docs/git-worktree)
+- [EMDX Delegate Command](../cli-api.md#delegate)
+- [Architecture Overview](../architecture.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,41 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for EMDX. ADRs document significant architectural decisions made during development.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-001](001-sqlite-fts5-storage.md) | SQLite + FTS5 as Storage Layer | Accepted |
+| [ADR-002](002-typer-cli-framework.md) | Typer for CLI Framework | Accepted |
+| [ADR-003](003-textual-tui.md) | Textual for TUI | Accepted |
+| [ADR-004](004-delegate-worktree-pattern.md) | Delegate/Worktree Pattern for Parallel Execution | Accepted |
+
+## ADR Template
+
+When creating new ADRs, use this template:
+
+```markdown
+# ADR-XXX: Title
+
+## Status
+
+Accepted | Proposed | Deprecated | Superseded
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+```
+
+## References
+
+- [Michael Nygard's ADR article](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+- [ADR GitHub Organization](https://adr.github.io/)


### PR DESCRIPTION
## Summary
- Created `docs/adr/` directory with README and index
- Added four ADRs documenting key architectural decisions:
  - **ADR-001**: SQLite + FTS5 as storage layer
  - **ADR-002**: Typer for CLI framework  
  - **ADR-003**: Textual for TUI
  - **ADR-004**: Delegate/worktree pattern for parallel execution
- Each ADR follows the standard template (Status, Context, Decision, Consequences)

## Test plan
- [x] Files created in correct location (`docs/adr/`)
- [x] Each ADR follows standard template format
- [x] Links in README.md point to correct files
- [x] Content accurately reflects architectural decisions from existing docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)