### PR TITLE
test: Reduce time.sleep() durations in test suite

### DIFF
--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -177,7 +177,7 @@ class TestGetDocument:
 
         doc_id = save_document("Accessed At Test", "Content")
         doc1 = get_document(doc_id)
-        time.sleep(0.05)
+        time.sleep(0.01)  # Minimal delay to ensure different timestamps
         doc2 = get_document(doc_id)
         # accessed_at should be updated (or at least not earlier)
         assert doc2["accessed_at"] >= doc1["accessed_at"]
@@ -219,7 +219,7 @@ class TestUpdateDocument:
 
         doc_id = save_document("Timestamp Test", "Content")
         doc_before = get_document(doc_id)
-        time.sleep(0.05)
+        time.sleep(0.01)  # Minimal delay to ensure different timestamps
         update_document(doc_id, "Timestamp Test v2", "New Content")
         doc_after = get_document(doc_id)
         assert doc_after["updated_at"] >= doc_before["updated_at"]
@@ -496,7 +496,7 @@ class TestGetRecentDocuments:
         id2 = save_document("New", "Content")
         # Access old one so its accessed_at is more recent
         get_document(id1)
-        time.sleep(0.05)
+        time.sleep(0.01)  # Minimal delay to ensure different timestamps
         get_document(id1)
 
         docs = get_recent_documents(limit=10)

--- a/tests/test_execution_system_comprehensive.py
+++ b/tests/test_execution_system_comprehensive.py
@@ -196,10 +196,16 @@ class ExecutionSystemTester:
                 self.tests_passed += 1
                 self.test_results.append(("Background execution", "✅ Passed"))
                 console.print("[green]✅ Background execution started[/green]")
-                
-                # Wait a bit for execution to start
-                time.sleep(2)
-                
+
+                # Poll for execution to start (max 2s with 0.2s intervals)
+                execution_found = False
+                for _ in range(10):
+                    time.sleep(0.2)
+                    exit_code, stdout, stderr = self.run_command("emdx exec running")
+                    if "claude" in stdout.lower() or "running" in stdout.lower():
+                        execution_found = True
+                        break
+
                 # Check running executions
                 exit_code, stdout, stderr = self.run_command("emdx exec running")
                 if "claude" in stdout.lower() or "running" in stdout.lower():

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -43,8 +43,8 @@ class TestFileWatcherPolling:
             watcher.start()
 
             try:
-                # Wait for initial callback
-                time.sleep(0.6)
+                # Wait for initial callback (poll interval is 0.5s)
+                time.sleep(0.55)
 
                 # Modify the file
                 with open(temp_file, 'a') as f:
@@ -72,8 +72,8 @@ class TestFileWatcherPolling:
             watcher.start()
 
             try:
-                # Wait for initial callback
-                time.sleep(0.6)
+                # Wait for initial callback (poll interval is 0.5s)
+                time.sleep(0.55)
 
                 # Append to file to change size
                 with open(temp_file, 'a') as f:
@@ -94,8 +94,8 @@ class TestFileWatcherPolling:
             watcher.start()
 
             try:
-                # Let polling run for a bit
-                time.sleep(0.6)
+                # Let polling run for one cycle (poll interval is 0.5s)
+                time.sleep(0.55)
                 # Should not crash
             finally:
                 watcher.stop()
@@ -113,8 +113,8 @@ class TestFileWatcherPolling:
 
             watcher.stop()
 
-            # Give thread time to terminate
-            time.sleep(0.2)
+            # Give thread time to terminate (daemon thread, should be quick)
+            time.sleep(0.1)
             assert not watcher.polling_thread.is_alive()
 
 
@@ -174,7 +174,7 @@ class TestFileWatcherWatchdog:
 
         try:
             # Modify the file
-            time.sleep(0.2)  # Give observer time to start
+            time.sleep(0.1)  # Give observer time to start
             with open(temp_file, 'a') as f:
                 f.write("new content\n")
 
@@ -286,18 +286,18 @@ class TestFileWatcherIntegration:
             watcher.start()
 
             try:
-                # Wait for initial callback
-                time.sleep(0.6)
+                # Wait for initial callback (poll interval is 0.5s)
+                time.sleep(0.55)
                 initial_count = callback_count[0]
 
                 # Make multiple modifications
                 for i in range(3):
-                    time.sleep(0.6)  # Wait longer than poll interval
+                    time.sleep(0.55)  # Wait longer than poll interval (0.5s)
                     with open(temp_file, 'a') as f:
                         f.write(f"modification {i}\n")
 
-                # Wait for all callbacks
-                time.sleep(1.0)
+                # Wait for final callback
+                time.sleep(0.55)
 
                 # Should have more callbacks than initial
                 assert callback_count[0] > initial_count, "Expected callbacks for modifications"
@@ -313,9 +313,9 @@ class TestFileWatcherIntegration:
 
             # First cycle
             watcher.start()
-            time.sleep(0.2)
+            time.sleep(0.1)
             watcher.stop()
-            time.sleep(0.2)
+            time.sleep(0.1)
 
             # Reset stop event for second cycle
             watcher.stop_event.clear()
@@ -323,7 +323,7 @@ class TestFileWatcherIntegration:
 
             # Second cycle
             watcher.start()
-            time.sleep(0.2)
+            time.sleep(0.1)
             watcher.stop()
 
             # Should not crash


### PR DESCRIPTION
## Summary
- Optimized time.sleep() calls across the test suite to reduce unnecessary waiting
- test_documents.py: Reduced timestamp waits from 0.05s to 0.01s (sufficient for SQLite timestamp resolution)
- test_file_watcher.py: Reduced poll waits from 0.6s to 0.55s, thread termination waits from 0.2s to 0.1s
- test_execution_system_comprehensive.py: Replaced 2s sleep with polling approach (max 2s with 0.2s intervals)

## Test plan
- [x] All 820 tests pass
- [x] 6 tests skipped (expected, related to optional dependencies)
- [x] No new test failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)