### PR TITLE
fix(similarity): Optimize merge candidate search from O(n²) to O(n*k) (Issue #DEBT-29)

### DIFF
--- a/emdx/services/similarity.py
+++ b/emdx/services/similarity.py
@@ -3,6 +3,10 @@ TF-IDF-based document similarity service for EMDX.
 
 Uses scikit-learn's TfidfVectorizer to compute document similarity
 with hybrid scoring that combines content similarity and tag similarity.
+
+For duplicate detection, uses radius-based nearest neighbor search
+(ball tree) to achieve O(n*k) complexity instead of O(n²) pairwise
+comparison, where k is the average number of similar documents per doc.
 """
 
 from __future__ import annotations
@@ -434,10 +438,16 @@ class SimilarityService:
         min_similarity: float = 0.7,
         progress_callback: Optional[callable] = None,
     ) -> List[tuple]:
-        """Find all pairs of similar documents efficiently using matrix operations.
+        """Find all pairs of similar documents efficiently using radius neighbors.
 
-        This is MUCH faster than pairwise comparison - O(n*k) instead of O(n²)
-        where k is the number of non-zero entries in the sparse matrix.
+        Uses sklearn NearestNeighbors with radius_neighbors for O(n*k) complexity
+        where k is the average number of similar neighbors per document, instead of
+        O(n²) pairwise comparison.
+
+        The algorithm:
+        1. Build a ball tree index on TF-IDF vectors (O(n log n))
+        2. Query radius neighbors for each document (O(n*k) total)
+        3. Convert cosine distance to similarity and filter by threshold
 
         Args:
             min_similarity: Minimum similarity threshold (0.0 to 1.0)
@@ -452,51 +462,85 @@ class SimilarityService:
         if not self._doc_ids or self._tfidf_matrix is None:
             return []
 
+        from sklearn.neighbors import NearestNeighbors
+        from sklearn.preprocessing import normalize
         import numpy as np
-        from scipy.sparse import csr_matrix
 
-        # Compute full similarity matrix (sparse operation, very fast)
+        n_docs = len(self._doc_ids)
+
         if progress_callback:
             progress_callback(0, 100, 0)
 
-        # This is the key optimization: cosine_similarity on sparse matrices
-        # is highly optimized and uses BLAS under the hood
-        similarity_matrix = cosine_similarity(self._tfidf_matrix)
+        # Normalize vectors for cosine similarity computation
+        # For normalized vectors: cosine_similarity = 1 - (euclidean_distance² / 2)
+        # So: euclidean_distance = sqrt(2 * (1 - cosine_similarity))
+        normalized_matrix = normalize(self._tfidf_matrix, norm='l2')
+
+        # Convert similarity threshold to distance threshold
+        # cosine_sim = 1 - (dist² / 2), so dist = sqrt(2 * (1 - sim))
+        max_distance = np.sqrt(2 * (1 - min_similarity))
 
         if progress_callback:
-            progress_callback(50, 100, 0)
+            progress_callback(10, 100, 0)
 
-        # Find pairs above threshold (only upper triangle to avoid duplicates)
+        # Use ball_tree algorithm which works well with sparse high-dimensional data
+        # Convert to dense for NearestNeighbors (required for ball_tree)
+        # For very large datasets, could chunk this or use brute with sparse
+        dense_matrix = normalized_matrix.toarray()
+
+        if progress_callback:
+            progress_callback(20, 100, 0)
+
+        # Build the neighbor index - O(n log n)
+        nn = NearestNeighbors(
+            radius=max_distance,
+            algorithm='ball_tree',
+            metric='euclidean',
+            n_jobs=-1  # Use all CPUs
+        )
+        nn.fit(dense_matrix)
+
+        if progress_callback:
+            progress_callback(40, 100, 0)
+
+        # Query all neighbors within radius - O(n*k) where k is avg neighbors
+        distances, indices = nn.radius_neighbors(dense_matrix, return_distance=True)
+
+        if progress_callback:
+            progress_callback(70, 100, 0)
+
+        # Build pairs (avoiding duplicates by only keeping i < j)
         pairs = []
-        n_docs = len(self._doc_ids)
+        seen_pairs = set()
 
-        # Use numpy to find all pairs above threshold efficiently
-        # Only look at upper triangle (i < j)
-        rows, cols = np.triu_indices(n_docs, k=1)
-        similarities = similarity_matrix[rows, cols]
+        for i in range(n_docs):
+            neighbor_indices = indices[i]
+            neighbor_distances = distances[i]
 
-        # Filter by threshold
-        mask = similarities >= min_similarity
-        matching_rows = rows[mask]
-        matching_cols = cols[mask]
-        matching_sims = similarities[mask]
+            for j_idx, j in enumerate(neighbor_indices):
+                if i >= j:  # Skip self and avoid duplicates (only keep i < j)
+                    continue
+
+                pair_key = (i, j)
+                if pair_key in seen_pairs:
+                    continue
+                seen_pairs.add(pair_key)
+
+                # Convert euclidean distance back to cosine similarity
+                dist = neighbor_distances[j_idx]
+                similarity = 1 - (dist * dist / 2)
+
+                if similarity >= min_similarity:
+                    pairs.append((
+                        self._doc_ids[i],
+                        self._doc_ids[j],
+                        self._doc_titles[i],
+                        self._doc_titles[j],
+                        float(similarity)
+                    ))
 
         if progress_callback:
-            progress_callback(75, 100, len(matching_sims))
-
-        # Build result tuples
-        for idx in range(len(matching_rows)):
-            i, j = matching_rows[idx], matching_cols[idx]
-            title1 = self._doc_titles[i]
-            title2 = self._doc_titles[j]
-
-            pairs.append((
-                self._doc_ids[i],
-                self._doc_ids[j],
-                title1,
-                title2,
-                float(matching_sims[idx])
-            ))
+            progress_callback(90, 100, len(pairs))
 
         # Sort by similarity descending
         pairs.sort(key=lambda x: x[4], reverse=True)


### PR DESCRIPTION
## Summary
- Replace full similarity matrix computation with radius-based nearest neighbor search
- Use sklearn's NearestNeighbors with ball tree algorithm for O(n*k) complexity
- Previous O(n²) implementation computed all n*(n-1)/2 pairwise similarities

## Technical Details
The previous implementation in `find_all_duplicate_pairs()`:
1. Called `cosine_similarity(self._tfidf_matrix)` creating a full n×n dense matrix
2. Used `np.triu_indices()` to iterate over all n*(n-1)/2 pairs
3. Filtered pairs by threshold

The new implementation:
1. Normalizes TF-IDF vectors (L2 norm)
2. Converts similarity threshold to euclidean distance: `dist = sqrt(2 * (1 - sim))`
3. Builds ball tree index in O(n log n)
4. Queries radius neighbors in O(n*k) where k = avg neighbors per document
5. For sparse similarity graphs (typical), k << n

## Test plan
- [x] All 820 existing tests pass
- [x] Document merger tests (18 tests) verify candidate finding
- [x] Similarity tests (17 tests) verify core functionality
- [x] Duplicate detector tests (23 tests) verify integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)