### PR TITLE
test(execution): Add unit tests for execution system lifecycle (Issue #DEBT-21)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ def isolate_test_database(tmp_path_factory):
             'emdx.database.groups',
             'emdx.models.executions',
             'emdx.services.execution_monitor',
+            'emdx.services.execution_service',
         ]
         import sys
         import importlib


### PR DESCRIPTION
## Summary
- Add comprehensive unit test coverage for the execution system
- Cover execution lifecycle: creating records, updating status, timeout handling, and log recording
- Focus on `emdx/models/executions.py` and `emdx/services/execution_service.py`

## Tests Added (24 total)

### TestExecutionDataclass (7 tests)
Tests for the `Execution` dataclass properties:
- Duration calculation for completed vs running executions
- `is_running` property
- `is_zombie` detection (no PID, not running, dead process)
- `log_path` property

### TestExecutionCRUD (9 tests)
Tests for execution CRUD operations:
- Create execution with all fields
- Create standalone delegate execution (no doc_id)
- Get non-existent execution returns None
- Update status to completed/failed
- Update generic fields (cost, tokens)
- Update PID and working directory

### TestExecutionQueries (3 tests)
Tests for query operations:
- Get recent executions with limit
- Get running executions only
- Get execution statistics

### TestTimeoutHandling (4 tests)
Tests for timeout/cleanup:
- Validates timeout parameter
- Cleanup old executions by age
- 2 tests skipped (heartbeat column removed in migration 013)

### TestExecutionService (2 tests)
Tests for the service facade:
- Filter Agent:/Delegate: prefixed executions
- Find log file for running executions

## Additional Changes
- Added `emdx.services.execution_service` to conftest.py's module patching list for proper test database isolation

## Test plan
- [x] Run `poetry run pytest tests/test_execution_system.py -v` - 22 passed, 2 skipped
- [x] Run full test suite `poetry run pytest tests/ -x` - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)