### PR TITLE
fix: Auto-fix ruff violations and type annotation fixes

### DIFF
--- a/emdx/applications/maintenance.py
+++ b/emdx/applications/maintenance.py
@@ -12,7 +12,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Union
+from typing import Callable, Union
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,7 @@ class MaintenanceApplication:
         result = app.clean_duplicates(dry_run=False)
     """
 
-    def __init__(self, db_path: Optional[Union[str, Path]] = None):
+    def __init__(self, db_path: Union[str, Path] | None = None):
         """
         Initialize maintenance application with optional database path.
 
@@ -103,10 +103,10 @@ class MaintenanceApplication:
         self._db = DatabaseConnection(self._db_path)
 
         # Lazily initialize services
-        self._duplicate_detector: Optional[DuplicateDetector] = None
-        self._auto_tagger: Optional[AutoTagger] = None
-        self._document_merger: Optional[DocumentMerger] = None
-        self._health_monitor: Optional[HealthMonitor] = None
+        self._duplicate_detector: DuplicateDetector | None = None
+        self._auto_tagger: AutoTagger | None = None
+        self._document_merger: DocumentMerger | None = None
+        self._health_monitor: HealthMonitor | None = None
 
     @property
     def duplicate_detector(self) -> DuplicateDetector:
@@ -338,7 +338,7 @@ class MaintenanceApplication:
 
     def merge_similar(
         self, dry_run: bool = True, threshold: float = 0.7,
-        progress_callback: Optional[callable] = None,
+        progress_callback: Callable | None = None,
         use_tfidf: bool = True,
     ) -> MaintenanceResult:
         """

--- a/emdx/commands/analyze.py
+++ b/emdx/commands/analyze.py
@@ -7,7 +7,7 @@ import json
 
 # Removed CommandDefinition import - using standard typer pattern
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import typer
 from rich import box
@@ -30,7 +30,7 @@ def analyze(
     tags: bool = typer.Option(False, "--tags", "-t", help="Analyze tag coverage and patterns"),
     projects: bool = typer.Option(False, "--projects", "-p", help="Show project-level analysis"),
     all_analyses: bool = typer.Option(False, "--all", "-a", help="Run all analyses"),
-    project: Optional[str] = typer.Option(None, "--project", help="Filter by specific project"),
+    project: str | None = typer.Option(None, "--project", help="Filter by specific project"),
     json_output: bool = typer.Option(False, "--json", help="Output results as JSON"),
 ):
     """
@@ -314,7 +314,7 @@ def _analyze_empty():
     console.print("\n[dim]Run 'emdx maintain --clean' to remove empty documents[/dim]")
 
 
-def _analyze_tags(project: Optional[str] = None):
+def _analyze_tags(project: str | None = None):
     """Analyze tag coverage and patterns."""
     with db_connection.get_connection() as conn:
         cursor = conn.cursor()
@@ -602,7 +602,7 @@ def _collect_empty_data() -> Dict[str, Any]:
     return result
 
 
-def _collect_tags_data(project: Optional[str] = None) -> Dict[str, Any]:
+def _collect_tags_data(project: str | None = None) -> Dict[str, Any]:
     """Collect tag analysis data."""
     with db_connection.get_connection() as conn:
         cursor = conn.cursor()

--- a/emdx/commands/ask.py
+++ b/emdx/commands/ask.py
@@ -2,7 +2,6 @@
 AI-powered Q&A and semantic search commands for EMDX.
 """
 
-from typing import Optional
 
 import typer
 from rich.panel import Panel
@@ -18,7 +17,7 @@ app = typer.Typer(help="AI-powered knowledge base features")
 def ask_question(
     question: str = typer.Argument(..., help="Your question"),
     limit: int = typer.Option(10, "--limit", "-n", help="Max documents to search"),
-    project: Optional[str] = typer.Option(None, "--project", "-p", help="Limit to project"),
+    project: str | None = typer.Option(None, "--project", "-p", help="Limit to project"),
     keyword: bool = typer.Option(False, "--keyword", "-k", help="Force keyword search (no embeddings)"),
     show_sources: bool = typer.Option(True, "--sources/--no-sources", help="Show source documents"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show debug info"),
@@ -61,7 +60,7 @@ def ask_question(
 def get_context(
     question: str = typer.Argument(..., help="Your question"),
     limit: int = typer.Option(10, "--limit", "-n", help="Max documents to retrieve"),
-    project: Optional[str] = typer.Option(None, "--project", "-p", help="Limit to project"),
+    project: str | None = typer.Option(None, "--project", "-p", help="Limit to project"),
     keyword: bool = typer.Option(False, "--keyword", "-k", help="Force keyword search"),
     include_question: bool = typer.Option(True, "--question/--no-question", help="Include question in output"),
 ):
@@ -168,7 +167,7 @@ def semantic_search(
     query: str = typer.Argument(..., help="Search query"),
     limit: int = typer.Option(10, "--limit", "-n", help="Max results"),
     threshold: float = typer.Option(0.3, "--threshold", "-t", help="Minimum similarity (0-1)"),
-    project: Optional[str] = typer.Option(None, "--project", "-p", help="Filter by project"),
+    project: str | None = typer.Option(None, "--project", "-p", help="Filter by project"),
 ):
     """
     Semantic search across your documents.

--- a/emdx/commands/browse.py
+++ b/emdx/commands/browse.py
@@ -2,7 +2,6 @@
 Browse and analytics commands for emdx
 """
 
-from typing import Optional
 
 import typer
 from rich.table import Table
@@ -18,7 +17,7 @@ app = typer.Typer(help="Browse and list documents with statistics")
 
 @app.command()
 def list(
-    project: Optional[str] = typer.Option(None, "--project", "-p", help="Filter by project"),
+    project: str | None = typer.Option(None, "--project", "-p", help="Filter by project"),
     limit: int = typer.Option(50, "--limit", "-n", help="Maximum documents to show"),
     format: str = typer.Option("table", "--format", "-f", help="Output format: table, json, csv"),
 ):
@@ -134,7 +133,7 @@ def recent(
 
 @app.command()
 def stats(
-    project: Optional[str] = typer.Option(
+    project: str | None = typer.Option(
         None, "--project", "-p", help="Show stats for specific project"
     ),
     detailed: bool = typer.Option(False, "--detailed", "-d", help="Show detailed statistics"),

--- a/emdx/commands/cascade.py
+++ b/emdx/commands/cascade.py
@@ -15,7 +15,6 @@ Key concepts:
 import re
 import time
 from datetime import datetime
-from typing import Optional
 
 import typer
 from rich.console import Console
@@ -25,7 +24,7 @@ from ..config.constants import EMDX_LOG_DIR
 from ..database import cascade as cascade_db
 from ..database.connection import db_connection
 from ..database.documents import get_document, save_document
-from ..services.claude_executor import execute_cli_sync, execute_claude_detached
+from ..services.claude_executor import execute_claude_detached, execute_cli_sync
 
 console = Console()
 
@@ -250,7 +249,7 @@ def _process_stage(doc: dict, stage: str, cascade_run_id: int = None) -> tuple[b
 @app.command()
 def add(
     content: str = typer.Argument(..., help="The idea content to add to the cascade"),
-    title: Optional[str] = typer.Option(None, "--title", "-t", help="Document title"),
+    title: str | None = typer.Option(None, "--title", "-t", help="Document title"),
     stage: str = typer.Option("idea", "--stage", "-s", help="Starting stage"),
     auto: bool = typer.Option(False, "--auto", "-a", help="Automatically run through stages"),
     stop: str = typer.Option("done", "--stop", help="Stage to stop at (default: done)"),
@@ -424,7 +423,7 @@ def show(
 @app.command()
 def process(
     stage: str = typer.Argument(..., help="Stage to process"),
-    doc_id: Optional[int] = typer.Option(None, "--doc", "-d", help="Specific document ID"),
+    doc_id: int | None = typer.Option(None, "--doc", "-d", help="Specific document ID"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be processed"),
     sync: bool = typer.Option(True, "--sync/--async", "-s", help="Wait for completion (default: sync)"),
 ):
@@ -570,7 +569,7 @@ def run(
 @app.command()
 def advance(
     doc_id: int = typer.Argument(..., help="Document ID to advance"),
-    to_stage: Optional[str] = typer.Option(None, "--to", help="Target stage (default: next stage)"),
+    to_stage: str | None = typer.Option(None, "--to", help="Target stage (default: next stage)"),
 ):
     """Manually advance a document to the next stage.
 
