### PR TITLE
refactor: centralize configuration constants (Issue #R4)

### DIFF
--- a/emdx/commands/cascade.py
+++ b/emdx/commands/cascade.py
@@ -21,7 +21,11 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from ..config.constants import EMDX_LOG_DIR
+from ..config.constants import (
+    DEFAULT_CLI_TIMEOUT_SECONDS,
+    EMDX_LOG_DIR,
+    IMPLEMENTATION_TIMEOUT_SECONDS,
+)
 from ..database import cascade as cascade_db
 from ..database.connection import db_connection
 from ..database.documents import get_document, save_document
@@ -170,7 +174,7 @@ def _process_stage(doc: dict, stage: str, cascade_run_id: int = None) -> tuple[b
         execution_id = cursor.lastrowid
 
     # Implementation stage needs longer timeout
-    timeout = 1800 if stage == "planned" else 300
+    timeout = IMPLEMENTATION_TIMEOUT_SECONDS if stage == "planned" else DEFAULT_CLI_TIMEOUT_SECONDS
 
     try:
         result = execute_cli_sync(

--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -38,6 +38,7 @@ from typing import List, Optional
 
 import typer
 
+from ..config.constants import DELEGATE_TIMEOUT_SECONDS, DISCOVERY_TIMEOUT_SECONDS
 from ..database.documents import get_document
 from ..services.unified_executor import ExecutionConfig, UnifiedExecutor
 
@@ -207,7 +208,7 @@ def _run_discovery(command: str) -> List[str]:
             shell=False,
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=DISCOVERY_TIMEOUT_SECONDS,
         )
         if result.returncode != 0:
             sys.stderr.write(f"delegate: discovery failed: {result.stderr.strip()}\n")
@@ -222,7 +223,7 @@ def _run_discovery(command: str) -> List[str]:
         return lines
 
     except subprocess.TimeoutExpired:
-        sys.stderr.write("delegate: discovery command timed out after 30s\n")
+        sys.stderr.write(f"delegate: discovery command timed out after {DISCOVERY_TIMEOUT_SECONDS}s\n")
         raise typer.Exit(1)
 
 
@@ -301,7 +302,7 @@ def _run_single(
         title=doc_title,
         output_instruction=output_instruction,
         working_dir=working_dir or str(Path.cwd()),
-        timeout_seconds=600,
+        timeout_seconds=DELEGATE_TIMEOUT_SECONDS,
         model=model,
     )
 

--- a/emdx/config/cli_config.py
+++ b/emdx/config/cli_config.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional
 
+from .constants import CLAUDE_OPUS_MODEL, CLAUDE_SONNET_MODEL
+
 # Default tools allowed for Claude CLI execution
 # These are the standard tools that most agents need for basic operations
 DEFAULT_ALLOWED_TOOLS: List[str] = [
@@ -76,7 +78,7 @@ CLI_CONFIGS: Dict[CliTool, CliConfig] = {
         default_output_format="stream-json",
         requires_verbose_for_stream=True,
         model_flag="--model",
-        default_model="claude-opus-4-5-20251101",
+        default_model=CLAUDE_OPUS_MODEL,
         supports_allowed_tools=True,
         allowed_tools_flag="--allowedTools",
         force_flag=None,
@@ -106,19 +108,19 @@ CLI_CONFIGS: Dict[CliTool, CliConfig] = {
 # Use these aliases for portable commands that work with either CLI
 MODEL_ALIASES: Dict[str, Dict[str, str]] = {
     "opus": {
-        "claude": "claude-opus-4-5-20251101",
+        "claude": CLAUDE_OPUS_MODEL,
         "cursor": "opus-4.5",
     },
     "sonnet": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": CLAUDE_SONNET_MODEL,
         "cursor": "sonnet-4.5",
     },
     "auto": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": CLAUDE_SONNET_MODEL,
         "cursor": "auto",
     },
     "fast": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": CLAUDE_SONNET_MODEL,
         "cursor": "auto",
     },
 }
@@ -173,8 +175,8 @@ def get_available_models(cli_tool: CliTool) -> List[str]:
     """
     if cli_tool == CliTool.CLAUDE:
         return [
-            "claude-opus-4-5-20251101",
-            "claude-sonnet-4-5-20250929",
+            CLAUDE_OPUS_MODEL,
+            CLAUDE_SONNET_MODEL,
             "opus",
             "sonnet",
         ]

--- a/emdx/config/constants.py
+++ b/emdx/config/constants.py
@@ -187,7 +187,55 @@ DATE_GROUP_TODAY_SECONDS = 3600  # Show as "today" if within 1 hour
 DEFAULT_STAGE_RUNS = 1  # Default number of runs per stage
 
 # =============================================================================
+# TIMEOUT CONSTANTS (in seconds)
+# =============================================================================
+
+# CLI execution timeouts
+DEFAULT_CLI_TIMEOUT_SECONDS = 300  # 5 minutes - default for CLI operations
+DELEGATE_TIMEOUT_SECONDS = 600  # 10 minutes - delegate command execution
+IMPLEMENTATION_TIMEOUT_SECONDS = 1800  # 30 minutes - planned stage/implementation
+DISCOVERY_TIMEOUT_SECONDS = 30  # Discovery command timeout
+
+# Subprocess timeouts
+SUBPROCESS_SHORT_TIMEOUT_SECONDS = 5  # Version checks, quick commands
+SUBPROCESS_MEDIUM_TIMEOUT_SECONDS = 10  # Auth status checks
+
+# =============================================================================
 # CLAUDE MODEL CONFIGURATION
 # =============================================================================
 
-DEFAULT_CLAUDE_MODEL = "claude-opus-4-5-20251101"
+# Primary model identifiers
+CLAUDE_OPUS_MODEL = "claude-opus-4-5-20251101"
+CLAUDE_SONNET_MODEL = "claude-sonnet-4-5-20250929"
+
+# Default model for various operations
+DEFAULT_CLAUDE_MODEL = CLAUDE_OPUS_MODEL
+DEFAULT_ASK_MODEL = CLAUDE_SONNET_MODEL  # Used for Q&A service
+
+# =============================================================================
+# ENVIRONMENT CONFIGURATION
+# =============================================================================
+
+# Required environment variables
+ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY"
+
+
+def validate_environment() -> tuple[bool, list[str]]:
+    """Check for required environment variables.
+
+    Returns:
+        Tuple of (is_valid, list of missing/error messages)
+    """
+    import os
+
+    errors = []
+
+    # Check ANTHROPIC_API_KEY
+    api_key = os.environ.get(ANTHROPIC_API_KEY_ENV)
+    if not api_key:
+        errors.append(
+            f"{ANTHROPIC_API_KEY_ENV} environment variable is not set. "
+            "Set it to use Claude API features."
+        )
+
+    return len(errors) == 0, errors

--- a/emdx/models/executions.py
+++ b/emdx/models/executions.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
+from ..config.constants import STALE_EXECUTION_TIMEOUT_SECONDS
 from ..database.connection import db_connection
 from ..utils.datetime_utils import parse_timestamp
 
@@ -247,11 +248,11 @@ def update_execution_heartbeat(exec_id: int) -> None:
         conn.commit()
 
 
-def get_stale_executions(timeout_seconds: int = 1800) -> List[Execution]:
+def get_stale_executions(timeout_seconds: int = STALE_EXECUTION_TIMEOUT_SECONDS) -> List[Execution]:
     """Get executions that haven't sent a heartbeat recently.
 
     Args:
-        timeout_seconds: Seconds after which an execution is considered stale (default 30 min)
+        timeout_seconds: Seconds after which an execution is considered stale (default from STALE_EXECUTION_TIMEOUT_SECONDS)
 
     Returns:
         List of stale executions

--- a/emdx/services/ask_service.py
+++ b/emdx/services/ask_service.py
@@ -20,6 +20,7 @@ except ImportError:
     anthropic = None  # type: ignore[assignment]
     HAS_ANTHROPIC = False
 
+from ..config.constants import DEFAULT_ASK_MODEL
 from ..database import db
 
 logger = logging.getLogger(__name__)
@@ -38,11 +39,10 @@ class Answer:
 class AskService:
     """Answer questions using your knowledge base."""
 
-    DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
     MIN_EMBEDDINGS_FOR_SEMANTIC = 50  # Use semantic only if we have enough coverage
 
     def __init__(self, model: Optional[str] = None):
-        self.model = model or self.DEFAULT_MODEL
+        self.model = model or DEFAULT_ASK_MODEL
         self._client = None
         self._embedding_service = None
 

--- a/emdx/services/cascade_service.py
+++ b/emdx/services/cascade_service.py
@@ -11,6 +11,10 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List
 
+from emdx.config.constants import (
+    DEFAULT_CLI_TIMEOUT_SECONDS,
+    IMPLEMENTATION_TIMEOUT_SECONDS,
+)
 from emdx.database import cascade as cascade_db
 from emdx.database.connection import db_connection
 from emdx.database.documents import get_document
@@ -94,7 +98,7 @@ def monitor_execution_completion(
     from emdx.models.executions import get_execution, update_execution_status
 
     poll_interval = 2.0
-    max_wait = 1800 if stage == "planned" else 300
+    max_wait = IMPLEMENTATION_TIMEOUT_SECONDS if stage == "planned" else DEFAULT_CLI_TIMEOUT_SECONDS
     start_time = time.time()
 
     while True:

--- a/emdx/services/claude_executor.py
+++ b/emdx/services/claude_executor.py
@@ -22,6 +22,7 @@ from typing import List, Optional
 logger = logging.getLogger(__name__)
 
 from ..config.cli_config import DEFAULT_ALLOWED_TOOLS
+from ..config.constants import DEFAULT_CLI_TIMEOUT_SECONDS, SUBPROCESS_SHORT_TIMEOUT_SECONDS
 from ..utils.environment import ensure_claude_in_path
 from ..utils.structured_logger import ProcessType, StructuredLogger
 from .cli_executor import get_cli_executor
@@ -228,7 +229,7 @@ def execute_cli_sync(
     allowed_tools: Optional[List[str]] = None,
     working_dir: Optional[str] = None,
     doc_id: Optional[str] = None,
-    timeout: int = 300,
+    timeout: int = DEFAULT_CLI_TIMEOUT_SECONDS,
 ) -> dict:
     """Execute a task with specified CLI tool synchronously, waiting for completion.
 
@@ -244,7 +245,7 @@ def execute_cli_sync(
         allowed_tools: List of allowed tools (defaults to DEFAULT_ALLOWED_TOOLS)
         working_dir: Working directory for execution
         doc_id: Document ID (for logging)
-        timeout: Maximum seconds to wait (default 300 = 5 minutes)
+        timeout: Maximum seconds to wait (default from DEFAULT_CLI_TIMEOUT_SECONDS)
 
     Returns:
         Dict with 'success' (bool), 'output' (str) or 'error' (str), and 'exit_code' (int)
@@ -341,7 +342,7 @@ def execute_cli_sync(
                         break
 
         # Get any remaining stderr
-        _, stderr = process.communicate(timeout=5)  # Short timeout since process should be done
+        _, stderr = process.communicate(timeout=SUBPROCESS_SHORT_TIMEOUT_SECONDS)  # Short timeout since process should be done
         stdout = ''.join(stdout_lines)
 
         # Log stderr if any

--- a/emdx/services/execution_monitor.py
+++ b/emdx/services/execution_monitor.py
@@ -8,6 +8,7 @@ import psutil
 
 logger = logging.getLogger(__name__)
 
+from ..config.constants import STALE_EXECUTION_TIMEOUT_SECONDS
 from ..database.connection import db_connection
 from ..models.executions import (
     Execution,
@@ -20,7 +21,7 @@ from ..models.executions import (
 class ExecutionMonitor:
     """Monitor and manage execution lifecycle."""
 
-    def __init__(self, stale_timeout_seconds: int = 1800):
+    def __init__(self, stale_timeout_seconds: int = STALE_EXECUTION_TIMEOUT_SECONDS):
         """Initialize execution monitor.
 
         Args:

--- a/emdx/services/unified_executor.py
+++ b/emdx/services/unified_executor.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from ..config.cli_config import DEFAULT_ALLOWED_TOOLS
-from ..config.constants import EMDX_LOG_DIR
+from ..config.constants import DEFAULT_CLI_TIMEOUT_SECONDS, EMDX_LOG_DIR
 from ..models.executions import create_execution, update_execution_status
 from ..utils.environment import get_subprocess_env
 from .cli_executor import get_cli_executor
@@ -145,7 +145,7 @@ class ExecutionConfig:
     doc_id: Optional[int] = None
     output_instruction: Optional[str] = None
     allowed_tools: List[str] = field(default_factory=lambda: DEFAULT_ALLOWED_TOOLS.copy())
-    timeout_seconds: int = 300
+    timeout_seconds: int = DEFAULT_CLI_TIMEOUT_SECONDS
     cli_tool: str = "claude"  # "claude" or "cursor"
     model: Optional[str] = None  # Override default model for the CLI
     verbose: bool = False  # Stream output in real-time


### PR DESCRIPTION
## Summary
- Add timeout constants (DEFAULT_CLI_TIMEOUT_SECONDS, DELEGATE_TIMEOUT_SECONDS, IMPLEMENTATION_TIMEOUT_SECONDS, DISCOVERY_TIMEOUT_SECONDS, SUBPROCESS_SHORT_TIMEOUT_SECONDS, SUBPROCESS_MEDIUM_TIMEOUT_SECONDS)
- Add model name constants (CLAUDE_OPUS_MODEL, CLAUDE_SONNET_MODEL, DEFAULT_ASK_MODEL)
- Add validate_environment() function to check for ANTHROPIC_API_KEY
- Update top 10 call sites to use centralized constants

## Test plan
- [x] Run poetry run pytest tests/ -x to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)