@@ -630,7 +629,7 @@ def remove(
 @app.command()
 def synthesize(
     stage: str = typer.Argument(..., help="Stage to synthesize from (e.g., 'analyzed')"),
-    title: Optional[str] = typer.Option(None, "--title", "-t", help="Title for synthesized document"),
+    title: str | None = typer.Option(None, "--title", "-t", help="Title for synthesized document"),
     next_stage: str = typer.Option("planned", "--next", "-n", help="Stage for the synthesized doc"),
     keep: bool = typer.Option(False, "--keep", "-k", help="Keep source docs in current stage"),
 ):
@@ -694,7 +693,7 @@ def synthesize(
 @app.command()
 def runs(
     limit: int = typer.Option(10, "--limit", "-n", help="Max runs to show"),
-    status_filter: Optional[str] = typer.Option(None, "--status", "-s", help="Filter by status"),
+    status_filter: str | None = typer.Option(None, "--status", "-s", help="Filter by status"),
 ):
     """Show cascade run history."""
     query = "SELECT id, start_doc_id, start_stage, stop_stage, current_stage, status, pr_url, started_at, completed_at FROM cascade_runs"

--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -9,7 +9,6 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 import typer
 from rich.markdown import Markdown
@@ -48,7 +47,7 @@ class InputContent:
 
     content: str
     source_type: str  # 'stdin', 'file', or 'direct'
-    source_path: Optional[Path] = None
+    source_path: Path | None = None
 
 
 @dataclass
@@ -56,11 +55,11 @@ class DocumentMetadata:
     """Container for document metadata"""
 
     title: str
-    project: Optional[str] = None
-    tags: Optional[list[str]] = None
+    project: str | None = None
+    tags: list[str] | None = None
 
 
-def get_input_content(input_arg: Optional[str]) -> InputContent:
+def get_input_content(input_arg: str | None) -> InputContent:
     """Handle input from stdin, file, or direct text"""
     import sys
 
@@ -96,7 +95,7 @@ def get_input_content(input_arg: Optional[str]) -> InputContent:
         raise typer.Exit(1)
 
 
-def generate_title(input_content: InputContent, provided_title: Optional[str]) -> str:
+def generate_title(input_content: InputContent, provided_title: str | None) -> str:
     """Generate appropriate title based on source and content"""
     if provided_title:
         return provided_title
@@ -116,7 +115,7 @@ def generate_title(input_content: InputContent, provided_title: Optional[str]) -
             return f"Note - {datetime.now().strftime('%Y-%m-%d %H:%M')}"
 
 
-def detect_project(input_content: InputContent, provided_project: Optional[str]) -> Optional[str]:
+def detect_project(input_content: InputContent, provided_project: str | None) -> str | None:
     """Detect project from git repository"""
     if provided_project:
         return provided_project
@@ -135,7 +134,7 @@ def detect_project(input_content: InputContent, provided_project: Optional[str])
     return detected_project
 
 
-def create_document(title: str, content: str, project: Optional[str]) -> int:
+def create_document(title: str, content: str, project: str | None) -> int:
     """Save document to database and return document ID"""
     # Ensure database schema exists
     try:
@@ -153,7 +152,7 @@ def create_document(title: str, content: str, project: Optional[str]) -> int:
         raise typer.Exit(1) from e
 
 
-def apply_tags(doc_id: int, tags_str: Optional[str]) -> list[str]:
+def apply_tags(doc_id: int, tags_str: str | None) -> list[str]:
     """Parse and apply tags to document"""
     if not tags_str:
         return []
@@ -170,7 +169,7 @@ def display_save_result(
     doc_id: int,
     metadata: DocumentMetadata,
     applied_tags: list[str],
-    supersede_target: Optional[dict] = None,
+    supersede_target: dict | None = None,
 ) -> None:
     """Display save result to user"""
     console.print(f"[green]✅ Saved as #{doc_id}:[/green] [cyan]{metadata.title}[/cyan]")
@@ -184,15 +183,15 @@ def display_save_result(
 
 @app.command()
 def save(
-    input: Optional[str] = typer.Argument(
+    input: str | None = typer.Argument(
         None, help="File path or content to save (reads from stdin if not provided)"
     ),
-    title: Optional[str] = typer.Option(None, "--title", "-t", help="Document title"),
-    project: Optional[str] = typer.Option(
+    title: str | None = typer.Option(None, "--title", "-t", help="Document title"),
+    project: str | None = typer.Option(
         None, "--project", "-p", help="Project name (auto-detected from git)"
     ),
-    tags: Optional[str] = typer.Option(None, "--tags", help="Comma-separated tags"),
-    group_id: Optional[int] = typer.Option(
+    tags: str | None = typer.Option(None, "--tags", help="Comma-separated tags"),
+    group_id: int | None = typer.Option(
         None, "--group", "-g",
         help="Add document to group",
         envvar="EMDX_GROUP_ID"
@@ -338,24 +337,24 @@ def save(
 
 @app.command()
 def find(
-    query: Optional[list[str]] = typer.Argument(
+    query: list[str] | None = typer.Argument(
         default=None, help="Search terms (optional if using --tags)"
     ),
-    project: Optional[str] = typer.Option(None, "--project", "-p", help="Filter by project"),
+    project: str | None = typer.Option(None, "--project", "-p", help="Filter by project"),
     limit: int = typer.Option(10, "--limit", "-n", help="Maximum results to return"),
     snippets: bool = typer.Option(False, "--snippets", "-s", help="Show content snippets"),
     fuzzy: bool = typer.Option(False, "--fuzzy", "-f", help="Use fuzzy search"),
-    tags: Optional[str] = typer.Option(
+    tags: str | None = typer.Option(
         None, "--tags", "-t", help="Filter by tags (comma-separated)"
     ),
     any_tags: bool = typer.Option(False, "--any-tags", help="Match ANY tag instead of ALL tags"),
-    no_tags: Optional[str] = typer.Option(None, "--no-tags", help="Exclude documents with these tags"),
+    no_tags: str | None = typer.Option(None, "--no-tags", help="Exclude documents with these tags"),
     ids_only: bool = typer.Option(False, "--ids-only", help="Output only document IDs (for piping)"),
     json_output: bool = typer.Option(False, "--json", help="Output results as JSON"),
-    created_after: Optional[str] = typer.Option(None, "--created-after", help="Show documents created after date (YYYY-MM-DD)"),
-    created_before: Optional[str] = typer.Option(None, "--created-before", help="Show documents created before date (YYYY-MM-DD)"),
-    modified_after: Optional[str] = typer.Option(None, "--modified-after", help="Show documents modified after date (YYYY-MM-DD)"),
-    modified_before: Optional[str] = typer.Option(None, "--modified-before", help="Show documents modified before date (YYYY-MM-DD)"),
+    created_after: str | None = typer.Option(None, "--created-after", help="Show documents created after date (YYYY-MM-DD)"),
+    created_before: str | None = typer.Option(None, "--created-before", help="Show documents created before date (YYYY-MM-DD)"),
+    modified_after: str | None = typer.Option(None, "--modified-after", help="Show documents modified after date (YYYY-MM-DD)"),
+    modified_before: str | None = typer.Option(None, "--modified-before", help="Show documents modified before date (YYYY-MM-DD)"),
 ) -> None:
     """Search the knowledge base with full-text search"""
     search_query = " ".join(query) if query else ""
@@ -643,10 +642,10 @@ def view(
 @app.command()
 def edit(
     identifier: str = typer.Argument(..., help="Document ID or title"),
-    title: Optional[str] = typer.Option(
+    title: str | None = typer.Option(
         None, "--title", "-t", help="Update title without editing content"
     ),
-    editor: Optional[str] = typer.Option(
+    editor: str | None = typer.Option(
         None, "--editor", "-e", help="Editor to use (default: $EDITOR)"
     ),
 ) -> None:

--- a/emdx/commands/executions.py
+++ b/emdx/commands/executions.py
@@ -5,7 +5,6 @@ import subprocess
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
 import typer
 
@@ -311,7 +310,7 @@ def tail(exec_id: int):
 
 
 @app.command(name="kill")
-def kill_execution(exec_id: Optional[int] = typer.Argument(None)):
+def kill_execution(exec_id: int | None = typer.Argument(None)):
     """Kill a running execution and mark it as completed.
 
     If no exec_id provided, shows running executions to choose from.

--- a/emdx/commands/gist.py
+++ b/emdx/commands/gist.py
@@ -6,7 +6,6 @@ import logging
 import os
 import subprocess
 import webbrowser
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +18,7 @@ from emdx.utils.output import console
 app = typer.Typer(help="GitHub Gist integration")
 
 
-def get_github_auth() -> Optional[str]:
+def get_github_auth() -> str | None:
     """Get GitHub authentication token.
 
     SECURITY NOTE: GitHub tokens are sensitive credentials.
@@ -62,7 +61,7 @@ def get_github_auth() -> Optional[str]:
 
 def create_gist_with_gh(
     content: str, filename: str, description: str, public: bool = False
-) -> Optional[dict[str, str]]:
+) -> dict[str, str] | None:
     """Create a gist using gh CLI.
 
     Uses secure temp file handling to prevent race conditions.
@@ -179,10 +178,10 @@ def create(
     identifier: str = typer.Argument(..., help="Document ID or title"),
     public: bool = typer.Option(False, "--public", help="Create public gist"),
     secret: bool = typer.Option(False, "--secret", help="Create secret gist (default)"),
-    description: Optional[str] = typer.Option(None, "--desc", "-d", help="Gist description"),
+    description: str | None = typer.Option(None, "--desc", "-d", help="Gist description"),
     copy_url: bool = typer.Option(False, "--copy", "-c", help="Copy gist URL to clipboard"),
     open_browser: bool = typer.Option(False, "--open", "-o", help="Open gist in browser"),
-    update: Optional[str] = typer.Option(None, "--update", "-u", help="Update existing gist ID"),
+    update: str | None = typer.Option(None, "--update", "-u", help="Update existing gist ID"),
 ):
     """Create or update a GitHub Gist from a document."""
     # Ensure database schema is up to date

--- a/emdx/commands/groups.py
+++ b/emdx/commands/groups.py
@@ -4,7 +4,6 @@ Document groups provide hierarchical organization of related documents
 into batches, rounds, and initiatives.
 """
 
-from typing import Optional
 
 import typer
 from rich.table import Table
@@ -24,13 +23,13 @@ def create(
         "batch", "--type", "-t",
         help="Group type: batch, initiative, round, session, custom"
     ),
-    parent: Optional[int] = typer.Option(
+    parent: int | None = typer.Option(
         None, "--parent", "-p", help="Parent group ID for nesting"
     ),
-    project: Optional[str] = typer.Option(
+    project: str | None = typer.Option(
         None, "--project", help="Associated project name"
     ),
-    description: Optional[str] = typer.Option(
+    description: str | None = typer.Option(
         None, "--description", "-d", help="Group description"
     ),
 ) -> None:
@@ -168,13 +167,13 @@ def remove(
 
 @app.command(name="list")
 def list_groups_cmd(
-    parent: Optional[int] = typer.Option(
+    parent: int | None = typer.Option(
         None, "--parent", "-p", help="Filter by parent group ID (-1 for top-level)"
     ),
-    project: Optional[str] = typer.Option(
+    project: str | None = typer.Option(
         None, "--project", help="Filter by project"
     ),
-    group_type: Optional[str] = typer.Option(
+    group_type: str | None = typer.Option(
         None, "--type", "-t", help="Filter by type"
     ),
     tree: bool = typer.Option(
@@ -236,7 +235,7 @@ def list_groups_cmd(
         raise typer.Exit(1)
 
 
-def _display_groups_tree(project: Optional[str], include_inactive: bool) -> None:
+def _display_groups_tree(project: str | None, include_inactive: bool) -> None:
     """Display groups as a tree structure."""
     # Get top-level groups
     top_groups = groups.list_groups(
@@ -408,10 +407,10 @@ def delete(
 @app.command()
 def edit(
     group_id: int = typer.Argument(..., help="Group ID to edit"),
-    name: Optional[str] = typer.Option(None, "--name", "-n", help="New name"),
-    description: Optional[str] = typer.Option(None, "--description", "-d", help="New description"),
-    parent: Optional[int] = typer.Option(None, "--parent", "-p", help="New parent group ID (0 to remove)"),
-    group_type: Optional[str] = typer.Option(None, "--type", "-t", help="New group type"),
+    name: str | None = typer.Option(None, "--name", "-n", help="New name"),
+    description: str | None = typer.Option(None, "--description", "-d", help="New description"),
+    parent: int | None = typer.Option(None, "--parent", "-p", help="New parent group ID (0 to remove)"),
+    group_type: str | None = typer.Option(None, "--type", "-t", help="New group type"),
 ) -> None:
     """Edit group properties."""
     try:

--- a/emdx/commands/maintain.py
+++ b/emdx/commands/maintain.py
@@ -13,7 +13,7 @@ import time
 # Removed CommandDefinition import - using standard typer pattern
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import typer
 
@@ -259,7 +259,7 @@ def _interactive_wizard(dry_run: bool):
         console.print()
 
 
-def _clean_documents(dry_run: bool) -> Optional[str]:
+def _clean_documents(dry_run: bool) -> str | None:
     """Clean duplicates and empty documents using MaintenanceApplication."""
     app = MaintenanceApplication()
     try:
@@ -283,7 +283,7 @@ def _clean_documents(dry_run: bool) -> Optional[str]:
     return result.message
 
 
-def _auto_tag_documents(dry_run: bool) -> Optional[str]:
+def _auto_tag_documents(dry_run: bool) -> str | None:
     """Auto-tag untagged documents using MaintenanceApplication."""
     app = MaintenanceApplication()
     result = app.auto_tag_documents(dry_run=dry_run)
@@ -306,7 +306,7 @@ def _auto_tag_documents(dry_run: bool) -> Optional[str]:
     return result.message
 
 
-def _merge_documents(dry_run: bool, threshold: float = 0.7) -> Optional[str]:
+def _merge_documents(dry_run: bool, threshold: float = 0.7) -> str | None:
     """Merge similar documents using MaintenanceApplication."""
     app = MaintenanceApplication()
     try:
@@ -333,7 +333,7 @@ def _merge_documents(dry_run: bool, threshold: float = 0.7) -> Optional[str]:
     return result.message
 
 
-def _deduplicate_pairs(pairs: list) -> Optional[str]:
+def _deduplicate_pairs(pairs: list) -> str | None:
     """Delete duplicate documents from similarity pairs.
 
     For each pair, keeps the document with more views (or longer content as tiebreaker)
@@ -379,7 +379,7 @@ def _deduplicate_pairs(pairs: list) -> Optional[str]:
     return f"Deleted {deleted_count} duplicates"
 
 
-def _garbage_collect(dry_run: bool) -> Optional[str]:
+def _garbage_collect(dry_run: bool) -> str | None:
     """Run garbage collection using MaintenanceApplication."""
     app = MaintenanceApplication()
     result = app.garbage_collect(dry_run=dry_run)
@@ -479,7 +479,7 @@ def cleanup_main(
         console.print("\n[dim]Run with --execute to perform these actions[/dim]")
 
 
-def _cleanup_branches(dry_run: bool, force: bool = False, older_than_days: int = 7) -> Optional[str]:
+def _cleanup_branches(dry_run: bool, force: bool = False, older_than_days: int = 7) -> str | None:
     """Clean up old execution branches.
 
     Args:
@@ -642,7 +642,7 @@ def _cleanup_branches(dry_run: bool, force: bool = False, older_than_days: int =
         return None
 
 
-def _cleanup_processes(dry_run: bool, max_runtime_hours: int = 2) -> Optional[str]:
+def _cleanup_processes(dry_run: bool, max_runtime_hours: int = 2) -> str | None:
     """Clean up zombie and stuck EMDX processes.
 
     Args:
@@ -795,7 +795,7 @@ def _cleanup_processes(dry_run: bool, max_runtime_hours: int = 2) -> Optional[st
     return f"Terminated {total_removed} processes" if total_removed > 0 else None
 
 
-def _cleanup_executions(dry_run: bool, timeout_minutes: int = 30, check_heartbeat: bool = True) -> Optional[str]:
+def _cleanup_executions(dry_run: bool, timeout_minutes: int = 30, check_heartbeat: bool = True) -> str | None:
     """Clean up stuck executions in the database.
 
     Args:

--- a/emdx/commands/prime.py
+++ b/emdx/commands/prime.py
@@ -6,7 +6,6 @@ It outputs priming context that should be injected at session start.
 """
 
 from datetime import datetime
-from typing import Optional
 
 import typer
 from rich.console import Console
@@ -136,7 +135,7 @@ def _get_execution_methods_json() -> list[dict]:
     ]
 
 
-def _output_text(project: Optional[str], verbose: bool, quiet: bool, markdown: bool, execution: bool):
+def _output_text(project: str | None, verbose: bool, quiet: bool, markdown: bool, execution: bool):
     """Output priming context as text."""
 
     lines = []
@@ -229,7 +228,7 @@ def _output_text(project: Optional[str], verbose: bool, quiet: bool, markdown: b
     print("\n".join(lines))
 
 
-def _output_json(project: Optional[str], verbose: bool, quiet: bool, execution: bool):
+def _output_json(project: str | None, verbose: bool, quiet: bool, execution: bool):
     """Output priming context as JSON."""
     import json
 
@@ -314,7 +313,7 @@ def _get_recent_docs() -> list:
 def _get_cascade_status() -> dict:
     """Get cascade queue status by stage."""
     stages = ["idea", "prompt", "analyzed", "planned", "done"]
-    status = {stage: 0 for stage in stages}
+    status = dict.fromkeys(stages, 0)
 
     try:
         with db.get_connection() as conn:

--- a/emdx/commands/recipe.py
+++ b/emdx/commands/recipe.py
@@ -10,7 +10,7 @@ instructions for Claude to follow via `emdx delegate`.
 
 import subprocess
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import typer
 
@@ -22,7 +22,7 @@ from ..utils.output import console
 app = typer.Typer(help="Manage and run EMDX recipes")
 
 
-def _find_recipe(id_or_name: str) -> Optional[dict]:
+def _find_recipe(id_or_name: str) -> dict | None:
     """Find a recipe by ID or title search."""
     # Try as numeric ID first
     try:
@@ -82,13 +82,13 @@ def list_recipes():
 @app.command("run")
 def run_recipe(
     id_or_name: str = typer.Argument(..., help="Recipe ID or title search"),
-    extra: Optional[List[str]] = typer.Argument(
+    extra: List[str] | None = typer.Argument(
         None, help="Extra arguments passed to the recipe"
     ),
     quiet: bool = typer.Option(
         False, "--quiet", "-q", help="Suppress metadata on stderr"
     ),
-    model: Optional[str] = typer.Option(
+    model: str | None = typer.Option(
         None, "--model", "-m", help="Model to use"
     ),
     pr: bool = typer.Option(
@@ -144,7 +144,7 @@ def run_recipe(
 @app.command("create")
 def create_recipe(
     file: str = typer.Argument(..., help="Markdown file to save as a recipe"),
-    title: Optional[str] = typer.Option(
+    title: str | None = typer.Option(
         None, "--title", "-T", help="Custom title (default: filename)"
     ),
 ):

--- a/emdx/commands/status.py
+++ b/emdx/commands/status.py
@@ -9,7 +9,6 @@ Provides a quick overview of:
 """
 
 from datetime import datetime, timedelta
-from typing import Optional
 
 import typer
 from rich.console import Console
@@ -25,7 +24,7 @@ from ..models.tasks import (
 console = Console()
 
 
-def _parse_timestamp(value) -> Optional[datetime]:
+def _parse_timestamp(value) -> datetime | None:
     """Parse a timestamp that may be a datetime, string, or None."""
     if value is None:
         return None

--- a/emdx/commands/tags.py
+++ b/emdx/commands/tags.py
@@ -6,7 +6,6 @@ works as a shorthand for `emdx tag add 42 gameplan`.
 """
 
 
-from typing import Optional
 
 import typer
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -32,7 +31,7 @@ app = typer.Typer(help="Manage document tags")
 
 def _add_tags_impl(
     doc_id: int,
-    tags: Optional[list[str]],
+    tags: list[str] | None,
     auto: bool,
     suggest: bool,
 ):
@@ -134,7 +133,7 @@ def tag_callback():
 @app.command()
 def add(
     doc_id: int = typer.Argument(..., help="Document ID to tag"),
-    tags: Optional[list[str]] = typer.Argument(None, help="Tags to add (space-separated)"),
+    tags: list[str] | None = typer.Argument(None, help="Tags to add (space-separated)"),
     auto: bool = typer.Option(False, "--auto", "-a", help="Apply high-confidence auto-tags"),
     suggest: bool = typer.Option(False, "--suggest", "-s", help="Show tag suggestions"),
 ):
@@ -322,11 +321,11 @@ def merge(
 @app.command()
 def batch(
     untagged_only: bool = typer.Option(True, "--untagged/--all", help="Only process untagged documents"),
-    project: Optional[str] = typer.Option(None, "--project", "-p", help="Filter by project"),
+    project: str | None = typer.Option(None, "--project", "-p", help="Filter by project"),
     confidence: float = typer.Option(0.7, "--confidence", "-c", help="Minimum confidence threshold"),
     max_tags: int = typer.Option(3, "--max-tags", "-m", help="Maximum tags per document"),
     dry_run: bool = typer.Option(True, "--dry-run/--execute", help="Execute tagging (default: dry run only)"),
-    limit: Optional[int] = typer.Option(None, "--limit", "-l", help="Maximum documents to process"),
+    limit: int | None = typer.Option(None, "--limit", "-l", help="Maximum documents to process"),
 ):
     """Batch auto-tag multiple documents."""
     try:

--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -4,7 +4,6 @@ Agent-facing commands for creating and consuming work items.
 Delegate activity tracking is separate (shown via `emdx status`).
 """
 
-from typing import Optional
 
 import typer
 from rich.table import Table
@@ -20,8 +19,8 @@ ICONS = {"open": "○", "active": "●", "done": "✓", "failed": "✗"}
 @app.command()
 def add(
     title: str = typer.Argument(..., help="Task title"),
-    doc: Optional[int] = typer.Option(None, "-d", "--doc", help="Link to document ID"),
-    description: Optional[str] = typer.Option(None, "-D", "--description", help="Task description"),
+    doc: int | None = typer.Option(None, "-d", "--doc", help="Link to document ID"),
+    description: str | None = typer.Option(None, "-D", "--description", help="Task description"),
 ):
     """Add a task to the work queue.
 
@@ -66,7 +65,7 @@ def ready():
 @app.command()
 def done(
     task_id: int = typer.Argument(..., help="Task ID"),
-    note: Optional[str] = typer.Option(None, "-n", "--note", help="Completion note"),
+    note: str | None = typer.Option(None, "-n", "--note", help="Completion note"),
 ):
     """Mark a task as done.
 
@@ -89,7 +88,7 @@ def done(
 
 @app.command("list")
 def list_cmd(
-    status: Optional[str] = typer.Option(None, "-s", "--status", help="Filter by status (comma-sep)"),
+    status: str | None = typer.Option(None, "-s", "--status", help="Filter by status (comma-sep)"),
     all: bool = typer.Option(False, "--all", "-a", help="Include delegate tasks"),
     limit: int = typer.Option(20, "-n", "--limit"),
 ):

--- a/emdx/commands/trash.py
+++ b/emdx/commands/trash.py
@@ -8,7 +8,6 @@ Consolidates trash, restore, and purge into a subcommand group:
     emdx trash purge     → permanently delete trash
 """
 
-from typing import Optional
 
 import typer
 from rich.table import Table
@@ -27,7 +26,7 @@ app = typer.Typer(help="Manage deleted documents (trash)")
 @app.callback(invoke_without_command=True)
 def trash_callback(
     ctx: typer.Context,
-    days: Optional[int] = typer.Option(
+    days: int | None = typer.Option(
         None, "--days", "-d", help="Show items deleted in last N days"
     ),
     limit: int = typer.Option(50, "--limit", "-n", help="Maximum results to return"),
@@ -41,7 +40,7 @@ def trash_callback(
 
 @app.command("list")
 def list_cmd(
-    days: Optional[int] = typer.Option(
+    days: int | None = typer.Option(
         None, "--days", "-d", help="Show items deleted in last N days"
     ),
     limit: int = typer.Option(50, "--limit", "-n", help="Maximum results to return"),
@@ -50,7 +49,7 @@ def list_cmd(
     _list_trash(days=days, limit=limit)
 
 
-def _list_trash(days: Optional[int] = None, limit: int = 50) -> None:
+def _list_trash(days: int | None = None, limit: int = 50) -> None:
     """Shared implementation for listing trash."""
     try:
         db.ensure_schema()
@@ -96,7 +95,7 @@ def _list_trash(days: Optional[int] = None, limit: int = 50) -> None:
 
 @app.command()
 def restore(
-    identifiers: Optional[list[str]] = typer.Argument(
+    identifiers: list[str] | None = typer.Argument(
         default=None, help="Document ID(s) or title(s) to restore"
     ),
     all: bool = typer.Option(False, "--all", help="Restore all deleted documents"),
@@ -154,7 +153,7 @@ def restore(
 
 @app.command()
 def purge(
-    older_than: Optional[int] = typer.Option(
+    older_than: int | None = typer.Option(
         None, "--older-than", help="Only purge items deleted more than N days ago"
     ),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),

--- a/emdx/config/cli_config.py
+++ b/emdx/config/cli_config.py
@@ -7,7 +7,7 @@ that can be used to execute agent tasks.
 import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 # Default tools allowed for Claude CLI execution
 # These are the standard tools that most agents need for basic operations
@@ -55,15 +55,15 @@ class CliConfig:
 
     # Tool control
     supports_allowed_tools: bool  # Claude has --allowedTools
-    allowed_tools_flag: Optional[str]  # "--allowedTools"
-    force_flag: Optional[str]  # Cursor uses "--force"
+    allowed_tools_flag: str | None  # "--allowedTools"
+    force_flag: str | None  # Cursor uses "--force"
 
     # Workspace
-    workspace_flag: Optional[str]  # Cursor has "--workspace"
+    workspace_flag: str | None  # Cursor has "--workspace"
 
     # Environment
-    config_path: Optional[str]  # Path to CLI config file
-    api_key_env: Optional[str]  # Environment variable for API key
+    config_path: str | None  # Path to CLI config file
+    api_key_env: str | None  # Environment variable for API key
 
 
 # CLI configurations
@@ -136,7 +136,7 @@ def get_default_cli_tool() -> CliTool:
         return CliTool.CLAUDE
 
 
-def get_cli_config(cli_tool: Optional[CliTool] = None) -> CliConfig:
+def get_cli_config(cli_tool: CliTool | None = None) -> CliConfig:
     """Get configuration for a CLI tool.
 
     Args:

--- a/emdx/config/tagging_rules.py
+++ b/emdx/config/tagging_rules.py
@@ -6,7 +6,7 @@ Allows users to define custom patterns for auto-tagging.
 import logging
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import yaml
 
@@ -40,7 +40,7 @@ class TaggingConfig:
 
     DEFAULT_CONFIG_PATH = str(EMDX_CONFIG_DIR / "tagging.yaml")
 
-    def __init__(self, config_path: Optional[str] = None):
+    def __init__(self, config_path: str | None = None):
         self.config_path = Path(config_path or self.DEFAULT_CONFIG_PATH).expanduser()
         self.rules: Dict[str, TaggingRule] = {}
         self.load_config()
@@ -134,7 +134,7 @@ class TaggingConfig:
             return True
         return False
 
-    def get_rule(self, name: str) -> Optional[TaggingRule]:
+    def get_rule(self, name: str) -> TaggingRule | None:
         """Get a specific rule by name."""
         return self.rules.get(name)
 

--- a/emdx/database/cascade.py
+++ b/emdx/database/cascade.py
@@ -227,7 +227,7 @@ def get_cascade_stats() -> dict[str, int]:
             GROUP BY cm.stage
             """
         )
-        results = {stage: 0 for stage in STAGES}
+        results = dict.fromkeys(STAGES, 0)
         for row in cursor.fetchall():
             results[row["stage"]] = row["count"]
         return results

--- a/emdx/database/connection.py
+++ b/emdx/database/connection.py
@@ -7,7 +7,6 @@ import sqlite3
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 from ..config.constants import EMDX_CONFIG_DIR
 from . import migrations
@@ -30,7 +29,7 @@ def get_db_path() -> Path:
 class DatabaseConnection:
     """SQLite database connection manager for emdx"""
 
-    def __init__(self, db_path: Optional[Path] = None):
+    def __init__(self, db_path: Path | None = None):
         if db_path is None:
             self.db_path = get_db_path()
         else:

--- a/emdx/database/documents.py
+++ b/emdx/database/documents.py
@@ -3,7 +3,7 @@ Document CRUD operations for emdx knowledge base
 """
 
 import logging
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 from ..utils.datetime_utils import parse_datetime
 from .connection import db_connection
@@ -24,9 +24,9 @@ def _parse_doc_datetimes(doc: dict[str, Any], fields: list[str] | None = None) -
 def save_document(
     title: str,
     content: str,
-    project: Optional[str] = None,
-    tags: Optional[list[str]] = None,
-    parent_id: Optional[int] = None,
+    project: str | None = None,
+    tags: list[str] | None = None,
+    parent_id: int | None = None,
 ) -> int:
     """Save a document to the knowledge base"""
     with db_connection.get_connection() as conn:
@@ -49,7 +49,7 @@ def save_document(
         return doc_id
 
 
-def get_document(identifier: Union[str, int]) -> Optional[dict[str, Any]]:
+def get_document(identifier: Union[str, int]) -> dict[str, Any] | None:
     """Get a document by ID or title"""
     with db_connection.get_connection() as conn:
         # Convert to string for consistent handling
@@ -102,9 +102,9 @@ def get_document(identifier: Union[str, int]) -> Optional[dict[str, Any]]:
 
 
 def list_documents(
-    project: Optional[str] = None,
+    project: str | None = None,
     limit: int = 50,
-    parent_id: Optional[int] = None,
+    parent_id: int | None = None,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
     """List documents with optional project and hierarchy filters.
@@ -165,8 +165,8 @@ def list_documents(
 
 
 def count_documents(
-    project: Optional[str] = None,
-    parent_id: Optional[int] = None,
+    project: str | None = None,
+    parent_id: int | None = None,
 ) -> int:
     """Count documents with optional project and hierarchy filters.
 
@@ -244,7 +244,7 @@ def get_children_count(
             list(doc_ids),
         )
 
-        result = {doc_id: 0 for doc_id in doc_ids}
+        result = dict.fromkeys(doc_ids, 0)
         for row in cursor.fetchall():
             result[row["parent_id"]] = row["child_count"]
         return result
@@ -335,7 +335,7 @@ def get_recent_documents(limit: int = 10) -> list[dict[str, Any]]:
         return docs
 
 
-def get_stats(project: Optional[str] = None) -> dict[str, Any]:
+def get_stats(project: str | None = None) -> dict[str, Any]:
     """Get database statistics"""
     with db_connection.get_connection() as conn:
         if project:
@@ -404,7 +404,7 @@ def get_stats(project: Optional[str] = None) -> dict[str, Any]:
         return stats
 
 
-def list_deleted_documents(days: Optional[int] = None, limit: int = 50) -> list[dict[str, Any]]:
+def list_deleted_documents(days: int | None = None, limit: int = 50) -> list[dict[str, Any]]:
     """List soft-deleted documents"""
     with db_connection.get_connection() as conn:
         if days:
@@ -467,7 +467,7 @@ def restore_document(identifier: Union[str, int]) -> bool:
         return cursor.rowcount > 0
 
 
-def purge_deleted_documents(older_than_days: Optional[int] = None) -> int:
+def purge_deleted_documents(older_than_days: int | None = None) -> int:
     """Permanently delete soft-deleted documents"""
     with db_connection.get_connection() as conn:
         if older_than_days:
@@ -493,11 +493,11 @@ def purge_deleted_documents(older_than_days: Optional[int] = None) -> int:
 
 def find_supersede_candidate(
     title: str,
-    project: Optional[str] = None,
+    project: str | None = None,
     title_threshold: float = 0.85,
-    content: Optional[str] = None,
+    content: str | None = None,
     content_threshold: float = 0.5,
-) -> Optional[dict[str, Any]]:
+) -> dict[str, Any] | None:
     """Find a document that should be superseded by a new document with the given title.
 
     Uses title normalization and optional content similarity to find the best candidate.

--- a/emdx/database/migrations.py
+++ b/emdx/database/migrations.py
@@ -1,8 +1,8 @@
 """Database migration system for emdx."""
 
 import sqlite3
+from collections.abc import Callable
 from contextlib import contextmanager
-from typing import Callable
 
 from ..config.settings import get_db_path
 

--- a/emdx/database/search.py
+++ b/emdx/database/search.py
@@ -2,7 +2,7 @@
 Search functionality for emdx documents using FTS5
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from ..utils.datetime_utils import parse_datetime
 from .connection import db_connection
@@ -39,13 +39,13 @@ def escape_fts5_query(query: str) -> str:
 
 def search_documents(
     query: str,
-    project: Optional[str] = None,
+    project: str | None = None,
     limit: int = 10,
     fuzzy: bool = False,
-    created_after: Optional[str] = None,
-    created_before: Optional[str] = None,
-    modified_after: Optional[str] = None,
-    modified_before: Optional[str] = None
+    created_after: str | None = None,
+    created_before: str | None = None,
+    modified_after: str | None = None,
+    modified_before: str | None = None
 ) -> list[dict[str, Any]]:
     """Search documents using FTS5
 

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -9,7 +9,6 @@ actually invoked.
 """
 
 import os
-from typing import Optional
 
 import typer
 
@@ -188,7 +187,7 @@ def main(
     version: bool = typer.Option(False, "--version", "-V", help="Show version and exit"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output"),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress non-error output"),
-    db_url: Optional[str] = typer.Option(
+    db_url: str | None = typer.Option(
         None, "--db-url", envvar="EMDX_DATABASE_URL", help="Database connection URL"
     ),
     safe_mode: bool = typer.Option(

--- a/emdx/models/executions.py
+++ b/emdx/models/executions.py
@@ -4,7 +4,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 from ..database.connection import db_connection
 from ..utils.datetime_utils import parse_timestamp
@@ -14,18 +14,18 @@ from ..utils.datetime_utils import parse_timestamp
 class Execution:
     """Represents a Claude execution."""
     id: int  # Now numeric auto-incrementing ID
-    doc_id: Optional[int]  # Can be None for standalone delegate executions
+    doc_id: int | None  # Can be None for standalone delegate executions
     doc_title: str
     status: str  # 'running', 'completed', 'failed'
     started_at: datetime
-    completed_at: Optional[datetime] = None
+    completed_at: datetime | None = None
     log_file: str = ""
-    exit_code: Optional[int] = None
-    working_dir: Optional[str] = None
-    pid: Optional[int] = None
+    exit_code: int | None = None
+    working_dir: str | None = None
+    pid: int | None = None
 
     @property
-    def duration(self) -> Optional[float]:
+    def duration(self) -> float | None:
         """Get execution duration in seconds."""
         if self.completed_at:
             return (self.completed_at - self.started_at).total_seconds()
@@ -59,8 +59,8 @@ class Execution:
         return Path(self.log_file).expanduser()
 
 
-def create_execution(doc_id: Optional[int], doc_title: str, log_file: str,
-                    working_dir: Optional[str] = None, pid: Optional[int] = None) -> int:
+def create_execution(doc_id: int | None, doc_title: str, log_file: str,
+                    working_dir: str | None = None, pid: int | None = None) -> int:
     """Create a new execution and return its ID.
 
     Args:
@@ -84,7 +84,7 @@ def create_execution(doc_id: Optional[int], doc_title: str, log_file: str,
         return cursor.lastrowid
 
 
-def get_execution(exec_id: int) -> Optional[Execution]:
+def get_execution(exec_id: int) -> Execution | None:
     """Get execution by ID."""
     with db_connection.get_connection() as conn:
         cursor = conn.cursor()
@@ -181,7 +181,7 @@ def get_running_executions() -> List[Execution]:
         return executions
 
 
-def update_execution_status(exec_id: int, status: str, exit_code: Optional[int] = None) -> None:
+def update_execution_status(exec_id: int, status: str, exit_code: int | None = None) -> None:
     """Update execution status and completion time."""
     with db_connection.get_connection() as conn:
         if status in ['completed', 'failed']:

--- a/emdx/models/tags.py
+++ b/emdx/models/tags.py
@@ -1,7 +1,7 @@
 """Tag management operations for emdx."""
 
 import sqlite3
-from typing import Any, Optional
+from typing import Any
 
 from emdx.database import db
 from emdx.utils.datetime_utils import parse_datetime
@@ -224,7 +224,7 @@ def list_all_tags(sort_by: str = "usage") -> list[dict[str, Any]]:
 
 
 def search_by_tags(
-    tag_names: list[str], mode: str = "all", project: Optional[str] = None, limit: int = 20,
+    tag_names: list[str], mode: str = "all", project: str | None = None, limit: int = 20,
     prefix_match: bool = True
 ) -> list[dict[str, Any]]:
     """Search documents by tags.

--- a/emdx/models/tasks.py
+++ b/emdx/models/tasks.py
@@ -1,7 +1,7 @@
 """Task operations for emdx."""
 
 import sqlite3
-from typing import Any, Optional
+from typing import Any
 
 from emdx.config.constants import (
     DEFAULT_BROWSE_LIMIT,
@@ -18,19 +18,19 @@ def create_task(
     title: str,
     description: str = "",
     priority: int = DEFAULT_TASK_PRIORITY,
-    gameplan_id: Optional[int] = None,
-    project: Optional[str] = None,
-    depends_on: Optional[list[int]] = None,
+    gameplan_id: int | None = None,
+    project: str | None = None,
+    depends_on: list[int] | None = None,
     # Delegate activity tracking fields
-    prompt: Optional[str] = None,
+    prompt: str | None = None,
     task_type: str = "single",
-    execution_id: Optional[int] = None,
-    output_doc_id: Optional[int] = None,
-    source_doc_id: Optional[int] = None,
-    parent_task_id: Optional[int] = None,
-    seq: Optional[int] = None,
-    retry_of: Optional[int] = None,
-    tags: Optional[str] = None,
+    execution_id: int | None = None,
+    output_doc_id: int | None = None,
+    source_doc_id: int | None = None,
+    parent_task_id: int | None = None,
+    seq: int | None = None,
+    retry_of: int | None = None,
+    tags: str | None = None,
     status: str = "open",
 ) -> int:
     """Create task and return its ID."""
@@ -60,7 +60,7 @@ def create_task(
         return task_id
 
 
-def get_task(task_id: int) -> Optional[dict[str, Any]]:
+def get_task(task_id: int) -> dict[str, Any] | None:
     """Get task by ID."""
     with db.get_connection() as conn:
         cursor = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,))
@@ -69,9 +69,9 @@ def get_task(task_id: int) -> Optional[dict[str, Any]]:
 
 
 def list_tasks(
-    status: Optional[list[str]] = None,
-    gameplan_id: Optional[int] = None,
-    project: Optional[str] = None,
+    status: list[str] | None = None,
+    gameplan_id: int | None = None,
+    project: str | None = None,
     limit: int = DEFAULT_BROWSE_LIMIT,
     exclude_delegate: bool = False,
 ) -> list[dict[str, Any]]:
@@ -160,7 +160,7 @@ def get_dependents(task_id: int) -> list[dict[str, Any]]:
         return [dict(row) for row in cursor.fetchall()]
 
 
-def get_ready_tasks(gameplan_id: Optional[int] = None, exclude_delegate: bool = True) -> list[dict[str, Any]]:
+def get_ready_tasks(gameplan_id: int | None = None, exclude_delegate: bool = True) -> list[dict[str, Any]]:
     """Get tasks ready to work (open + all deps done).
 
     Args:

--- a/emdx/prompts/__init__.py
+++ b/emdx/prompts/__init__.py
@@ -12,7 +12,7 @@ def load_prompt_template(template_name: str) -> str:
     return template_path.read_text()
 
 
-def build_prompt(template_name: Optional[str], content: str) -> str:
+def build_prompt(template_name: str | None, content: str) -> str:
     """Build a prompt from template and content."""
     if not template_name:
         return content

--- a/emdx/services/ask_service.py
+++ b/emdx/services/ask_service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 try:
     import anthropic
@@ -41,7 +41,7 @@ class AskService:
     DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
     MIN_EMBEDDINGS_FOR_SEMANTIC = 50  # Use semantic only if we have enough coverage
 
-    def __init__(self, model: Optional[str] = None):
+    def __init__(self, model: str | None = None):
         self.model = model or self.DEFAULT_MODEL
         self._client = None
         self._embedding_service = None
@@ -86,7 +86,7 @@ class AskService:
         self,
         question: str,
         limit: int = 10,
-        project: Optional[str] = None,
+        project: str | None = None,
         force_keyword: bool = False,
     ) -> Answer:
         """
@@ -112,7 +112,7 @@ class AskService:
         )
 
     def _retrieve_keyword(
-        self, question: str, limit: int, project: Optional[str] = None
+        self, question: str, limit: int, project: str | None = None
     ) -> Tuple[List[tuple], str]:
         """Retrieve documents using FTS keyword search."""
         docs = []
@@ -208,7 +208,7 @@ class AskService:
         return docs[:limit], "keyword"
 
     def _retrieve_semantic(
-        self, question: str, limit: int, project: Optional[str] = None
+        self, question: str, limit: int, project: str | None = None
     ) -> Tuple[List[tuple], str]:
         """Retrieve documents using semantic (embedding) search."""
         embedding_service = self._get_embedding_service()
@@ -304,7 +304,7 @@ Rules:
         question: str,
         additional_context: str,
         limit: int = 5,
-        project: Optional[str] = None,
+        project: str | None = None,
     ) -> Answer:
         """
         Ask a question with additional context (e.g., from external resources).

--- a/emdx/services/auto_tagger.py
+++ b/emdx/services/auto_tagger.py
@@ -6,7 +6,7 @@ Analyzes document content and suggests appropriate tags based on patterns.
 import re
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 # Type alias for SQL parameters
 SqlParam = Union[str, int, float, None]
@@ -103,8 +103,8 @@ class AutoTagger:
 
     def __init__(
         self,
-        db_path: Optional[Union[str, Path]] = None,
-        patterns: Optional[Dict] = None,
+        db_path: Union[str, Path] | None = None,
+        patterns: Dict | None = None,
     ):
         # Use centralized database connection management
         if db_path is not None:
@@ -124,8 +124,8 @@ class AutoTagger:
     def analyze_document(
         self,
         title: str,
-        content: Optional[str] = None,
-        existing_tags: Optional[List[str]] = None
+        content: str | None = None,
+        existing_tags: List[str] | None = None
     ) -> List[Tuple[str, float]]:
         """
         Analyze a document and suggest tags with confidence scores.
@@ -279,8 +279,8 @@ class AutoTagger:
     def batch_suggest(
         self,
         untagged_only: bool = True,
-        project: Optional[str] = None,
-        limit: Optional[int] = None,
+        project: str | None = None,
+        limit: int | None = None,
     ) -> Dict[int, List[Tuple[str, float]]]:
         """
         Suggest tags for multiple documents.
@@ -338,9 +338,9 @@ class AutoTagger:
 
     def batch_auto_tag(
         self,
-        document_ids: Optional[List[int]] = None,
+        document_ids: List[int] | None = None,
         untagged_only: bool = True,
-        project: Optional[str] = None,
+        project: str | None = None,
         confidence_threshold: float = DEFAULT_TAGGING_CONFIDENCE,
         max_tags_per_doc: int = DEFAULT_MAX_TAGS_PER_DOC,
         dry_run: bool = True
@@ -436,8 +436,8 @@ class AutoTagger:
     def add_custom_pattern(
         self,
         name: str,
-        title_patterns: Optional[List[str]] = None,
-        content_patterns: Optional[List[str]] = None,
+        title_patterns: List[str] | None = None,
+        content_patterns: List[str] | None = None,
         tags: List[str] = None,
         confidence: float = DEFAULT_TAGGING_CONFIDENCE
     ):

--- a/emdx/services/cascade_service.py
+++ b/emdx/services/cascade_service.py
@@ -8,8 +8,9 @@ import json
 import logging
 import os
 import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Dict, List
+from typing import Any, Dict, List
 
 from emdx.database import cascade as cascade_db
 from emdx.database.connection import db_connection

--- a/emdx/services/claude_executor.py
+++ b/emdx/services/claude_executor.py
@@ -17,7 +17,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -65,11 +65,11 @@ def execute_claude_detached(
     task: str,
     execution_id: int,
     log_file: Path,
-    allowed_tools: Optional[List[str]] = None,
-    working_dir: Optional[str] = None,
-    doc_id: Optional[str] = None,
+    allowed_tools: List[str] | None = None,
+    working_dir: str | None = None,
+    doc_id: str | None = None,
     cli_tool: str = "claude",
-    model: Optional[str] = None,
+    model: str | None = None,
 ) -> int:
     """Execute a task with a CLI tool in a fully detached background process.
 
@@ -224,10 +224,10 @@ def execute_cli_sync(
     execution_id: int,
     log_file: Path,
     cli_tool: str = "claude",
-    model: Optional[str] = None,
-    allowed_tools: Optional[List[str]] = None,
-    working_dir: Optional[str] = None,
-    doc_id: Optional[str] = None,
+    model: str | None = None,
+    allowed_tools: List[str] | None = None,
+    working_dir: str | None = None,
+    doc_id: str | None = None,
     timeout: int = 300,
 ) -> dict:
     """Execute a task with specified CLI tool synchronously, waiting for completion.

--- a/emdx/services/cli_executor/base.py
+++ b/emdx/services/cli_executor/base.py
@@ -5,7 +5,7 @@ This module defines the abstract interface that all CLI executors must implement
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 
 @dataclass
@@ -14,7 +14,7 @@ class CliCommand:
 
     args: List[str]  # Command arguments
     env: Dict[str, str] = field(default_factory=dict)  # Additional env vars
-    cwd: Optional[str] = None  # Working directory
+    cwd: str | None = None  # Working directory
 
 
 @dataclass
@@ -23,7 +23,7 @@ class CliResult:
 
     success: bool
     output: str
-    error: Optional[str] = None
+    error: str | None = None
     exit_code: int = 0
 
     # Token usage (may be unavailable for some CLIs)
@@ -40,7 +40,7 @@ class CliResult:
     duration_api_ms: int = 0
 
     # Session tracking
-    session_id: Optional[str] = None
+    session_id: str | None = None
 
     @property
     def total_tokens(self) -> int:
@@ -70,11 +70,11 @@ class CliExecutor(ABC):
     def build_command(
         self,
         prompt: str,
-        model: Optional[str] = None,
-        allowed_tools: Optional[List[str]] = None,
+        model: str | None = None,
+        allowed_tools: List[str] | None = None,
         output_format: str = "stream-json",
-        working_dir: Optional[str] = None,
-        timeout: Optional[int] = None,
+        working_dir: str | None = None,
+        timeout: int | None = None,
     ) -> CliCommand:
         """Build the CLI command to execute.
 
@@ -111,7 +111,7 @@ class CliExecutor(ABC):
         pass
 
     @abstractmethod
-    def parse_stream_line(self, line: str) -> Optional[Dict[str, Any]]:
+    def parse_stream_line(self, line: str) -> Dict[str, Any] | None:
         """Parse a single line from stream-json output.
 
         Args:
@@ -132,7 +132,7 @@ class CliExecutor(ABC):
         pass
 
     @abstractmethod
-    def get_binary_path(self) -> Optional[str]:
+    def get_binary_path(self) -> str | None:
         """Get the path to the CLI binary.
 
         Returns:

--- a/emdx/services/cli_executor/claude.py
+++ b/emdx/services/cli_executor/claude.py
@@ -5,7 +5,7 @@ import logging
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from ...config.cli_config import CLI_CONFIGS, CliTool, resolve_model_alias
 from .base import CliCommand, CliExecutor, CliResult
@@ -26,11 +26,11 @@ class ClaudeCliExecutor(CliExecutor):
     def build_command(
         self,
         prompt: str,
-        model: Optional[str] = None,
-        allowed_tools: Optional[List[str]] = None,
+        model: str | None = None,
+        allowed_tools: List[str] | None = None,
         output_format: str = "stream-json",
-        working_dir: Optional[str] = None,
-        timeout: Optional[int] = None,
+        working_dir: str | None = None,
+        timeout: int | None = None,
     ) -> CliCommand:
         """Build Claude CLI command.
 
@@ -131,7 +131,7 @@ class ClaudeCliExecutor(CliExecutor):
             exit_code=exit_code,
         )
 
-    def parse_stream_line(self, line: str) -> Optional[Dict[str, Any]]:
+    def parse_stream_line(self, line: str) -> Dict[str, Any] | None:
         """Parse a single line from Claude's stream-json output."""
         if not line.strip():
             return None
@@ -212,6 +212,6 @@ class ClaudeCliExecutor(CliExecutor):
 
         return len(info["errors"]) == 0, info
 
-    def get_binary_path(self) -> Optional[str]:
+    def get_binary_path(self) -> str | None:
         """Get path to claude binary."""
         return shutil.which("claude")

--- a/emdx/services/cli_executor/cursor.py
+++ b/emdx/services/cli_executor/cursor.py
@@ -4,7 +4,7 @@ import json
 import logging
 import shutil
 import subprocess
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from ...config.cli_config import CLI_CONFIGS, CliTool, resolve_model_alias
 from .base import CliCommand, CliExecutor, CliResult
@@ -25,11 +25,11 @@ class CursorCliExecutor(CliExecutor):
     def build_command(
         self,
         prompt: str,
-        model: Optional[str] = None,
-        allowed_tools: Optional[List[str]] = None,
+        model: str | None = None,
+        allowed_tools: List[str] | None = None,
         output_format: str = "stream-json",
-        working_dir: Optional[str] = None,
-        timeout: Optional[int] = None,
+        working_dir: str | None = None,
+        timeout: int | None = None,
     ) -> CliCommand:
         """Build Cursor CLI command.
 
@@ -156,7 +156,7 @@ class CursorCliExecutor(CliExecutor):
             return "Model not available for your account"
         return error_text
 
-    def parse_stream_line(self, line: str) -> Optional[Dict[str, Any]]:
+    def parse_stream_line(self, line: str) -> Dict[str, Any] | None:
         """Parse a single line from Cursor's stream-json output."""
         if not line.strip():
             return None
@@ -266,6 +266,6 @@ class CursorCliExecutor(CliExecutor):
 
         return len(info["errors"]) == 0, info
 
-    def get_binary_path(self) -> Optional[str]:
+    def get_binary_path(self) -> str | None:
         """Get path to cursor binary."""
         return shutil.which("cursor")

--- a/emdx/services/cli_executor/factory.py
+++ b/emdx/services/cli_executor/factory.py
@@ -1,7 +1,7 @@
 """Factory for creating CLI executors."""
 
 import os
-from typing import Optional, Union
+from typing import Union
 
 from ...config.cli_config import CliTool
 from .base import CliExecutor
@@ -15,7 +15,7 @@ _EXECUTORS = {
 }
 
 
-def get_cli_executor(cli_tool: Optional[Union[str, CliTool]] = None) -> CliExecutor:
+def get_cli_executor(cli_tool: Union[str, CliTool] | None = None) -> CliExecutor:
     """Get the appropriate CLI executor.
 
     Args:
@@ -65,7 +65,7 @@ def get_available_cli_tools() -> list[str]:
     return [tool.value for tool in _EXECUTORS.keys()]
 
 
-def detect_available_cli() -> Optional[CliTool]:
+def detect_available_cli() -> CliTool | None:
     """Detect which CLI tools are available on the system.
 
     Checks for installed CLIs in order of preference (Claude first).

--- a/emdx/services/document_merger.py
+++ b/emdx/services/document_merger.py
@@ -12,7 +12,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 from ..config.settings import get_db_path
 from ..database.connection import DatabaseConnection
@@ -57,16 +57,16 @@ class DocumentMerger:
     SIMILARITY_THRESHOLD = 0.7  # Minimum similarity for merge candidates
     PREFILTER_THRESHOLD = 0.3   # Lower threshold for TF-IDF pre-filtering
 
-    def __init__(self, db_path: Optional[Union[str, Path]] = None):
+    def __init__(self, db_path: Union[str, Path] | None = None):
         self.db_path = Path(db_path) if db_path else get_db_path()
         self._db = DatabaseConnection(self.db_path)
         self._similarity_service = SimilarityService(self.db_path)
 
     def find_merge_candidates(
         self,
-        project: Optional[str] = None,
+        project: str | None = None,
         similarity_threshold: float = None,
-        progress_callback: Optional[callable] = None
+        progress_callback: Callable | None = None
     ) -> List[MergeCandidate]:
         """
         Find documents that are candidates for merging.
@@ -188,7 +188,7 @@ class DocumentMerger:
         candidates.sort(key=lambda c: c.similarity_score, reverse=True)
         return candidates
 
-    def _get_document_metadata(self, project: Optional[str] = None) -> Dict[int, Dict[str, Any]]:
+    def _get_document_metadata(self, project: str | None = None) -> Dict[int, Dict[str, Any]]:
         """
         Get metadata for all active documents.
 

--- a/emdx/services/duplicate_detector.py
+++ b/emdx/services/duplicate_detector.py
@@ -13,7 +13,7 @@ import hashlib
 import re
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 try:
     from datasketch import MinHash, MinHashLSH
@@ -100,7 +100,7 @@ class DuplicateDetector:
         """Initialize the duplicate detector. Uses the shared db module for connections."""
         pass
 
-    def _get_content_hash(self, content: Optional[str]) -> str:
+    def _get_content_hash(self, content: str | None) -> str:
         """Generate hash of content for duplicate detection."""
         if not content:
             return "empty"
@@ -163,7 +163,7 @@ class DuplicateDetector:
         self,
         threshold: float = 0.85,
         num_perm: int = DEFAULT_NUM_PERM,
-        max_documents: Optional[int] = None,
+        max_documents: int | None = None,
     ) -> List[Tuple[Dict, Dict, float]]:
         """
         Find near-duplicate documents based on content similarity using MinHash/LSH.

--- a/emdx/services/embedding_service.py
+++ b/emdx/services/embedding_service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Optional
+from typing import List
 
 try:
     import numpy as np
@@ -58,7 +58,7 @@ class SemanticMatch:
 
     doc_id: int
     title: str
-    project: Optional[str]
+    project: str | None
     similarity: float
     snippet: str
 
@@ -115,7 +115,7 @@ class EmbeddingService:
 
         return embedding
 
-    def _get_cached_embedding(self, doc_id: int) -> Optional[np.ndarray]:
+    def _get_cached_embedding(self, doc_id: int) -> np.ndarray | None:
         """Get cached embedding from database."""
         with db.get_connection() as conn:
             cursor = conn.cursor()

--- a/emdx/services/file_watcher.py
+++ b/emdx/services/file_watcher.py
@@ -2,8 +2,8 @@
 
 import logging
 import threading
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 # Try to use watchdog for efficient file watching
 try:

--- a/emdx/services/health_monitor.py
+++ b/emdx/services/health_monitor.py
@@ -6,7 +6,7 @@ Analyzes knowledge base health and provides actionable recommendations.
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from ..config.settings import get_db_path
 from ..database.connection import DatabaseConnection
@@ -53,7 +53,7 @@ class HealthMonitor:
         'growth': 0.10
     }
 
-    def __init__(self, db_path: Optional[Union[str, Path]] = None):
+    def __init__(self, db_path: Union[str, Path] | None = None):
         self.db_path = Path(db_path) if db_path else get_db_path()
         self._db = DatabaseConnection(self.db_path)
 
@@ -510,7 +510,7 @@ class HealthMonitor:
             recommendations=recommendations
         )
 
-    def get_project_health(self, limit: Optional[int] = None) -> List[ProjectHealth]:
+    def get_project_health(self, limit: int | None = None) -> List[ProjectHealth]:
         """
         Get health metrics for each project.
 

--- a/emdx/services/log_stream.py
+++ b/emdx/services/log_stream.py
@@ -5,7 +5,7 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -31,11 +31,11 @@ class LogStream:
         self.path = log_file_path
         self.position = 0
         self.subscribers: List[LogStreamSubscriber] = []
-        self.watcher: Optional['FileWatcher'] = None
+        self.watcher: FileWatcher | None = None
         self.is_watching = False
         self._polling = False
         self._stopped = False
-        self._poll_thread: Optional[threading.Thread] = None
+        self._poll_thread: threading.Thread | None = None
         self._poll_interval = 1.0
 
     def subscribe(self, subscriber: LogStreamSubscriber) -> None:

--- a/emdx/services/similarity.py
+++ b/emdx/services/similarity.py
@@ -16,7 +16,7 @@ import pickle
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import Callable, List, Set
 
 from ..config.constants import EMDX_CONFIG_DIR
 
@@ -47,7 +47,7 @@ class SimilarDocument:
     """Represents a document similar to a query document."""
     doc_id: int
     title: str
-    project: Optional[str]
+    project: str | None
     similarity_score: float
     content_similarity: float
     tag_similarity: float
@@ -61,7 +61,7 @@ class IndexStats:
     vocabulary_size: int
     cache_size_bytes: int
     cache_age_seconds: float
-    last_built: Optional[datetime]
+    last_built: datetime | None
 
 
 class SimilarityService:
@@ -74,7 +74,7 @@ class SimilarityService:
     CONTENT_WEIGHT = 0.6      # Content similarity weight
     TAG_WEIGHT = 0.4          # Tag similarity weight
 
-    def __init__(self, db_path: Optional[Path] = None):
+    def __init__(self, db_path: Path | None = None):
         """Initialize the similarity service.
 
         Args:
@@ -86,13 +86,13 @@ class SimilarityService:
         self._cache_path = self._cache_dir / "similarity_cache.pkl"
 
         # Index state
-        self._vectorizer: Optional[TfidfVectorizer] = None
+        self._vectorizer: TfidfVectorizer | None = None
         self._tfidf_matrix = None
         self._doc_ids: List[int] = []
         self._doc_titles: List[str] = []
-        self._doc_projects: List[Optional[str]] = []
+        self._doc_projects: List[str | None] = []
         self._doc_tags: List[Set[str]] = []
-        self._last_built: Optional[datetime] = None
+        self._last_built: datetime | None = None
 
     def _load_cache(self) -> bool:
         """Load the cached index if it exists.
@@ -436,7 +436,7 @@ class SimilarityService:
     def find_all_duplicate_pairs(
         self,
         min_similarity: float = 0.7,
-        progress_callback: Optional[callable] = None,
+        progress_callback: Callable | None = None,
     ) -> List[tuple]:
         """Find all pairs of similar documents efficiently using radius neighbors.
 
@@ -462,9 +462,9 @@ class SimilarityService:
         if not self._doc_ids or self._tfidf_matrix is None:
             return []
 
+        import numpy as np
         from sklearn.neighbors import NearestNeighbors
         from sklearn.preprocessing import normalize
-        import numpy as np
 
         n_docs = len(self._doc_ids)
 

--- a/emdx/services/unified_executor.py
+++ b/emdx/services/unified_executor.py
@@ -14,7 +14,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from ..config.cli_config import DEFAULT_ALLOWED_TOOLS
 from ..config.constants import EMDX_LOG_DIR
@@ -38,7 +38,7 @@ def format_timestamp(ts: float) -> str:
     return f"[{dt.strftime('%H:%M:%S')}]"
 
 
-def format_stream_line(line: str, timestamp: float) -> Optional[str]:
+def format_stream_line(line: str, timestamp: float) -> str | None:
     """Format a stream-json line into readable log output.
 
     Works with both Claude and Cursor output formats.
@@ -142,12 +142,12 @@ class ExecutionConfig:
     prompt: str
     working_dir: str = field(default_factory=lambda: str(Path.cwd()))
     title: str = "CLI Execution"
-    doc_id: Optional[int] = None
-    output_instruction: Optional[str] = None
+    doc_id: int | None = None
+    output_instruction: str | None = None
     allowed_tools: List[str] = field(default_factory=lambda: DEFAULT_ALLOWED_TOOLS.copy())
     timeout_seconds: int = 300
     cli_tool: str = "claude"  # "claude" or "cursor"
-    model: Optional[str] = None  # Override default model for the CLI
+    model: str | None = None  # Override default model for the CLI
     verbose: bool = False  # Stream output in real-time
 
 
@@ -157,15 +157,15 @@ class ExecutionResult:
     success: bool
     execution_id: int
     log_file: Path
-    output_doc_id: Optional[int] = None
-    output_content: Optional[str] = None
+    output_doc_id: int | None = None
+    output_content: str | None = None
     tokens_used: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
     cost_usd: float = 0.0
     execution_time_ms: int = 0
-    error_message: Optional[str] = None
-    exit_code: Optional[int] = None
+    error_message: str | None = None
+    exit_code: int | None = None
     cli_tool: str = "claude"  # Which CLI was used
 
     def to_dict(self) -> Dict[str, Any]:
@@ -192,7 +192,7 @@ class UnifiedExecutor:
     Supports multiple CLI tools (Claude, Cursor) through the strategy pattern.
     """
 
-    def __init__(self, log_dir: Optional[Path] = None):
+    def __init__(self, log_dir: Path | None = None):
         self.log_dir = log_dir or EMDX_LOG_DIR
         self.log_dir.mkdir(parents=True, exist_ok=True)
 

--- a/emdx/services/unified_search.py
+++ b/emdx/services/unified_search.py
@@ -10,7 +10,7 @@ import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from difflib import SequenceMatcher
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 from ..database import db
 from ..database.search import search_documents
@@ -28,11 +28,11 @@ class SearchQuery:
     tags: List[str] = field(default_factory=list)
     tag_mode: str = "all"  # "all" or "any"
     semantic: bool = False
-    created_after: Optional[datetime] = None
-    created_before: Optional[datetime] = None
-    modified_after: Optional[datetime] = None
-    modified_before: Optional[datetime] = None
-    project: Optional[str] = None
+    created_after: datetime | None = None
+    created_before: datetime | None = None
+    modified_after: datetime | None = None
+    modified_before: datetime | None = None
+    project: str | None = None
     limit: int = 50
 
 
@@ -46,9 +46,9 @@ class SearchResult:
     score: float  # Normalized 0-1
     source: str  # "fts", "tags", "semantic", "fuzzy"
     tags: List[str] = field(default_factory=list)
-    project: Optional[str] = None
-    created_at: Optional[datetime] = None
-    updated_at: Optional[datetime] = None
+    project: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
 
 
 class UnifiedSearchService:
@@ -385,7 +385,7 @@ class UnifiedSearchService:
         query: str,
         limit: int = 20,
         threshold: float = 0.4,
-        exclude_ids: Optional[Set[int]] = None,
+        exclude_ids: Set[int] | None = None,
     ) -> List[SearchResult]:
         """
         Fuzzy search document titles using SequenceMatcher.
@@ -538,7 +538,7 @@ class UnifiedSearchService:
 
         return [{"name": normalize_tag_to_emoji(row[0]), "count": row[1]} for row in rows]
 
-    def get_document_by_id(self, doc_id: int) -> Optional[SearchResult]:
+    def get_document_by_id(self, doc_id: int) -> SearchResult | None:
         """Get a single document by ID."""
         with db.get_connection() as conn:
             cursor = conn.cursor()

--- a/emdx/ui/activity/activity_items.py
+++ b/emdx/ui/activity/activity_items.py
@@ -7,7 +7,7 @@ replacing the stringly-typed item_type field with proper polymorphism.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 
 @dataclass
@@ -21,7 +21,7 @@ class ActivityItem(ABC):
     expanded: bool = False
     children: List["ActivityItem"] = field(default_factory=list)
     status: str = "completed"  # Default status for items that don't track status
-    doc_id: Optional[int] = None  # Document ID if this item has associated content
+    doc_id: int | None = None  # Document ID if this item has associated content
     cost: float = 0.0  # Cost in USD if tracked
 
     @property
@@ -251,7 +251,7 @@ class CascadeRunItem(ActivityItem):
 class CascadeStageItem(ActivityItem):
     """A single stage execution within a cascade run."""
 
-    doc_id: Optional[int] = None
+    doc_id: int | None = None
     status: str = "pending"
     stage: str = ""
 
@@ -439,7 +439,7 @@ class AgentExecutionItem(ActivityItem):
 
     execution: Dict[str, Any] = field(default_factory=dict)
     status: str = "running"
-    doc_id: Optional[int] = None
+    doc_id: int | None = None
     log_file: str = ""
     cli_tool: str = "claude"
 

--- a/emdx/ui/activity/activity_tree.py
+++ b/emdx/ui/activity/activity_tree.py
@@ -17,7 +17,7 @@ aligned across all rows regardless of depth.
 """
 
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from rich.style import Style
 from rich.text import Text
@@ -315,11 +315,11 @@ class ActivityTree(Tree[ActivityItem]):
 
     def find_node_by_item_key(
         self, item_type: str, item_id: int
-    ) -> Optional[TreeNode[ActivityItem]]:
+    ) -> TreeNode[ActivityItem] | None:
         """Walk the tree to find a node matching (item_type, item_id)."""
         target_key = (item_type, item_id)
 
-        def _search(node: TreeNode[ActivityItem]) -> Optional[TreeNode[ActivityItem]]:
+        def _search(node: TreeNode[ActivityItem]) -> TreeNode[ActivityItem] | None:
             if node.data is not None and _item_key(node.data) == target_key:
                 return node
             for child in node.children:
@@ -332,10 +332,10 @@ class ActivityTree(Tree[ActivityItem]):
 
     def find_node_by_doc_id(
         self, doc_id: int
-    ) -> Optional[TreeNode[ActivityItem]]:
+    ) -> TreeNode[ActivityItem] | None:
         """Walk the tree to find a node with a matching doc_id."""
 
-        def _search(node: TreeNode[ActivityItem]) -> Optional[TreeNode[ActivityItem]]:
+        def _search(node: TreeNode[ActivityItem]) -> TreeNode[ActivityItem] | None:
             if node.data is not None:
                 if getattr(node.data, "doc_id", None) == doc_id:
                     return node

--- a/emdx/ui/activity/activity_view.py
+++ b/emdx/ui/activity/activity_view.py
@@ -13,7 +13,7 @@ and cursor tracking by node reference — eliminating scroll jumping.
 import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal, ScrollableContainer, Vertical
@@ -254,12 +254,12 @@ class ActivityView(HelpMixin, Widget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.activity_items: List[ActivityItem] = []
-        self.log_stream: Optional[LogStream] = None
+        self.log_stream: LogStream | None = None
         self.log_subscriber = AgentLogSubscriber(self)
-        self.streaming_item_id: Optional[int] = None
+        self.streaming_item_id: int | None = None
         self._fullscreen = False
         # Cache to prevent flickering during refresh
-        self._last_preview_key: Optional[tuple] = None  # (item_type, item_id, status)
+        self._last_preview_key: tuple | None = None  # (item_type, item_id, status)
         # Flag to only run zombie cleanup once on startup
         self._zombies_cleaned = False
         # Reentrance guard: prevents overlapping async refreshes
@@ -267,7 +267,7 @@ class ActivityView(HelpMixin, Widget):
         # Data loader (owns DB queries)
         self._data_loader = ActivityDataLoader()
 
-    def _get_selected_item(self) -> Optional[ActivityItem]:
+    def _get_selected_item(self) -> ActivityItem | None:
         """Get the currently selected ActivityItem from the tree."""
         try:
             tree = self.query_one("#activity-tree", ActivityTree)

--- a/emdx/ui/activity/group_picker.py
+++ b/emdx/ui/activity/group_picker.py
@@ -6,7 +6,6 @@ or creating a new group.
 """
 
 import logging
-from typing import Optional
 
 from textual import events
 from textual.app import ComposeResult
@@ -40,8 +39,8 @@ class GroupPicker(Widget):
             self,
             group_id: int,
             group_name: str,
-            doc_id: Optional[int],
-            source_group_id: Optional[int],
+            doc_id: int | None,
+            source_group_id: int | None,
         ) -> None:
             self.group_id = group_id
             self.group_name = group_name
@@ -55,8 +54,8 @@ class GroupPicker(Widget):
             self,
             group_id: int,
             group_name: str,
-            doc_id: Optional[int],
-            source_group_id: Optional[int],
+            doc_id: int | None,
+            source_group_id: int | None,
         ) -> None:
             self.group_id = group_id
             self.group_name = group_name
@@ -116,8 +115,8 @@ class GroupPicker(Widget):
         self.groups: list[dict] = []
         self.filtered_groups: list[dict] = []
         self.selected_index: int = 0
-        self.doc_id: Optional[int] = None
-        self.source_group_id: Optional[int] = None  # When nesting a group
+        self.doc_id: int | None = None
+        self.source_group_id: int | None = None  # When nesting a group
         self._visible = False
 
     def compose(self) -> ComposeResult:
@@ -127,8 +126,8 @@ class GroupPicker(Widget):
 
     def show(
         self,
-        doc_id: Optional[int] = None,
-        source_group_id: Optional[int] = None,
+        doc_id: int | None = None,
+        source_group_id: int | None = None,
     ) -> None:
         """Show the picker for a document or group.
 

--- a/emdx/ui/activity/sparkline.py
+++ b/emdx/ui/activity/sparkline.py
@@ -1,11 +1,11 @@
 """Sparkline utilities for terminal visualization."""
 
-from typing import List, Optional
+from typing import List
 
 BLOCKS = "▁▂▃▄▅▆▇█"
 
 
-def sparkline(values: List[float], width: Optional[int] = None) -> str:
+def sparkline(values: List[float], width: int | None = None) -> str:
     """Generate a sparkline string from values.
 
     Args:

--- a/emdx/ui/activity_browser.py
+++ b/emdx/ui/activity_browser.py
@@ -1,7 +1,6 @@
 """Activity Browser - wraps ActivityView for the browser container."""
 
 import logging
-from typing import Optional
 
 from textual.app import ComposeResult
 from textual.widget import Widget
@@ -42,7 +41,7 @@ class ActivityBrowser(Widget):
 
     def __init__(self):
         super().__init__()
-        self.activity_view: Optional[ActivityView] = None
+        self.activity_view: ActivityView | None = None
 
     def compose(self) -> ComposeResult:
         self.activity_view = ActivityView(id="activity-view")

--- a/emdx/ui/cascade/cascade_browser.py
+++ b/emdx/ui/cascade/cascade_browser.py
@@ -3,7 +3,6 @@
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 from textual.app import ComposeResult
 from textual.widget import Widget
@@ -45,7 +44,7 @@ class CascadeBrowser(Widget):
 
     def __init__(self):
         super().__init__()
-        self.cascade_view: Optional[CascadeView] = None
+        self.cascade_view: CascadeView | None = None
 
     def compose(self) -> ComposeResult:
         self.cascade_view = CascadeView(id="cascade-view")

--- a/emdx/ui/cascade/cascade_view.py
+++ b/emdx/ui/cascade/cascade_view.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -39,7 +39,7 @@ class CascadeView(Widget):
             super().__init__()
 
     class ProcessStage(Message):
-        def __init__(self, stage: str, doc_id: Optional[int] = None):
+        def __init__(self, stage: str, doc_id: int | None = None):
             self.stage = stage
             self.doc_id = doc_id
             super().__init__()
@@ -89,16 +89,16 @@ class CascadeView(Widget):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.summary: Optional[StageSummaryBar] = None
-        self.doc_list: Optional[DocumentList] = None
-        self.pipeline_table: Optional[DataTable] = None
+        self.summary: StageSummaryBar | None = None
+        self.doc_list: DocumentList | None = None
+        self.pipeline_table: DataTable | None = None
         self._pipeline_data: List[Dict[str, Any]] = []
-        self._selected_pipeline_idx: Optional[int] = None
+        self._selected_pipeline_idx: int | None = None
         self._pipeline_view_mode: str = "output"
         self._auto_refresh_timer = None
         self._log_stream = None
         self._log_subscriber = None
-        self._selected_exec: Optional[Dict[str, Any]] = None
+        self._selected_exec: Dict[str, Any] | None = None
 
     def compose(self) -> ComposeResult:
         from textual.containers import ScrollableContainer
@@ -416,7 +416,7 @@ class CascadeView(Widget):
             if doc_id:
                 self.post_message(self.ViewDocument(doc_id))
 
-    def _get_selected_pipeline_act(self) -> Optional[Dict[str, Any]]:
+    def _get_selected_pipeline_act(self) -> Dict[str, Any] | None:
         if self._selected_pipeline_idx is None:
             self._update_status("[yellow]Select a pipeline row first[/yellow]")
             return None

--- a/emdx/ui/cascade/document_list.py
+++ b/emdx/ui/cascade/document_list.py
@@ -1,6 +1,6 @@
 """Document list widget for cascade browser."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from textual.app import ComposeResult
 from textual.message import Message
@@ -162,7 +162,7 @@ class DocumentList(Widget):
         """Get list of selected document IDs."""
         return list(self.selected_ids)
 
-    def get_selected_doc_id(self) -> Optional[int]:
+    def get_selected_doc_id(self) -> int | None:
         """Get currently selected document ID (cursor position)."""
         table = self.query_one("#doc-table", DataTable)
         if table.row_count > 0 and table.cursor_row is not None:

--- a/emdx/ui/command_palette/palette_commands.py
+++ b/emdx/ui/command_palette/palette_commands.py
@@ -5,10 +5,11 @@ Manages available commands that can be invoked from the palette.
 """
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from enum import Enum
-from typing import Callable, Dict, List, Optional
+from typing import Dict, List
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +30,9 @@ class PaletteCommand:
     name: str  # Display name: "Go to Activity"
     description: str  # What it does
     keywords: List[str] = field(default_factory=list)  # For fuzzy matching
-    action: Optional[Callable] = None  # Function to execute (app) -> None
+    action: Callable | None = None  # Function to execute (app) -> None
     context: CommandContext = CommandContext.GLOBAL  # Where available
-    shortcut: Optional[str] = None  # Keyboard shortcut hint
+    shortcut: str | None = None  # Keyboard shortcut hint
     category: str = "General"  # For grouping in UI
 
 
@@ -54,11 +55,11 @@ class CommandRegistry:
             return True
         return False
 
-    def get(self, command_id: str) -> Optional[PaletteCommand]:
+    def get(self, command_id: str) -> PaletteCommand | None:
         """Get a command by ID."""
         return self._commands.get(command_id)
 
-    def get_all(self, context: Optional[CommandContext] = None) -> List[PaletteCommand]:
+    def get_all(self, context: CommandContext | None = None) -> List[PaletteCommand]:
         """Get all commands, optionally filtered by context."""
         commands = list(self._commands.values())
         if context:
@@ -70,7 +71,7 @@ class CommandRegistry:
     def search(
         self,
         query: str,
-        context: Optional[CommandContext] = None,
+        context: CommandContext | None = None,
         limit: int = 10,
         threshold: float = 0.3,
     ) -> List[PaletteCommand]:
@@ -295,7 +296,7 @@ class CommandRegistry:
 
 
 # Global registry instance
-_registry: Optional[CommandRegistry] = None
+_registry: CommandRegistry | None = None
 
 
 def get_command_registry() -> CommandRegistry:

--- a/emdx/ui/command_palette/palette_presenter.py
+++ b/emdx/ui/command_palette/palette_presenter.py
@@ -5,9 +5,10 @@ Handles search logic, result ranking, and action dispatch.
 """
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Dict, List, Set
 
 from .palette_commands import CommandContext, PaletteCommand, get_command_registry
 
@@ -62,8 +63,8 @@ class PalettePresenter:
 
     def __init__(
         self,
-        on_state_update: Optional[Callable[[PaletteState], None]] = None,
-        context: Optional[CommandContext] = None,
+        on_state_update: Callable[[PaletteState], None] | None = None,
+        context: CommandContext | None = None,
     ):
         self.on_state_update = on_state_update
         self.context = context or CommandContext.GLOBAL
@@ -416,7 +417,7 @@ class PalettePresenter:
         self._state.selected_index = new_index
         self._notify_update()
 
-    def get_selected_result(self) -> Optional[PaletteResultItem]:
+    def get_selected_result(self) -> PaletteResultItem | None:
         """Get the currently selected result."""
         if not self._state.results:
             return None
@@ -433,7 +434,7 @@ class PalettePresenter:
         # Trim
         self._history = self._history[: self._max_history]
 
-    async def execute_selected(self, app) -> Optional[Dict[str, Any]]:
+    async def execute_selected(self, app) -> Dict[str, Any] | None:
         """
         Execute the selected result.
 

--- a/emdx/ui/command_palette/palette_screen.py
+++ b/emdx/ui/command_palette/palette_screen.py
@@ -8,7 +8,7 @@ via keyboard-driven fuzzy search.
 import asyncio
 import logging
 import traceback
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -152,7 +152,7 @@ class CommandPaletteScreen(ModalScreen):
     def __init__(
         self,
         initial_query: str = "",
-        context: Optional[CommandContext] = None,
+        context: CommandContext | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/emdx/ui/document_browser.py
+++ b/emdx/ui/document_browser.py
@@ -8,7 +8,7 @@ operations while this widget focuses on display and user interaction.
 """
 
 import logging
-from typing import Any, Dict, Optional, Protocol
+from typing import Any, Dict, Protocol
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -78,15 +78,15 @@ class DocumentBrowser(HelpMixin, Widget):
         super().__init__(*args, **kwargs)
         # UI state
         self.edit_mode: bool = False
-        self.editing_doc_id: Optional[int] = None
-        self.tag_action: Optional[str] = None
+        self.editing_doc_id: int | None = None
+        self.tag_action: str | None = None
 
         # Debounce preview updates
-        self._pending_preview_doc_id: Optional[int] = None
+        self._pending_preview_doc_id: int | None = None
         self._preview_timer = None
 
         # Current ViewModel (updated by presenter callbacks)
-        self._current_vm: Optional[DocumentListVM] = None
+        self._current_vm: DocumentListVM | None = None
 
         # Initialize presenter with update callbacks
         self.presenter = DocumentBrowserPresenter(
@@ -1090,7 +1090,7 @@ class DocumentBrowser(HelpMixin, Widget):
         table = self.query_one("#doc-table", DataTable)
         table.focus()
 
-    async def apply_search(self, query: Optional[str] = None) -> None:
+    async def apply_search(self, query: str | None = None) -> None:
         """Apply current search filter via presenter.
 
         Args:

--- a/emdx/ui/gui.py
+++ b/emdx/ui/gui.py
@@ -2,7 +2,6 @@
 GUI interface for emdx - seamless textual browser
 """
 
-from typing import Optional
 
 import typer
 
@@ -10,7 +9,7 @@ from emdx.utils.output import console
 
 
 def gui(
-    theme: Optional[str] = typer.Option(
+    theme: str | None = typer.Option(
         None,
         "--theme",
         "-t",

--- a/emdx/ui/keybindings/config.py
+++ b/emdx/ui/keybindings/config.py
@@ -6,7 +6,7 @@ Loads user keybinding customizations from ~/.config/emdx/keybindings.yaml
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from emdx.config.constants import EMDX_CONFIG_DIR
 
@@ -158,7 +158,7 @@ def parse_overrides(config: Dict[str, Any]) -> List[KeybindingEntry]:
     return entries
 
 
-def _parse_context(context_str: str) -> Optional[Context]:
+def _parse_context(context_str: str) -> Context | None:
     """Parse a context string into a Context enum value."""
     # Try direct match
     for ctx in Context:
@@ -189,7 +189,7 @@ class KeybindingConfig:
             new_action = config.get_override("t", Context.DOCUMENT_NORMAL)
     """
 
-    def __init__(self, config_path: Optional[Path] = None):
+    def __init__(self, config_path: Path | None = None):
         self.config_path = config_path or get_config_path()
         self.config: Dict[str, Any] = {}
         self.overrides: List[KeybindingEntry] = []
@@ -218,7 +218,7 @@ class KeybindingConfig:
         """Check if a key is overridden in a context."""
         return (key, context) in self._override_map
 
-    def get_override(self, key: str, context: Context) -> Optional[KeybindingEntry]:
+    def get_override(self, key: str, context: Context) -> KeybindingEntry | None:
         """Get the override for a key in a context."""
         return self._override_map.get((key, context))
 

--- a/emdx/ui/keybindings/extractor.py
+++ b/emdx/ui/keybindings/extractor.py
@@ -9,7 +9,7 @@ import importlib
 import inspect
 import logging
 import pkgutil
-from typing import List, Optional, Type
+from typing import List, Type
 
 from textual.binding import Binding
 from textual.widget import Widget
@@ -118,7 +118,7 @@ class KeybindingExtractor:
 
     def _binding_to_entry(
         self, binding: Binding, widget_class: Type[Widget], context: Context
-    ) -> Optional[KeybindingEntry]:
+    ) -> KeybindingEntry | None:
         """Convert a Textual Binding to a KeybindingEntry."""
         try:
             return KeybindingEntry(
@@ -138,7 +138,7 @@ class KeybindingExtractor:
 
     def _tuple_to_entry(
         self, binding: tuple, widget_class: Type[Widget], context: Context
-    ) -> Optional[KeybindingEntry]:
+    ) -> KeybindingEntry | None:
         """Convert a legacy tuple binding to a KeybindingEntry."""
         try:
             key = binding[0]

--- a/emdx/ui/keybindings/registry.py
+++ b/emdx/ui/keybindings/registry.py
@@ -8,7 +8,7 @@ at startup before they can cause runtime crashes.
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Set
 
 from .context import Context
 
@@ -250,7 +250,7 @@ class KeybindingRegistry:
 
     def _check_conflict(
         self, key: str, binding1: KeybindingEntry, binding2: KeybindingEntry
-    ) -> Optional[ConflictReport]:
+    ) -> ConflictReport | None:
         """
         Check if two bindings for the same key conflict.
 
@@ -363,7 +363,7 @@ class KeybindingRegistry:
 
     def get_binding_for_key(
         self, key: str, context: Context
-    ) -> Optional[KeybindingEntry]:
+    ) -> KeybindingEntry | None:
         """
         Get the active binding for a key in a context.
 

--- a/emdx/ui/log_browser.py
+++ b/emdx/ui/log_browser.py
@@ -14,7 +14,6 @@ The LogBrowser uses mixins for separation of concerns:
 
 import logging
 from pathlib import Path
-from typing import Optional
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -138,7 +137,7 @@ class LogBrowser(
         super().__init__(*args, **kwargs)
         self.executions: list[Execution] = []
         self.selection_mode = False
-        self.current_stream: Optional[LogStream] = None
+        self.current_stream: LogStream | None = None
         self.is_live_mode = False
         self.stream_subscriber = LogBrowserSubscriber(self)
 

--- a/emdx/ui/modals.py
+++ b/emdx/ui/modals.py
@@ -4,7 +4,7 @@ Modal screens for EMDX TUI.
 """
 
 import logging
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -326,7 +326,7 @@ class DocumentPreviewModal(ModalScreen):
     def __init__(self, doc_id: int, **kwargs):
         super().__init__(**kwargs)
         self.doc_id = doc_id
-        self._doc_data: Optional[dict] = None
+        self._doc_data: dict | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical(id="preview-dialog"):

--- a/emdx/ui/presenters/document_browser_presenter.py
+++ b/emdx/ui/presenters/document_browser_presenter.py
@@ -13,7 +13,8 @@ The original presenter handled:
 """
 
 import logging
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
+from collections.abc import Awaitable, Callable
+from typing import Any, Dict, List, Set
 
 from emdx.services.document_service import (
     count_documents,
@@ -45,7 +46,7 @@ class DocumentBrowserPresenter:
     def __init__(
         self,
         on_list_update: Callable[[DocumentListVM], Awaitable[None]],
-        on_detail_update: Optional[Callable[[DocumentDetailVM], Awaitable[None]]] = None,
+        on_detail_update: Callable[[DocumentDetailVM], Awaitable[None]] | None = None,
     ):
         """Initialize the presenter."""
         self.on_list_update = on_list_update
@@ -408,7 +409,7 @@ class DocumentBrowserPresenter:
         except Exception as e:
             logger.error(f"Error removing tags from document {doc_id}: {e}")
 
-    def get_document_detail(self, doc_id: int) -> Optional[DocumentDetailVM]:
+    def get_document_detail(self, doc_id: int) -> DocumentDetailVM | None:
         """Get full document details for the detail panel."""
         try:
             if doc_id in self._doc_cache:
@@ -449,7 +450,7 @@ class DocumentBrowserPresenter:
         self,
         title: str,
         content: str,
-        tags: Optional[List[str]] = None,
+        tags: List[str] | None = None,
     ) -> int:
         """Save a new document."""
         project = get_git_project()
@@ -464,8 +465,8 @@ class DocumentBrowserPresenter:
     async def update_existing_document(
         self,
         doc_id: int,
-        title: Optional[str] = None,
-        content: Optional[str] = None,
+        title: str | None = None,
+        content: str | None = None,
     ) -> bool:
         """Update an existing document."""
         try:
@@ -485,13 +486,13 @@ class DocumentBrowserPresenter:
             logger.error(f"Error updating document {doc_id}: {e}")
             return False
 
-    def get_document_at_index(self, index: int) -> Optional[DocumentListItem]:
+    def get_document_at_index(self, index: int) -> DocumentListItem | None:
         """Get document at the given index in the filtered list."""
         if 0 <= index < len(self._filtered_documents):
             return self._filtered_documents[index]
         return None
 
-    def get_parent_document(self, doc: DocumentListItem) -> Optional[DocumentListItem]:
+    def get_parent_document(self, doc: DocumentListItem) -> DocumentListItem | None:
         """Get the parent document of a given document."""
         if doc.parent_id is None:
             return None

--- a/emdx/ui/search/search_presenter.py
+++ b/emdx/ui/search/search_presenter.py
@@ -5,9 +5,10 @@ Handles search logic with debouncing, mode switching, and result management.
 """
 
 import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
+from typing import Any, Dict, List, Set
 
 logger = logging.getLogger(__name__)
 
@@ -32,8 +33,8 @@ class SearchResultItem:
     tags_display: str  # Formatted tags for display
     score: float  # Normalized 0-1
     source: str  # "fts", "tags", "semantic"
-    project: Optional[str] = None
-    updated_at: Optional[str] = None
+    project: str | None = None
+    updated_at: str | None = None
     is_selected: bool = False  # For multi-select
 
 
@@ -78,7 +79,7 @@ class SearchPresenter:
 
     def __init__(
         self,
-        on_state_update: Optional[Callable[[SearchStateVM], Awaitable[None]]] = None,
+        on_state_update: Callable[[SearchStateVM], Awaitable[None]] | None = None,
     ):
         self.on_state_update = on_state_update
         self._state = SearchStateVM()
@@ -103,7 +104,7 @@ class SearchPresenter:
         """Get current state."""
         return self._state
 
-    def get_debounce_time(self, mode: Optional[SearchMode] = None) -> int:
+    def get_debounce_time(self, mode: SearchMode | None = None) -> int:
         """Get debounce time for the given mode in milliseconds."""
         mode = mode or self._state.mode
         return self.DEBOUNCE_TIMES.get(mode, 150)
@@ -161,7 +162,7 @@ class SearchPresenter:
         popular_tags = self.search_service.get_popular_tags(limit=15)
         return recent, popular_tags
 
-    async def search(self, query: str, mode: Optional[SearchMode] = None) -> None:
+    async def search(self, query: str, mode: SearchMode | None = None) -> None:
         """
         Execute search with the given query and mode.
 
@@ -365,7 +366,7 @@ class SearchPresenter:
             if i < len(self._state.results)
         ]
 
-    def get_result_at_index(self, index: int) -> Optional[SearchResultItem]:
+    def get_result_at_index(self, index: int) -> SearchResultItem | None:
         """Get result at the given index."""
         if 0 <= index < len(self._state.results):
             return self._state.results[index]

--- a/emdx/ui/search/search_screen.py
+++ b/emdx/ui/search/search_screen.py
@@ -10,7 +10,6 @@ Features:
 
 import asyncio
 import logging
-from typing import Optional
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -136,7 +135,7 @@ class SearchScreen(HelpMixin, Widget):
         super().__init__(*args, **kwargs)
         self.presenter = SearchPresenter(on_state_update=self._on_state_update)
         self._debounce_timer = None
-        self._current_vm: Optional[SearchStateVM] = None
+        self._current_vm: SearchStateVM | None = None
 
     def compose(self) -> ComposeResult:
         # Search bar

--- a/emdx/ui/viewmodels/__init__.py
+++ b/emdx/ui/viewmodels/__init__.py
@@ -20,12 +20,12 @@ class DocumentListItem:
     tags_display: str
     project: str
     access_count: int
-    created_at: Optional[str] = None
-    accessed_at: Optional[str] = None
-    parent_id: Optional[int] = None
+    created_at: str | None = None
+    accessed_at: str | None = None
+    parent_id: int | None = None
     has_children: bool = False
     depth: int = 0
-    relationship: Optional[str] = None
+    relationship: str | None = None
 
 
 @dataclass
@@ -38,9 +38,9 @@ class DocumentDetailVM:
     project: str
     tags: List[str]
     tags_formatted: str
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
-    accessed_at: Optional[str] = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    accessed_at: str | None = None
     access_count: int = 0
     word_count: int = 0
     char_count: int = 0

--- a/emdx/utils/datetime_utils.py
+++ b/emdx/utils/datetime_utils.py
@@ -6,12 +6,12 @@ handling various input formats from SQLite, JSON, and ISO 8601 strings.
 """
 
 from datetime import datetime, timezone
-from typing import Optional, Union
+from typing import Union
 
 
 def parse_datetime(value: Union[str, datetime, None],
-                   default: Optional[datetime] = None,
-                   assume_utc: bool = False) -> Optional[datetime]:
+                   default: datetime | None = None,
+                   assume_utc: bool = False) -> datetime | None:
     """
     Parse a datetime value from various formats.
 

--- a/emdx/utils/environment.py
+++ b/emdx/utils/environment.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from emdx.config.constants import EMDX_CONFIG_DIR
 from emdx.utils.output import console
@@ -103,7 +103,7 @@ class EnvironmentValidator:
             else:
                 self.errors.append(f"Required command '{cmd}' not found in PATH")
 
-    def _get_version_command(self, cmd: str) -> Optional[List[str]]:
+    def _get_version_command(self, cmd: str) -> List[str] | None:
         """Get the version command for a CLI tool."""
         if cmd == "claude":
             return ["claude", "--version"]
@@ -249,7 +249,7 @@ class EnvironmentValidator:
 def validate_execution_environment(
     verbose: bool = False,
     cli_tool: str = "claude"
-) -> Tuple[bool, Optional[Dict[str, any]]]:
+) -> Tuple[bool, Dict[str, any] | None]:
     """Validate the execution environment.
 
     Args:

--- a/emdx/utils/git.py
+++ b/emdx/utils/git.py
@@ -8,7 +8,6 @@ import random
 import subprocess
 import time
 from pathlib import Path
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +60,7 @@ def cleanup_worktree(worktree_path: str):
         logger.warning("Could not clean up worktree %s: %s", worktree_path, e)
 
 
-def get_git_project(path: Optional[Path] = None) -> Optional[str]:
+def get_git_project(path: Path | None = None) -> str | None:
     """
     Get the git repository name for a given path.
 

--- a/emdx/utils/git_ops.py
+++ b/emdx/utils/git_ops.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 from .logging_utils import get_logger
 
@@ -189,7 +189,7 @@ def discover_projects_from_main_repos() -> List[GitProject]:
     return projects
 
 
-def discover_projects_from_worktrees(worktree_dirs: Optional[List[str]] = None) -> List[GitProject]:
+def discover_projects_from_worktrees(worktree_dirs: List[str] | None = None) -> List[GitProject]:
     """
     Discover projects by grouping worktrees.
 
@@ -296,7 +296,7 @@ def discover_projects_from_worktrees(worktree_dirs: Optional[List[str]] = None) 
     return projects
 
 
-def discover_git_projects(search_paths: Optional[List[str]] = None, max_depth: int = 1) -> List[GitProject]:
+def discover_git_projects(search_paths: List[str] | None = None, max_depth: int = 1) -> List[GitProject]:
     """
     Discover git projects in common locations.
 
@@ -370,7 +370,7 @@ def discover_git_projects(search_paths: Optional[List[str]] = None, max_depth: i
     return projects
 
 
-def get_worktrees(project_path: Optional[str] = None) -> List[GitWorktree]:
+def get_worktrees(project_path: str | None = None) -> List[GitWorktree]:
     """
     Get list of all git worktrees for a project.
 
@@ -424,7 +424,7 @@ def get_worktrees(project_path: Optional[str] = None) -> List[GitWorktree]:
         return []
 
 
-def get_git_status(worktree_path: Optional[str] = None) -> List[GitFileStatus]:
+def get_git_status(worktree_path: str | None = None) -> List[GitFileStatus]:
     """Get git status for current directory or specified worktree."""
     try:
         cmd = ['git', 'status', '--porcelain']
@@ -479,7 +479,7 @@ def get_git_status(worktree_path: Optional[str] = None) -> List[GitFileStatus]:
         return []
 
 
-def get_comprehensive_git_diff(file_path: str, worktree_path: Optional[str] = None) -> str:
+def get_comprehensive_git_diff(file_path: str, worktree_path: str | None = None) -> str:
     """Get comprehensive diff showing both staged and unstaged changes."""
     staged_diff = get_git_diff(file_path, staged=True, worktree_path=worktree_path)
     unstaged_diff = get_git_diff(file_path, staged=False, worktree_path=worktree_path)
@@ -505,7 +505,7 @@ def get_comprehensive_git_diff(file_path: str, worktree_path: Optional[str] = No
     return "\n".join(output_parts)
 
 
-def get_git_diff(file_path: str, staged: bool = False, worktree_path: Optional[str] = None) -> str:
+def get_git_diff(file_path: str, staged: bool = False, worktree_path: str | None = None) -> str:
     """Get git diff for a specific file with beautiful formatting."""
     try:
         cmd = ['git', 'diff']
@@ -557,7 +557,7 @@ def get_git_diff(file_path: str, staged: bool = False, worktree_path: Optional[s
         return f"Error: Could not get diff for {file_path}"
 
 
-def is_git_repository(path: Optional[str] = None) -> bool:
+def is_git_repository(path: str | None = None) -> bool:
     """Check if directory is a git repository."""
     try:
         cwd = path if path else None
@@ -572,7 +572,7 @@ def is_git_repository(path: Optional[str] = None) -> bool:
         return False
 
 
-def get_current_branch(worktree_path: Optional[str] = None) -> str:
+def get_current_branch(worktree_path: str | None = None) -> str:
     """Get current git branch name."""
     try:
         cwd = worktree_path if worktree_path else None
@@ -588,7 +588,7 @@ def get_current_branch(worktree_path: Optional[str] = None) -> str:
         return "unknown"
 
 
-def get_repository_root(path: Optional[str] = None) -> Optional[str]:
+def get_repository_root(path: str | None = None) -> str | None:
     """Get the root directory of the git repository."""
     try:
         cwd = path if path else None
@@ -604,7 +604,7 @@ def get_repository_root(path: Optional[str] = None) -> Optional[str]:
         return None
 
 
-def git_stage_file(file_path: str, worktree_path: Optional[str] = None) -> bool:
+def git_stage_file(file_path: str, worktree_path: str | None = None) -> bool:
     """Stage a file for commit."""
     try:
         cwd = worktree_path if worktree_path else None
@@ -620,7 +620,7 @@ def git_stage_file(file_path: str, worktree_path: Optional[str] = None) -> bool:
         return False
 
 
-def git_unstage_file(file_path: str, worktree_path: Optional[str] = None) -> bool:
+def git_unstage_file(file_path: str, worktree_path: str | None = None) -> bool:
     """Unstage a file (remove from staging area)."""
     try:
         cwd = worktree_path if worktree_path else None
@@ -636,7 +636,7 @@ def git_unstage_file(file_path: str, worktree_path: Optional[str] = None) -> boo
         return False
 
 
-def git_commit(message: str, worktree_path: Optional[str] = None) -> Tuple[bool, str]:
+def git_commit(message: str, worktree_path: str | None = None) -> Tuple[bool, str]:
     """Commit staged changes with a message."""
     try:
         cwd = worktree_path if worktree_path else None
@@ -652,7 +652,7 @@ def git_commit(message: str, worktree_path: Optional[str] = None) -> Tuple[bool,
         return False, e.stderr.strip() if e.stderr else "Commit failed"
 
 
-def git_discard_changes(file_path: str, worktree_path: Optional[str] = None) -> bool:
+def git_discard_changes(file_path: str, worktree_path: str | None = None) -> bool:
     """Discard unstaged changes to a file."""
     try:
         cwd = worktree_path if worktree_path else None
@@ -668,7 +668,7 @@ def git_discard_changes(file_path: str, worktree_path: Optional[str] = None) -> 
         return False
 
 
-def create_worktree(branch_name: str, path: Optional[str] = None, base_branch: Optional[str] = None, repo_path: Optional[str] = None) -> Tuple[bool, str, str]:
+def create_worktree(branch_name: str, path: str | None = None, base_branch: str | None = None, repo_path: str | None = None) -> Tuple[bool, str, str]:
     """
     Create a new git worktree.
 

--- a/emdx/utils/output_parser.py
+++ b/emdx/utils/output_parser.py
@@ -9,12 +9,12 @@ import json
 import logging
 import re
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict
 
 logger = logging.getLogger(__name__)
 
 
-def extract_output_doc_id(log_file: Path) -> Optional[int]:
+def extract_output_doc_id(log_file: Path) -> int | None:
     """Extract output document ID from execution log.
 
     Looks for patterns like "Created document #123" or "Saved as #123"

--- a/emdx/utils/stream_json_parser.py
+++ b/emdx/utils/stream_json_parser.py
@@ -17,7 +17,7 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -28,9 +28,9 @@ class StreamEvent:
 
     event_type: str  # "text", "tool", "status", "result", "skip"
     content: str  # Main content to display
-    timestamp: Optional[datetime] = None  # From StructuredLogger lines
-    tool_name: Optional[str] = None  # For tool_use events
-    tool_input: Optional[str] = None  # Brief summary of tool input
+    timestamp: datetime | None = None  # From StructuredLogger lines
+    tool_name: str | None = None  # For tool_use events
+    tool_input: str | None = None  # Brief summary of tool input
     raw_line: str = ""  # Original line for debugging
 
 

--- a/emdx/utils/structured_logger.py
+++ b/emdx/utils/structured_logger.py
@@ -14,7 +14,7 @@ import threading
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 
 class LogLevel(Enum):
@@ -38,7 +38,7 @@ class StructuredLogger:
     """Thread-safe structured logger for EMDX processes."""
 
     def __init__(self, log_file: Union[str, Path], process_type: ProcessType,
-                 process_id: Optional[int] = None):
+                 process_id: int | None = None):
         """Initialize the structured logger.
 
         Args:
@@ -55,7 +55,7 @@ class StructuredLogger:
         self.log_file.parent.mkdir(parents=True, exist_ok=True)
 
     def _create_entry(self, level: LogLevel, message: str,
-                      context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+                      context: Dict[str, Any] | None = None) -> Dict[str, Any]:
         """Create a structured log entry.
 
         Args:
@@ -105,7 +105,7 @@ class StructuredLogger:
                 print(f"Failed to write log entry: {e}", file=sys.stderr)
 
     def log(self, level: LogLevel, message: str,
-            context: Optional[Dict[str, Any]] = None) -> None:
+            context: Dict[str, Any] | None = None) -> None:
         """Write a log entry.
 
         Args:
@@ -116,23 +116,23 @@ class StructuredLogger:
         entry = self._create_entry(level, message, context)
         self._write_entry(entry)
 
-    def debug(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+    def debug(self, message: str, context: Dict[str, Any] | None = None) -> None:
         """Write a debug log entry."""
         self.log(LogLevel.DEBUG, message, context)
 
-    def info(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+    def info(self, message: str, context: Dict[str, Any] | None = None) -> None:
         """Write an info log entry."""
         self.log(LogLevel.INFO, message, context)
 
-    def warning(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+    def warning(self, message: str, context: Dict[str, Any] | None = None) -> None:
         """Write a warning log entry."""
         self.log(LogLevel.WARNING, message, context)
 
-    def error(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+    def error(self, message: str, context: Dict[str, Any] | None = None) -> None:
         """Write an error log entry."""
         self.log(LogLevel.ERROR, message, context)
 
-    def critical(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+    def critical(self, message: str, context: Dict[str, Any] | None = None) -> None:
         """Write a critical log entry."""
         self.log(LogLevel.CRITICAL, message, context)
 
@@ -210,7 +210,7 @@ class StructuredLogger:
             "duration_seconds": duration
         })
 
-    def log_process_lifecycle(self, event: str, details: Optional[Dict[str, Any]] = None) -> None:
+    def log_process_lifecycle(self, event: str, details: Dict[str, Any] | None = None) -> None:
         """Log process lifecycle events (start, heartbeat, stop)."""
         self.info(f"Process {event}", {
             "event": f"process_{event}",


### PR DESCRIPTION
## Summary
- Auto-fixed 459 ruff violations across 76 files using `ruff check --fix`
- Fixed `callable | None` -> `Callable | None` in 3 files (runtime TypeError)
- This is part of the larger tech debt initiative (DEBT-14)

## What was already merged (17 PRs)
The broader tech debt initiative already merged these PRs into main:
- **DEBT-1** (#518): Command injection fix in delegate --each
- **DEBT-3** (#516): Remove unused deps, update ruff
- **DEBT-4** (#515): Expand CI matrix (3.11, 3.12, 3.13) + lint/type-check
- **DEBT-6** (#517): Remove dead code (unused imports, deprecated functions)
- **DEBT-8** (#521): Standardize CLI interfaces
- **DEBT-9** (#520): ON DELETE CASCADE + LOWER(title) index
- **DEBT-16** (#523): Dependabot + Renovate config
- **DEBT-17** (#534): Cascade command tests
- **DEBT-18** (#528): Task command tests
- **DEBT-19** (#557): Delegate command tests
- **DEBT-20** (#531): Reduce test sleep times
- **DEBT-22** (#533): Strengthen weak test assertions
- **DEBT-23** (#527): Release automation workflow
- **DEBT-24** (#532): Consolidate PRAGMA foreign_keys
- **DEBT-25** (#537): COLLATE NOCASE indexes
- **DEBT-28** (merged): O(n^2) duplicate detection optimization
- **DEBT-31** (#538): Architecture Decision Records

## Test plan
- [x] All 1031 tests pass
- [x] No regressions from auto-fixes
- [x] callable type annotation fix verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)