### PR TITLE
refactor(commands): Adopt command helpers to reduce code duplication

### DIFF
--- a/emdx/commands/_helpers.py
+++ b/emdx/commands/_helpers.py
@@ -1,0 +1,187 @@
+"""Shared command helpers to reduce duplication across commands.
+
+This module provides:
+- require_document(): Fetch a document or exit with error
+- @handle_command_error: Consistent error handling decorator
+- @ensure_schema: Ensures database schema before command execution
+"""
+
+from functools import wraps
+from typing import Any, Callable, TypeVar
+
+import typer
+
+from emdx.database import db
+from emdx.models.documents import get_document
+from emdx.utils.output import console
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class DocumentNotFoundError(Exception):
+    """Raised when a document cannot be found."""
+
+    def __init__(self, identifier: str):
+        self.identifier = identifier
+        super().__init__(f"Document '{identifier}' not found")
+
+
+def require_document(identifier: str | int) -> dict[str, Any]:
+    """Fetch a document by ID or title, or exit with error if not found.
+
+    Args:
+        identifier: Document ID (int or str) or title string
+
+    Returns:
+        Document dict with all fields
+
+    Raises:
+        typer.Exit: If document is not found (exits with code 1)
+
+    Example:
+        doc = require_document(42)
+        doc = require_document("My Document Title")
+    """
+    doc = get_document(str(identifier))
+    if not doc:
+        console.print(f"[red]Error: Document '{identifier}' not found[/red]")
+        raise typer.Exit(1)
+    return doc
+
+
+def require_document_or_raise(identifier: str | int) -> dict[str, Any]:
+    """Fetch a document by ID or title, or raise DocumentNotFoundError.
+
+    Use this variant when you want to handle the error yourself or when
+    using inside @handle_command_error decorated functions.
+
+    Args:
+        identifier: Document ID (int or str) or title string
+
+    Returns:
+        Document dict with all fields
+
+    Raises:
+        DocumentNotFoundError: If document is not found
+    """
+    doc = get_document(str(identifier))
+    if not doc:
+        raise DocumentNotFoundError(str(identifier))
+    return doc
+
+
+def handle_command_error(
+    operation: str | None = None,
+    *,
+    exit_code: int = 1,
+    reraise_abort: bool = True,
+) -> Callable[[F], F]:
+    """Decorator for consistent error handling in CLI commands.
+
+    Catches exceptions and displays a formatted error message before exiting.
+    Handles typer.Abort specially to show "Cancelled" message.
+
+    Args:
+        operation: Description of the operation for error messages (e.g., "viewing document")
+                  If not provided, extracts from function name.
+        exit_code: Exit code to use on error (default: 1)
+        reraise_abort: Whether to let typer.Abort propagate (default: True)
+
+    Example:
+        @app.command()
+        @handle_command_error("viewing document")
+        def view(doc_id: int):
+            doc = require_document(doc_id)
+            ...
+
+        @app.command()
+        @handle_command_error()  # Auto-detects operation from function name
+        def delete(doc_id: int):
+            ...
+    """
+
+    def decorator(func: F) -> F:
+        # Auto-detect operation from function name if not provided
+        op = operation
+        if op is None:
+            # Convert function name: "list_tags" -> "listing tags"
+            name = func.__name__.replace("_", " ")
+            if name.endswith("s"):
+                op = f"{name}ing"[:-1]  # "tags" -> "tagging"
+            else:
+                op = f"{name}ing"
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return func(*args, **kwargs)
+            except typer.Exit:
+                # Let explicit exits pass through
+                raise
+            except typer.Abort:
+                console.print("[yellow]Cancelled[/yellow]")
+                if reraise_abort:
+                    raise typer.Exit(0) from None
+                raise
+            except DocumentNotFoundError as e:
+                console.print(f"[red]Error: Document '{e.identifier}' not found[/red]")
+                raise typer.Exit(exit_code) from e
+            except Exception as e:
+                console.print(f"[red]Error {op}: {e}[/red]")
+                raise typer.Exit(exit_code) from e
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def ensure_schema(func: F) -> F:
+    """Decorator to ensure database schema exists before command execution.
+
+    This should be applied to command functions that interact with the database.
+    It calls db.ensure_schema() before executing the function.
+
+    Example:
+        @app.command()
+        @ensure_schema
+        def view(doc_id: int):
+            doc = require_document(doc_id)
+            ...
+
+    Can be combined with handle_command_error (order matters - ensure_schema should be inner):
+        @app.command()
+        @handle_command_error("viewing document")
+        @ensure_schema
+        def view(doc_id: int):
+            ...
+    """
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        db.ensure_schema()
+        return func(*args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]
+
+
+def combined_decorator(operation: str | None = None) -> Callable[[F], F]:
+    """Convenience decorator combining @handle_command_error and @ensure_schema.
+
+    This is the most common pattern for commands - ensure schema and handle errors.
+
+    Args:
+        operation: Description of the operation for error messages
+
+    Example:
+        @app.command()
+        @combined_decorator("viewing document")
+        def view(doc_id: int):
+            doc = require_document(doc_id)
+            ...
+    """
+
+    def decorator(func: F) -> F:
+        # Apply decorators in correct order: error handling wraps schema check
+        return handle_command_error(operation)(ensure_schema(func))
+
+    return decorator

--- a/emdx/commands/browse.py
+++ b/emdx/commands/browse.py
@@ -2,10 +2,11 @@
 Browse and analytics commands for emdx
 """
 
-
 import typer
 from rich.table import Table
 
+from emdx.commands._helpers import combined_decorator
+from emdx.config.constants import TITLE_TRUNCATE_LENGTH
 from emdx.database import db
 from emdx.models.documents import get_recent_documents, get_stats, list_documents
 from emdx.utils.datetime_utils import format_datetime as _format_datetime
@@ -16,122 +17,109 @@ app = typer.Typer(help="Browse and list documents with statistics")
 
 
 @app.command()
+@combined_decorator("listing documents")
 def list(
     project: str | None = typer.Option(None, "--project", "-p", help="Filter by project"),
     limit: int = typer.Option(50, "--limit", "-n", help="Maximum documents to show"),
     format: str = typer.Option("table", "--format", "-f", help="Output format: table, json, csv"),
 ):
     """List all documents in the knowledge base"""
-    try:
-        import json
+    import json
 
-        # Ensure database schema exists
-        db.ensure_schema()
+    # Query database
+    docs = list_documents(project=project, limit=limit)
 
-        # Query database
-        docs = list_documents(project=project, limit=limit)
+    if not docs:
+        console.print("[yellow]No documents found[/yellow]")
+        return
 
-        if not docs:
-            console.print("[yellow]No documents found[/yellow]")
-            return
+    if format == "table":
+        # Create table with title
+        title = "Knowledge Base Documents"
+        if project:
+            title += f" - Project: {project}"
 
-        if format == "table":
-            # Create table with title
-            title = "Knowledge Base Documents"
-            if project:
-                title += f" - Project: {project}"
-
-            table = Table(title=title)
-            table.add_column("ID", style="cyan", no_wrap=True)
-            table.add_column("Title", style="magenta")
-            table.add_column("Project", style="green")
-            table.add_column("Created", style="yellow")
-            table.add_column("Views", justify="right", style="blue")
-
-            # Add rows from database
-            for doc in docs:
-                table.add_row(
-                    str(doc["id"]),
-                    truncate_title(doc["title"]),
-                    doc["project"] or "None",
-                    doc["created_at"].strftime("%Y-%m-%d"),
-                    str(doc["access_count"]),
-                )
-
-            console.print(table)
-            console.print(f"\n[dim]Showing {len(docs)} of {len(docs)} documents[/dim]")
-
-        elif format == "json":
-            # Convert datetime objects to strings
-            for doc in docs:
-                doc["created_at"] = doc["created_at"].isoformat()
-                if doc.get("accessed_at"):
-                    doc["accessed_at"] = doc["accessed_at"].isoformat()
-            # Use plain print for machine-parseable output
-            print(json.dumps(docs, indent=2))
-
-        elif format == "csv":
-            print("id,title,project,created,views")
-            for doc in docs:
-                # Escape commas in title
-                title = doc["title"].replace(",", "\\,")
-                print(
-                    f"{doc['id']},{title},{doc['project'] or ''}"
-                    f",{doc['created_at'].strftime('%Y-%m-%d')},{doc['access_count']}"
-                )
-
-    except Exception as e:
-        console.print(f"[red]Error listing documents: {e}[/red]")
-        raise typer.Exit(1) from e
-
-
-@app.command()
-def recent(
-    limit: int = typer.Argument(10, help="Number of recent documents to show"),
-):
-    """Show recently accessed documents"""
-    try:
-        # Ensure database schema exists
-        db.ensure_schema()
-
-        # Query database for recently accessed documents
-        docs = get_recent_documents(limit=limit)
-
-        if not docs:
-            console.print("[yellow]No recently accessed documents found[/yellow]")
-            return
-
-        table = Table(title=f"Last {limit} Accessed Documents")
+        table = Table(title=title)
         table.add_column("ID", style="cyan", no_wrap=True)
         table.add_column("Title", style="magenta")
         table.add_column("Project", style="green")
-        table.add_column("Last Accessed", style="yellow")
+        table.add_column("Created", style="yellow")
         table.add_column("Views", justify="right", style="blue")
 
         # Add rows from database
         for doc in docs:
-            # Format accessed_at datetime
-            accessed_str = "Never"
-            if doc["accessed_at"]:
-                accessed_str = doc["accessed_at"].strftime("%Y-%m-%d %H:%M")
-
             table.add_row(
                 str(doc["id"]),
-                truncate_title(doc["title"]),
+                truncate_title(doc["title"], TITLE_TRUNCATE_LENGTH),
                 doc["project"] or "None",
-                accessed_str,
+                doc["created_at"].strftime("%Y-%m-%d"),
                 str(doc["access_count"]),
             )
 
         console.print(table)
-        console.print(f"\n[dim]Showing {len(docs)} recently accessed documents[/dim]")
+        console.print(f"\n[dim]Showing {len(docs)} of {len(docs)} documents[/dim]")
 
-    except Exception as e:
-        console.print(f"[red]Error getting recent documents: {e}[/red]")
-        raise typer.Exit(1) from e
+    elif format == "json":
+        # Convert datetime objects to strings
+        for doc in docs:
+            doc["created_at"] = doc["created_at"].isoformat()
+            if doc.get("accessed_at"):
+                doc["accessed_at"] = doc["accessed_at"].isoformat()
+        # Use plain print for machine-parseable output
+        print(json.dumps(docs, indent=2))
+
+    elif format == "csv":
+        print("id,title,project,created,views")
+        for doc in docs:
+            # Escape commas in title
+            title = doc["title"].replace(",", "\\,")
+            print(
+                f"{doc['id']},{title},{doc['project'] or ''}"
+                f",{doc['created_at'].strftime('%Y-%m-%d')},{doc['access_count']}"
+            )
 
 
 @app.command()
+@combined_decorator("getting recent documents")
+def recent(
+    limit: int = typer.Argument(10, help="Number of recent documents to show"),
+):
+    """Show recently accessed documents"""
+    # Query database for recently accessed documents
+    docs = get_recent_documents(limit=limit)
+
+    if not docs:
+        console.print("[yellow]No recently accessed documents found[/yellow]")
+        return
+
+    table = Table(title=f"Last {limit} Accessed Documents")
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Title", style="magenta")
+    table.add_column("Project", style="green")
+    table.add_column("Last Accessed", style="yellow")
+    table.add_column("Views", justify="right", style="blue")
+
+    # Add rows from database
+    for doc in docs:
+        # Format accessed_at datetime
+        accessed_str = "Never"
+        if doc["accessed_at"]:
+            accessed_str = doc["accessed_at"].strftime("%Y-%m-%d %H:%M")
+
+        table.add_row(
+            str(doc["id"]),
+            truncate_title(doc["title"], TITLE_TRUNCATE_LENGTH),
+            doc["project"] or "None",
+            accessed_str,
+            str(doc["access_count"]),
+        )
+
+    console.print(table)
+    console.print(f"\n[dim]Showing {len(docs)} recently accessed documents[/dim]")
+
+
+@app.command()
+@combined_decorator("getting statistics")
 def stats(
     project: str | None = typer.Option(
         None, "--project", "-p", help="Show stats for specific project"
@@ -139,115 +127,107 @@ def stats(
     detailed: bool = typer.Option(False, "--detailed", "-d", help="Show detailed statistics"),
 ):
     """Show knowledge base statistics"""
-    try:
-        # Ensure database schema exists
-        db.ensure_schema()
+    # Query database for statistics
+    stats_data = get_stats(project=project)
 
-        # Query database for statistics
-        stats_data = get_stats(project=project)
+    if project:
+        console.print(f"[bold]Knowledge Base Statistics - Project: {project}[/bold]")
+    else:
+        console.print("[bold]Knowledge Base Statistics[/bold]")
+    console.print("=" * 40)
 
-        if project:
-            console.print(f"[bold]Knowledge Base Statistics - Project: {project}[/bold]")
-        else:
-            console.print("[bold]Knowledge Base Statistics[/bold]")
-        console.print("=" * 40)
+    # Format and display basic stats
+    console.print(f"[blue]Total Documents:[/blue] {stats_data.get('total_documents', 0)}")
 
-        # Format and display basic stats
-        console.print(f"[blue]Total Documents:[/blue] {stats_data.get('total_documents', 0)}")
+    if not project:
+        console.print(f"[blue]Total Projects:[/blue] {stats_data.get('total_projects', 0)}")
 
+    console.print(f"[blue]Total Views:[/blue] {stats_data.get('total_views', 0)}")
+    console.print(f"[blue]Average Views:[/blue] {stats_data.get('avg_views', 0):.1f}")
+    console.print(f"[blue]Database Size:[/blue] {stats_data.get('table_size', '0 MB')}")
+
+    # Most viewed document
+    if stats_data.get("most_viewed"):
+        most_viewed = stats_data["most_viewed"]
+        console.print(
+            f"[blue]Most Viewed:[/blue] \"{most_viewed['title']}\" "
+            f"({most_viewed['access_count']} views)"
+        )
+    else:
+        console.print("[blue]Most Viewed:[/blue] N/A")
+
+    # Most recent document
+    newest_date = stats_data.get("newest_doc")
+    console.print(f"[blue]Most Recent:[/blue] {_format_datetime(newest_date)}")
+
+    if detailed:
+        console.print("\n[bold]Detailed Statistics[/bold]")
+        console.print("-" * 40)
+
+        # Show project breakdown if viewing overall stats
         if not project:
-            console.print(f"[blue]Total Projects:[/blue] {stats_data.get('total_projects', 0)}")
-
-        console.print(f"[blue]Total Views:[/blue] {stats_data.get('total_views', 0)}")
-        console.print(f"[blue]Average Views:[/blue] {stats_data.get('avg_views', 0):.1f}")
-        console.print(f"[blue]Database Size:[/blue] {stats_data.get('table_size', '0 MB')}")
-
-        # Most viewed document
-        if stats_data.get("most_viewed"):
-            most_viewed = stats_data["most_viewed"]
-            console.print(
-                f"[blue]Most Viewed:[/blue] \"{most_viewed['title']}\" "
-                f"({most_viewed['access_count']} views)"
-            )
-        else:
-            console.print("[blue]Most Viewed:[/blue] N/A")
-
-        # Most recent document
-        newest_date = stats_data.get("newest_doc")
-        console.print(f"[blue]Most Recent:[/blue] {_format_datetime(newest_date)}")
-
-        if detailed:
-            console.print("\n[bold]Detailed Statistics[/bold]")
-            console.print("-" * 40)
-
-            # Show project breakdown if viewing overall stats
-            if not project:
-                with db.get_connection() as conn:
-                    cursor = conn.execute(
-                        """
-                        SELECT
-                            project,
-                            COUNT(*) as doc_count,
-                            SUM(access_count) as total_views,
-                            MAX(created_at) as last_updated
-                        FROM documents
-                        WHERE is_deleted = FALSE
-                        GROUP BY project
-                        ORDER BY doc_count DESC
-                        """
-                    )
-
-                    project_table = Table(title="Documents by Project")
-                    project_table.add_column("Project", style="green")
-                    project_table.add_column("Documents", justify="right", style="cyan")
-                    project_table.add_column("Total Views", justify="right", style="blue")
-                    project_table.add_column("Last Updated", style="yellow")
-
-                    for row in cursor.fetchall():
-                        project_name = row[0] or "None"
-                        doc_count = row[1]
-                        total_views = row[2] or 0
-                        last_updated = row[3]
-
-                        project_table.add_row(
-                            project_name,
-                            str(doc_count),
-                            str(total_views),
-                            _format_datetime(last_updated, "%Y-%m-%d"),
-                        )
-
-                    console.print(project_table)
-
-            # Show access patterns
             with db.get_connection() as conn:
                 cursor = conn.execute(
                     """
                     SELECT
-                        CASE
-                            WHEN access_count = 0 THEN 'Never accessed'
-                            WHEN access_count <= 5 THEN '1-5 views'
-                            WHEN access_count <= 10 THEN '6-10 views'
-                            WHEN access_count <= 25 THEN '11-25 views'
-                            ELSE '25+ views'
-                        END as view_range,
-                        COUNT(*) as document_count
+                        project,
+                        COUNT(*) as doc_count,
+                        SUM(access_count) as total_views,
+                        MAX(created_at) as last_updated
                     FROM documents
                     WHERE is_deleted = FALSE
+                    GROUP BY project
+                    ORDER BY doc_count DESC
                     """
-                    + (" AND project = ?" if project else "")
-                    + """
-                    GROUP BY view_range
-                    ORDER BY MIN(access_count)
-                    """,
-                    (project,) if project else (),
                 )
 
-                console.print("\n[bold]Access Patterns[/bold]")
-                for row in cursor.fetchall():
-                    console.print(f"[blue]{row[0]}:[/blue] {row[1]} documents")
+                project_table = Table(title="Documents by Project")
+                project_table.add_column("Project", style="green")
+                project_table.add_column("Documents", justify="right", style="cyan")
+                project_table.add_column("Total Views", justify="right", style="blue")
+                project_table.add_column("Last Updated", style="yellow")
 
-    except Exception as e:
-        console.print(f"[red]Error getting statistics: {e}[/red]")
-        raise typer.Exit(1) from e
+                for row in cursor.fetchall():
+                    project_name = row[0] or "None"
+                    doc_count = row[1]
+                    total_views = row[2] or 0
+                    last_updated = row[3]
+
+                    project_table.add_row(
+                        project_name,
+                        str(doc_count),
+                        str(total_views),
+                        _format_datetime(last_updated, "%Y-%m-%d"),
+                    )
+
+                console.print(project_table)
+
+        # Show access patterns
+        with db.get_connection() as conn:
+            cursor = conn.execute(
+                """
+                SELECT
+                    CASE
+                        WHEN access_count = 0 THEN 'Never accessed'
+                        WHEN access_count <= 5 THEN '1-5 views'
+                        WHEN access_count <= 10 THEN '6-10 views'
+                        WHEN access_count <= 25 THEN '11-25 views'
+                        ELSE '25+ views'
+                    END as view_range,
+                    COUNT(*) as document_count
+                FROM documents
+                WHERE is_deleted = FALSE
+                """
+                + (" AND project = ?" if project else "")
+                + """
+                GROUP BY view_range
+                ORDER BY MIN(access_count)
+                """,
+                (project,) if project else (),
+            )
+
+            console.print("\n[bold]Access Patterns[/bold]")
+            for row in cursor.fetchall():
+                console.print(f"[blue]{row[0]}:[/blue] {row[1]} documents")
 
 

--- a/emdx/commands/tags.py
+++ b/emdx/commands/tags.py
@@ -5,13 +5,12 @@ The `add` subcommand is also the default callback, so `emdx tag 42 gameplan`
 works as a shorthand for `emdx tag add 42 gameplan`.
 """
 
-
-
 import typer
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
-from emdx.database import db
+from emdx.commands._helpers import combined_decorator, require_document
+from emdx.config.constants import TITLE_TRUNCATE_LENGTH
 from emdx.models.documents import get_document
 from emdx.models.tags import (
     add_tags_to_document,
@@ -29,6 +28,7 @@ from emdx.utils.text_formatting import truncate_title
 app = typer.Typer(help="Manage document tags")
 
 
+@combined_decorator("adding tags")
 def _add_tags_impl(
     doc_id: int,
     tags: list[str] | None,
@@ -36,88 +36,77 @@ def _add_tags_impl(
     suggest: bool,
 ):
     """Shared implementation for adding tags (used by both callback and add subcommand)."""
-    try:
-        # Ensure database schema exists
-        db.ensure_schema()
+    # Check if document exists
+    doc = require_document(doc_id)
 
-        # Check if document exists
-        doc = get_document(str(doc_id))
-        if not doc:
-            console.print(f"[red]Error: Document #{doc_id} not found[/red]")
-            raise typer.Exit(1)
-
-        # Handle auto-tagging
-        if auto:
-            tagger = AutoTagger()
-            applied = tagger.auto_tag_document(doc_id, confidence_threshold=0.7)
-            if applied:
-                console.print(
-                    f"[green]Auto-tagged #{doc_id} with:[/green] [cyan]{format_tags(applied)}[/cyan]"
-                )
-            else:
-                console.print("[yellow]No tags met confidence threshold for auto-tagging[/yellow]")
-
-            # Show all tags
-            all_tags = get_document_tags(doc_id)
-            console.print(f"[dim]All tags:[/dim] {format_tags(all_tags)}")
-            return
-
-        # Handle suggestions
-        if suggest:
-            tagger = AutoTagger()
-            suggestions = tagger.suggest_tags(doc_id)
-
-            if suggestions:
-                console.print(f"\n[bold]Tag suggestions for #{doc_id}: {doc['title']}[/bold]\n")
-
-                table = Table(show_header=True, header_style="bold cyan")
-                table.add_column("Tag", style="cyan")
-                table.add_column("Confidence", justify="right")
-                table.add_column("Apply?", style="dim")
-
-                for tag_name, confidence in suggestions:
-                    conf_percent = f"{confidence:.0%}"
-                    apply_hint = "High" if confidence >= 0.8 else "Medium" if confidence >= 0.7 else "Low"
-                    table.add_row(tag_name, conf_percent, apply_hint)
-
-                console.print(table)
-                console.print("\n[dim]Use 'emdx tag add ID TAG...' to apply tags[/dim]")
-            else:
-                console.print("[yellow]No tag suggestions found[/yellow]")
-
-            # Show current tags
-            current_tags = get_document_tags(doc_id)
-            if current_tags:
-                console.print(f"\n[dim]Current tags:[/dim] {format_tags(current_tags)}")
-            return
-
-        # If no tags provided and no auto/suggest, show current tags
-        if not tags:
-            current_tags = get_document_tags(doc_id)
-            if current_tags:
-                console.print(f"\n[bold]Tags for #{doc_id}: {doc['title']}[/bold]")
-                console.print(f"[cyan]{format_tags(current_tags)}[/cyan]")
-            else:
-                console.print(f"[yellow]No tags for #{doc_id}: {doc['title']}[/yellow]")
-            return
-
-        # Add tags manually
-        added_tags = add_tags_to_document(doc_id, tags)
-
-        if added_tags:
+    # Handle auto-tagging
+    if auto:
+        tagger = AutoTagger()
+        applied = tagger.auto_tag_document(doc_id, confidence_threshold=0.7)
+        if applied:
             console.print(
-                f"[green]Added tags to #{doc_id}:[/green] [cyan]{format_tags(added_tags)}[/cyan]"
+                f"[green]Auto-tagged #{doc_id} with:[/green] [cyan]{format_tags(applied)}[/cyan]"
             )
         else:
-            console.print("[yellow]No new tags added (may already exist)[/yellow]")
+            console.print("[yellow]No tags met confidence threshold for auto-tagging[/yellow]")
 
-        # Show all tags for the document
+        # Show all tags
         all_tags = get_document_tags(doc_id)
         console.print(f"[dim]All tags:[/dim] {format_tags(all_tags)}")
+        return
 
-    except Exception as e:
-        console.print(f"[red]Error adding tags: {e}[/red]")
-        raise typer.Exit(1) from e
+    # Handle suggestions
+    if suggest:
+        tagger = AutoTagger()
+        suggestions = tagger.suggest_tags(doc_id)
+
+        if suggestions:
+            console.print(f"\n[bold]Tag suggestions for #{doc_id}: {doc['title']}[/bold]\n")
+
+            table = Table(show_header=True, header_style="bold cyan")
+            table.add_column("Tag", style="cyan")
+            table.add_column("Confidence", justify="right")
+            table.add_column("Apply?", style="dim")
+
+            for tag_name, confidence in suggestions:
+                conf_percent = f"{confidence:.0%}"
+                apply_hint = "High" if confidence >= 0.8 else "Medium" if confidence >= 0.7 else "Low"
+                table.add_row(tag_name, conf_percent, apply_hint)
+
+            console.print(table)
+            console.print("\n[dim]Use 'emdx tag add ID TAG...' to apply tags[/dim]")
+        else:
+            console.print("[yellow]No tag suggestions found[/yellow]")
+
+        # Show current tags
+        current_tags = get_document_tags(doc_id)
+        if current_tags:
+            console.print(f"\n[dim]Current tags:[/dim] {format_tags(current_tags)}")
+        return
+
+    # If no tags provided and no auto/suggest, show current tags
+    if not tags:
+        current_tags = get_document_tags(doc_id)
+        if current_tags:
+            console.print(f"\n[bold]Tags for #{doc_id}: {doc['title']}[/bold]")
+            console.print(f"[cyan]{format_tags(current_tags)}[/cyan]")
+        else:
+            console.print(f"[yellow]No tags for #{doc_id}: {doc['title']}[/yellow]")
+        return
+
+    # Add tags manually
+    added_tags = add_tags_to_document(doc_id, tags)
+
+    if added_tags:
+        console.print(
+            f"[green]Added tags to #{doc_id}:[/green] [cyan]{format_tags(added_tags)}[/cyan]"
+        )
+    else:
+        console.print("[yellow]No new tags added (may already exist)[/yellow]")
+
+    # Show all tags for the document
+    all_tags = get_document_tags(doc_id)
+    console.print(f"[dim]All tags:[/dim] {format_tags(all_tags)}")
 
 
 @app.callback()
@@ -142,183 +131,147 @@ def add(
 
 
 @app.command()
+@combined_decorator("removing tags")
 def remove(
     doc_id: int = typer.Argument(..., help="Document ID to untag"),
     tags: list[str] = typer.Argument(..., help="Tags to remove (space-separated)"),
 ):
     """Remove tags from a document."""
-    try:
-        # Ensure database schema exists
-        db.ensure_schema()
+    # Check if document exists
+    doc = require_document(doc_id)
 
-        # Check if document exists
-        doc = get_document(str(doc_id))
-        if not doc:
-            console.print(f"[red]Error: Document #{doc_id} not found[/red]")
-            raise typer.Exit(1)
+    # Remove tags
+    removed_tags = remove_tags_from_document(doc_id, tags)
 
-        # Remove tags
-        removed_tags = remove_tags_from_document(doc_id, tags)
+    if removed_tags:
+        console.print(
+            f"[green]✅ Removed tags from #{doc_id}:[/green] "
+            f"[cyan]{format_tags(removed_tags)}[/cyan]"
+        )
+    else:
+        console.print("[yellow]No tags removed (may not exist)[/yellow]")
 
-        if removed_tags:
-            console.print(
-                f"[green]✅ Removed tags from #{doc_id}:[/green] "
-                f"[cyan]{format_tags(removed_tags)}[/cyan]"
-            )
-        else:
-            console.print("[yellow]No tags removed (may not exist)[/yellow]")
-
-        # Show remaining tags
-        remaining_tags = get_document_tags(doc_id)
-        if remaining_tags:
-            console.print(f"[dim]Remaining tags:[/dim] {format_tags(remaining_tags)}")
-        else:
-            console.print("[dim]No tags remaining[/dim]")
-
-    except Exception as e:
-        console.print(f"[red]Error removing tags: {e}[/red]")
-        raise typer.Exit(1) from e
+    # Show remaining tags
+    remaining_tags = get_document_tags(doc_id)
+    if remaining_tags:
+        console.print(f"[dim]Remaining tags:[/dim] {format_tags(remaining_tags)}")
+    else:
+        console.print("[dim]No tags remaining[/dim]")
 
 
 @app.command("list")
+@combined_decorator("listing tags")
 def list_tags(
     sort: str = typer.Option("usage", "--sort", "-s", help="Sort by: usage, name, created"),
     limit: int = typer.Option(50, "--limit", "-n", help="Maximum tags to show"),
 ):
     """List all tags with statistics."""
-    try:
-        # Ensure database schema exists
-        db.ensure_schema()
+    # Get all tags
+    all_tags = list_all_tags(sort_by=sort)
 
-        # Get all tags
-        all_tags = list_all_tags(sort_by=sort)
+    if not all_tags:
+        console.print("[yellow]No tags found[/yellow]")
+        return
 
-        if not all_tags:
-            console.print("[yellow]No tags found[/yellow]")
-            return
+    # Display tags in a table
+    console.print(f"\n[bold]📏 Tag Statistics (sorted by {sort}):[/bold]\n")
 
-        # Display tags in a table
-        console.print(f"\n[bold]📏 Tag Statistics (sorted by {sort}):[/bold]\n")
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("Tag", style="cyan")
+    table.add_column("Count", style="yellow", justify="right")
+    table.add_column("Created", style="green")
+    table.add_column("Last Used", style="magenta")
 
-        table = Table(show_header=True, header_style="bold cyan")
-        table.add_column("Tag", style="cyan")
-        table.add_column("Count", style="yellow", justify="right")
-        table.add_column("Created", style="green")
-        table.add_column("Last Used", style="magenta")
+    for tag_entry in all_tags[:limit]:
+        created = tag_entry["created_at"].strftime("%Y-%m-%d") if tag_entry["created_at"] else "Unknown"
+        last_used = tag_entry["last_used"].strftime("%Y-%m-%d") if tag_entry["last_used"] else "Never"
 
-        for tag_entry in all_tags[:limit]:
-            created = tag_entry["created_at"].strftime("%Y-%m-%d") if tag_entry["created_at"] else "Unknown"
-            last_used = tag_entry["last_used"].strftime("%Y-%m-%d") if tag_entry["last_used"] else "Never"
+        table.add_row(tag_entry["name"], str(tag_entry["count"]), created, last_used)
 
-            table.add_row(tag_entry["name"], str(tag_entry["count"]), created, last_used)
+    console.print(table)
 
-        console.print(table)
+    if len(all_tags) > limit:
+        console.print(f"\n[dim]Showing {limit} of {len(all_tags)} tags[/dim]")
 
-        if len(all_tags) > limit:
-            console.print(f"\n[dim]Showing {limit} of {len(all_tags)} tags[/dim]")
-
-        console.print(f"\n[dim]Total tags: {len(all_tags)}[/dim]")
-
-    except Exception as e:
-        console.print(f"[red]Error listing tags: {e}[/red]")
-        raise typer.Exit(1) from e
+    console.print(f"\n[dim]Total tags: {len(all_tags)}[/dim]")
 
 
 @app.command()
+@combined_decorator("renaming tag")
 def rename(
     old_tag: str = typer.Argument(..., help="Old tag name"),
     new_tag: str = typer.Argument(..., help="New tag name"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
 ):
     """Rename a tag globally."""
-    try:
-        # Ensure database schema exists
-        db.ensure_schema()
+    # Get current usage
+    all_tags = list_all_tags()
+    old_tag_info = next((t for t in all_tags if t["name"] == old_tag.lower()), None)
 
-        # Get current usage
-        all_tags = list_all_tags()
-        old_tag_info = next((t for t in all_tags if t["name"] == old_tag.lower()), None)
+    if not old_tag_info:
+        console.print(f"[red]Error: Tag '{old_tag}' not found[/red]")
+        raise typer.Exit(1)
 
-        if not old_tag_info:
-            console.print(f"[red]Error: Tag '{old_tag}' not found[/red]")
-            raise typer.Exit(1)
+    # Confirm
+    if not force:
+        console.print(
+            f"\n[yellow]This will rename tag '{old_tag}' to '{new_tag}' across "
+            f"{old_tag_info['count']} document(s)[/yellow]"
+        )
+        typer.confirm("Continue?", abort=True)
 
-        # Confirm
-        if not force:
-            console.print(
-                f"\n[yellow]This will rename tag '{old_tag}' to '{new_tag}' across "
-                f"{old_tag_info['count']} document(s)[/yellow]"
-            )
-            typer.confirm("Continue?", abort=True)
+    # Rename
+    success = rename_tag(old_tag, new_tag)
 
-        # Rename
-        success = rename_tag(old_tag, new_tag)
-
-        if success:
-            console.print(f"[green]✅ Renamed tag '{old_tag}' to '{new_tag}'[/green]")
-        else:
-            console.print(f"[red]Error: Could not rename tag ('{new_tag}' may already exist)[/red]")
-            raise typer.Exit(1)
-
-    except typer.Abort:
-        console.print("[yellow]Rename cancelled[/yellow]")
-        raise typer.Exit(0) from None
-    except Exception as e:
-        console.print(f"[red]Error renaming tag: {e}[/red]")
-        raise typer.Exit(1) from e
+    if success:
+        console.print(f"[green]✅ Renamed tag '{old_tag}' to '{new_tag}'[/green]")
+    else:
+        console.print(f"[red]Error: Could not rename tag ('{new_tag}' may already exist)[/red]")
+        raise typer.Exit(1)
 
 
 @app.command()
+@combined_decorator("merging tags")
 def merge(
     source_tags: list[str] = typer.Argument(..., help="Source tags to merge"),
     target: str = typer.Option(..., "--into", "-i", help="Target tag to merge into"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
 ):
     """Merge multiple tags into one."""
-    try:
-        # Ensure database schema exists
-        db.ensure_schema()
+    # Get info about source tags
+    all_tags = list_all_tags()
+    source_infos = []
+    total_docs = 0
 
-        # Get info about source tags
-        all_tags = list_all_tags()
-        source_infos = []
-        total_docs = 0
+    for tag_name in source_tags:
+        tag_info = next((t for t in all_tags if t["name"] == tag_name.lower()), None)
+        if tag_info:
+            source_infos.append(tag_info)
+            total_docs += tag_info["count"]
 
-        for tag_name in source_tags:
-            tag_info = next((t for t in all_tags if t["name"] == tag_name.lower()), None)
-            if tag_info:
-                source_infos.append(tag_info)
-                total_docs += tag_info["count"]
+    if not source_infos:
+        console.print("[red]Error: No valid source tags found[/red]")
+        raise typer.Exit(1)
 
-        if not source_infos:
-            console.print("[red]Error: No valid source tags found[/red]")
-            raise typer.Exit(1)
+    # Confirm
+    if not force:
+        console.print(
+            f"\n[yellow]This will merge {len(source_infos)} tag(s) into '{target}':[/yellow]"
+        )
+        for info in source_infos:
+            console.print(f"  • {info['name']} ({info['count']} documents)")
+        console.print(f"\n[yellow]Affecting up to {total_docs} document associations[/yellow]")
+        typer.confirm("Continue?", abort=True)
 
-        # Confirm
-        if not force:
-            console.print(
-                f"\n[yellow]This will merge {len(source_infos)} tag(s) into '{target}':[/yellow]"
-            )
-            for info in source_infos:
-                console.print(f"  • {info['name']} ({info['count']} documents)")
-            console.print(f"\n[yellow]Affecting up to {total_docs} document associations[/yellow]")
-            typer.confirm("Continue?", abort=True)
+    # Merge
+    merged_count = merge_tags(source_tags, target)
 
-        # Merge
-        merged_count = merge_tags(source_tags, target)
-
-        console.print(f"[green]✅ Merged {len(source_infos)} tag(s) into '{target}'[/green]")
-        console.print(f"[dim]Updated {merged_count} document associations[/dim]")
-
-    except typer.Abort:
-        console.print("[yellow]Merge cancelled[/yellow]")
-        raise typer.Exit(0) from None
-    except Exception as e:
-        console.print(f"[red]Error merging tags: {e}[/red]")
-        raise typer.Exit(1) from e
+    console.print(f"[green]✅ Merged {len(source_infos)} tag(s) into '{target}'[/green]")
+    console.print(f"[dim]Updated {merged_count} document associations[/dim]")
 
 
 @app.command()
+@combined_decorator("batch tagging")
 def batch(
     untagged_only: bool = typer.Option(True, "--untagged/--all", help="Only process untagged documents"),
     project: str | None = typer.Option(None, "--project", "-p", help="Filter by project"),
@@ -328,99 +281,91 @@ def batch(
     limit: int | None = typer.Option(None, "--limit", "-l", help="Maximum documents to process"),
 ):
     """Batch auto-tag multiple documents."""
-    try:
-        # Ensure database schema exists
-        db.ensure_schema()
+    tagger = AutoTagger()
 
-        tagger = AutoTagger()
+    # Get suggestions first
+    with console.status("[bold green]Analyzing documents..."):
+        suggestions = tagger.batch_suggest(
+            untagged_only=untagged_only,
+            project=project,
+            limit=limit
+        )
 
-        # Get suggestions first
-        with console.status("[bold green]Analyzing documents..."):
-            suggestions = tagger.batch_suggest(
-                untagged_only=untagged_only,
-                project=project,
-                limit=limit
-            )
+    if not suggestions:
+        console.print("[yellow]No documents found matching criteria[/yellow]")
+        return
 
-        if not suggestions:
-            console.print("[yellow]No documents found matching criteria[/yellow]")
+    # Filter by confidence
+    eligible_docs = []
+    total_tags_to_apply = 0
+
+    for doc_id, doc_suggestions in suggestions.items():
+        eligible_tags = [
+            (tag_name, conf) for tag_name, conf in doc_suggestions[:max_tags]
+            if conf >= confidence
+        ]
+        if eligible_tags:
+            eligible_docs.append((doc_id, eligible_tags))
+            total_tags_to_apply += len(eligible_tags)
+
+    if not eligible_docs:
+        console.print(f"[yellow]No tags found with confidence >= {confidence:.0%}[/yellow]")
+        return
+
+    # Display what will be done
+    console.print("\n[bold cyan]🏷️  Batch Auto-Tagging Report[/bold cyan]")
+    console.print(f"\n[yellow]Found {len(eligible_docs)} documents to tag[/yellow]")
+    console.print(f"[yellow]Total tags to apply: {total_tags_to_apply}[/yellow]\n")
+
+    # Show sample of what will be done
+    sample_size = min(10, len(eligible_docs))
+    if sample_size > 0:
+        console.print("[bold]Sample of documents to be tagged:[/bold]\n")
+
+        for doc_id, tag_list in eligible_docs[:sample_size]:
+            # Get document title
+            doc = get_document(str(doc_id))
+            title = truncate_title(doc['title'], TITLE_TRUNCATE_LENGTH)
+
+            console.print(f"  [dim]#{doc_id}[/dim] {title}")
+            for tag_name, conf in tag_list:
+                console.print(f"    → {tag_name} [dim]({conf:.0%})[/dim]")
+            console.print()
+
+        if len(eligible_docs) > sample_size:
+            console.print(f"[dim]... and {len(eligible_docs) - sample_size} more documents[/dim]\n")
+
+    if dry_run:
+        console.print("[yellow]🔍 DRY RUN MODE - No changes will be made[/yellow]")
+        console.print(f"Would apply {total_tags_to_apply} tags to {len(eligible_docs)} documents")
+        console.print("\n[dim]Run with --execute to apply tags[/dim]")
+    else:
+        # Confirm
+        if not typer.confirm(f"\n🏷️  Apply {total_tags_to_apply} tags to {len(eligible_docs)} documents?"):
+            console.print("[red]Batch tagging cancelled[/red]")
             return
 
-        # Filter by confidence
-        eligible_docs = []
-        total_tags_to_apply = 0
+        # Execute batch tagging
+        applied_count = 0
+        tagged_docs = 0
 
-        for doc_id, doc_suggestions in suggestions.items():
-            eligible_tags = [
-                (tag_name, conf) for tag_name, conf in doc_suggestions[:max_tags]
-                if conf >= confidence
-            ]
-            if eligible_tags:
-                eligible_docs.append((doc_id, eligible_tags))
-                total_tags_to_apply += len(eligible_tags)
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console
+        ) as progress:
+            task = progress.add_task("Applying tags...", total=len(eligible_docs))
 
-        if not eligible_docs:
-            console.print(f"[yellow]No tags found with confidence >= {confidence:.0%}[/yellow]")
-            return
+            for doc_id, tag_list in eligible_docs:
+                applied = tagger.auto_tag_document(
+                    doc_id,
+                    confidence_threshold=confidence,
+                    max_tags=max_tags
+                )
+                if applied:
+                    applied_count += len(applied)
+                    tagged_docs += 1
+                progress.update(task, advance=1)
 
-        # Display what will be done
-        console.print("\n[bold cyan]🏷️  Batch Auto-Tagging Report[/bold cyan]")
-        console.print(f"\n[yellow]Found {len(eligible_docs)} documents to tag[/yellow]")
-        console.print(f"[yellow]Total tags to apply: {total_tags_to_apply}[/yellow]\n")
-
-        # Show sample of what will be done
-        sample_size = min(10, len(eligible_docs))
-        if sample_size > 0:
-            console.print("[bold]Sample of documents to be tagged:[/bold]\n")
-
-            for doc_id, tag_list in eligible_docs[:sample_size]:
-                # Get document title
-                doc = get_document(str(doc_id))
-                title = truncate_title(doc['title'])
-
-                console.print(f"  [dim]#{doc_id}[/dim] {title}")
-                for tag_name, conf in tag_list:
-                    console.print(f"    → {tag_name} [dim]({conf:.0%})[/dim]")
-                console.print()
-
-            if len(eligible_docs) > sample_size:
-                console.print(f"[dim]... and {len(eligible_docs) - sample_size} more documents[/dim]\n")
-
-        if dry_run:
-            console.print("[yellow]🔍 DRY RUN MODE - No changes will be made[/yellow]")
-            console.print(f"Would apply {total_tags_to_apply} tags to {len(eligible_docs)} documents")
-            console.print("\n[dim]Run with --execute to apply tags[/dim]")
-        else:
-            # Confirm
-            if not typer.confirm(f"\n🏷️  Apply {total_tags_to_apply} tags to {len(eligible_docs)} documents?"):
-                console.print("[red]Batch tagging cancelled[/red]")
-                return
-
-            # Execute batch tagging
-            applied_count = 0
-            tagged_docs = 0
-
-            with Progress(
-                SpinnerColumn(),
-                TextColumn("[progress.description]{task.description}"),
-                console=console
-            ) as progress:
-                task = progress.add_task("Applying tags...", total=len(eligible_docs))
-
-                for doc_id, tag_list in eligible_docs:
-                    applied = tagger.auto_tag_document(
-                        doc_id,
-                        confidence_threshold=confidence,
-                        max_tags=max_tags
-                    )
-                    if applied:
-                        applied_count += len(applied)
-                        tagged_docs += 1
-                    progress.update(task, advance=1)
-
-            console.print(f"\n✅ [green]Successfully tagged {tagged_docs} documents![/green]")
-            console.print(f"[dim]Total tags applied: {applied_count}[/dim]")
-
-    except Exception as e:
-        console.print(f"[red]Error batch tagging: {e}[/red]")
-        raise typer.Exit(1) from e
+        console.print(f"\n✅ [green]Successfully tagged {tagged_docs} documents![/green]")
+        console.print(f"[dim]Total tags applied: {applied_count}[/dim]")

--- a/emdx/commands/trash.py
+++ b/emdx/commands/trash.py
@@ -8,11 +8,10 @@ Consolidates trash, restore, and purge into a subcommand group:
     emdx trash purge     → permanently delete trash
 """
 
-
 import typer
 from rich.table import Table
 
-from emdx.database import db
+from emdx.commands._helpers import combined_decorator
 from emdx.models.documents import (
     list_deleted_documents,
     purge_deleted_documents,
@@ -49,51 +48,46 @@ def list_cmd(
     _list_trash(days=days, limit=limit)
 
 
+@combined_decorator("listing deleted documents")
 def _list_trash(days: int | None = None, limit: int = 50) -> None:
     """Shared implementation for listing trash."""
-    try:
-        db.ensure_schema()
+    deleted_docs = list_deleted_documents(days=days, limit=limit)
 
-        deleted_docs = list_deleted_documents(days=days, limit=limit)
-
-        if not deleted_docs:
-            if days:
-                console.print(f"[yellow]No documents deleted in the last {days} days[/yellow]")
-            else:
-                console.print("[yellow]No documents in trash[/yellow]")
-            return
-
+    if not deleted_docs:
         if days:
-            console.print(f"\n[bold]🗑️  Documents deleted in the last {days} days:[/bold]\n")
+            console.print(f"[yellow]No documents deleted in the last {days} days[/yellow]")
         else:
-            console.print(f"\n[bold]🗑️  Documents in trash ({len(deleted_docs)} items):[/bold]\n")
+            console.print("[yellow]No documents in trash[/yellow]")
+        return
 
-        table = Table(show_header=True, header_style="bold cyan")
-        table.add_column("ID", style="cyan", width=6)
-        table.add_column("Title", style="white")
-        table.add_column("Project", style="green")
-        table.add_column("Deleted", style="red")
-        table.add_column("Views", style="yellow", justify="right")
+    if days:
+        console.print(f"\n[bold]🗑️  Documents deleted in the last {days} days:[/bold]\n")
+    else:
+        console.print(f"\n[bold]🗑️  Documents in trash ({len(deleted_docs)} items):[/bold]\n")
 
-        for doc in deleted_docs:
-            table.add_row(
-                str(doc["id"]),
-                doc["title"][:50] + "..." if len(doc["title"]) > 50 else doc["title"],
-                doc["project"] or "[dim]None[/dim]",
-                doc["deleted_at"].strftime("%Y-%m-%d %H:%M"),
-                str(doc["access_count"]),
-            )
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("ID", style="cyan", width=6)
+    table.add_column("Title", style="white")
+    table.add_column("Project", style="green")
+    table.add_column("Deleted", style="red")
+    table.add_column("Views", style="yellow", justify="right")
 
-        console.print(table)
-        console.print("\n[dim]💡 Use 'emdx trash restore <id>' to restore documents[/dim]")
-        console.print("[dim]💡 Use 'emdx trash purge' to permanently delete all items[/dim]")
+    for doc in deleted_docs:
+        table.add_row(
+            str(doc["id"]),
+            doc["title"][:50] + "..." if len(doc["title"]) > 50 else doc["title"],
+            doc["project"] or "[dim]None[/dim]",
+            doc["deleted_at"].strftime("%Y-%m-%d %H:%M"),
+            str(doc["access_count"]),
+        )
 
-    except Exception as e:
-        console.print(f"[red]Error listing deleted documents: {e}[/red]")
-        raise typer.Exit(1) from e
+    console.print(table)
+    console.print("\n[dim]💡 Use 'emdx trash restore <id>' to restore documents[/dim]")
+    console.print("[dim]💡 Use 'emdx trash purge' to permanently delete all items[/dim]")
 
 
 @app.command()
+@combined_decorator("restoring documents")
 def restore(
     identifiers: list[str] | None = typer.Argument(
         default=None, help="Document ID(s) or title(s) to restore"
@@ -101,57 +95,48 @@ def restore(
     all: bool = typer.Option(False, "--all", help="Restore all deleted documents"),
 ) -> None:
     """Restore soft-deleted document(s)."""
-    try:
-        db.ensure_schema()
+    if not identifiers and not all:
+        console.print("[red]Error: Provide document ID(s) to restore or use --all[/red]")
+        raise typer.Exit(1)
 
-        if not identifiers and not all:
-            console.print("[red]Error: Provide document ID(s) to restore or use --all[/red]")
-            raise typer.Exit(1)
+    if all:
+        deleted_docs = list_deleted_documents()
+        if not deleted_docs:
+            console.print("[yellow]No documents to restore[/yellow]")
+            return
 
-        if all:
-            deleted_docs = list_deleted_documents()
-            if not deleted_docs:
-                console.print("[yellow]No documents to restore[/yellow]")
-                return
+        console.print(f"\n[bold]Will restore {len(deleted_docs)} document(s)[/bold]")
+        typer.confirm("Continue?", abort=True)
 
-            console.print(f"\n[bold]Will restore {len(deleted_docs)} document(s)[/bold]")
-            typer.confirm("Continue?", abort=True)
+        restored_count = 0
+        for doc in deleted_docs:
+            if restore_document(str(doc["id"])):
+                restored_count += 1
 
-            restored_count = 0
-            for doc in deleted_docs:
-                if restore_document(str(doc["id"])):
-                    restored_count += 1
+        console.print(f"\n[green]✅ Restored {restored_count} document(s)[/green]")
+    else:
+        restored = []
+        not_found = []
 
-            console.print(f"\n[green]✅ Restored {restored_count} document(s)[/green]")
-        else:
-            restored = []
-            not_found = []
+        for identifier in identifiers:
+            if restore_document(identifier):
+                restored.append(identifier)
+            else:
+                not_found.append(identifier)
 
-            for identifier in identifiers:
-                if restore_document(identifier):
-                    restored.append(identifier)
-                else:
-                    not_found.append(identifier)
+        if restored:
+            console.print(f"\n[green]✅ Restored {len(restored)} document(s):[/green]")
+            for r in restored:
+                console.print(f"  [dim]• {r}[/dim]")
 
-            if restored:
-                console.print(f"\n[green]✅ Restored {len(restored)} document(s):[/green]")
-                for r in restored:
-                    console.print(f"  [dim]• {r}[/dim]")
-
-            if not_found:
-                console.print(f"\n[yellow]Could not restore {len(not_found)} document(s):[/yellow]")
-                for nf in not_found:
-                    console.print(f"  [dim]• {nf} (not found in trash)[/dim]")
-
-    except typer.Abort:
-        console.print("[yellow]Restore cancelled[/yellow]")
-        raise typer.Exit(0) from None
-    except Exception as e:
-        console.print(f"[red]Error restoring documents: {e}[/red]")
-        raise typer.Exit(1) from e
+        if not_found:
+            console.print(f"\n[yellow]Could not restore {len(not_found)} document(s):[/yellow]")
+            for nf in not_found:
+                console.print(f"  [dim]• {nf} (not found in trash)[/dim]")
 
 
 @app.command()
+@combined_decorator("purging documents")
 def purge(
     older_than: int | None = typer.Option(
         None, "--older-than", help="Only purge items deleted more than N days ago"
@@ -159,47 +144,37 @@ def purge(
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
 ) -> None:
     """Permanently delete all items in trash."""
-    try:
-        db.ensure_schema()
+    if older_than:
+        deleted_docs = list_deleted_documents()
+        from datetime import datetime, timedelta
 
+        cutoff = datetime.now() - timedelta(days=older_than)
+        docs_to_purge = [d for d in deleted_docs if d["deleted_at"] < cutoff]
+        count = len(docs_to_purge)
+    else:
+        deleted_docs = list_deleted_documents()
+        count = len(deleted_docs)
+
+    if count == 0:
         if older_than:
-            deleted_docs = list_deleted_documents()
-            from datetime import datetime, timedelta
-
-            cutoff = datetime.now() - timedelta(days=older_than)
-            docs_to_purge = [d for d in deleted_docs if d["deleted_at"] < cutoff]
-            count = len(docs_to_purge)
+            console.print(
+                f"[yellow]No documents deleted more than {older_than} days ago[/yellow]"
+            )
         else:
-            deleted_docs = list_deleted_documents()
-            count = len(deleted_docs)
+            console.print("[yellow]No documents in trash to purge[/yellow]")
+        return
 
-        if count == 0:
-            if older_than:
-                console.print(
-                    f"[yellow]No documents deleted more than {older_than} days ago[/yellow]"
-                )
-            else:
-                console.print("[yellow]No documents in trash to purge[/yellow]")
-            return
+    console.print(
+        f"\n[red bold]⚠️  WARNING: This will PERMANENTLY delete "
+        f"{count} document(s) from trash![/red bold]"
+    )
+    console.print("[red]This action cannot be undone![/red]\n")
 
-        console.print(
-            f"\n[red bold]⚠️  WARNING: This will PERMANENTLY delete "
-            f"{count} document(s) from trash![/red bold]"
-        )
-        console.print("[red]This action cannot be undone![/red]\n")
+    if not force:
+        typer.confirm("Are you absolutely sure?", abort=True)
 
-        if not force:
-            typer.confirm("Are you absolutely sure?", abort=True)
+    purged_count = purge_deleted_documents(older_than_days=older_than)
 
-        purged_count = purge_deleted_documents(older_than_days=older_than)
-
-        console.print(
-            f"\n[green]✅ Permanently deleted {purged_count} document(s) from trash[/green]"
-        )
-
-    except typer.Abort:
-        console.print("[yellow]Purge cancelled[/yellow]")
-        raise typer.Exit(0) from None
-    except Exception as e:
-        console.print(f"[red]Error purging documents: {e}[/red]")
-        raise typer.Exit(1) from e
+    console.print(
+        f"\n[green]✅ Permanently deleted {purged_count} document(s) from trash[/green]"
+    )

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -13,7 +13,7 @@ runner = CliRunner()
 class TestBrowseCommands:
     """Test browse command-line interface."""
 
-    @patch("emdx.commands.browse.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.browse.list_documents")
     def test_list_command_empty_database(self, mock_list_docs, mock_db):
         """Test list command with empty database."""
@@ -26,7 +26,7 @@ class TestBrowseCommands:
         assert "No documents found" in result.stdout
         mock_list_docs.assert_called_once()
 
-    @patch("emdx.commands.browse.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.browse.list_documents")
     def test_list_command_with_documents(self, mock_list_docs, mock_db):
         """Test list command with documents."""
@@ -47,7 +47,7 @@ class TestBrowseCommands:
         assert "Test Document" in result.stdout
         mock_list_docs.assert_called_once()
 
-    @patch("emdx.commands.browse.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.browse.list_documents")
     def test_list_command_with_project_filter(self, mock_list_docs, mock_db):
         """Test list command with project filter."""
@@ -61,7 +61,7 @@ class TestBrowseCommands:
             project="test-project", limit=50
         )
 
-    @patch("emdx.commands.browse.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.browse.list_documents")
     def test_list_command_json_format(self, mock_list_docs, mock_db):
         """Test list command with JSON format."""
@@ -80,7 +80,7 @@ class TestBrowseCommands:
         assert "[" in result.stdout  # JSON array
         assert '"id": 1' in result.stdout
 
-    @patch("emdx.commands.browse.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.browse.get_recent_documents")
     def test_recent_command(self, mock_get_recent_docs, mock_db):
         """Test recent command."""
@@ -101,7 +101,7 @@ class TestBrowseCommands:
         assert "Recent Doc" in result.stdout
         mock_get_recent_docs.assert_called_once_with(limit=10)
 
-    @patch("emdx.commands.browse.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.browse.get_stats")
     def test_stats_command(self, mock_get_stats, mock_db):
         """Test stats command."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,7 +52,7 @@ class TestCLIBasics:
             or result.exit_code == 2
         )
 
-    @patch("emdx.commands.browse.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.browse.list_documents")
     def test_list_command(self, mock_list_docs, mock_db):
         """Test list command."""
@@ -69,7 +69,7 @@ class TestCLIBasics:
         # Should work even with empty database
         assert result.exit_code == 0 or "no documents" in result.stdout.lower()
 
-    @patch("emdx.commands.browse.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.browse.get_stats")
     def test_stats_command(self, mock_get_stats, mock_db):
         """Test stats command."""

--- a/tests/test_commands_core.py
+++ b/tests/test_commands_core.py
@@ -535,7 +535,7 @@ class TestTrashCommand:
     """Tests for the trash command."""
 
     @patch("emdx.commands.trash.list_deleted_documents")
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     def test_trash_empty(self, mock_db, mock_list_deleted):
         """Empty trash shows message."""
         mock_db.ensure_schema = Mock()
@@ -546,7 +546,7 @@ class TestTrashCommand:
         assert "No documents in trash" in _out(result)
 
     @patch("emdx.commands.trash.list_deleted_documents")
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     def test_trash_with_items(self, mock_db, mock_list_deleted):
         """Trash with items shows table."""
         mock_db.ensure_schema = Mock()
@@ -565,7 +565,7 @@ class TestTrashCommand:
         assert "Deleted Doc" in _out(result)
 
     @patch("emdx.commands.trash.list_deleted_documents")
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     def test_trash_with_days_filter(self, mock_db, mock_list_deleted):
         """Trash --days filters by age."""
         mock_db.ensure_schema = Mock()
@@ -583,7 +583,7 @@ class TestRestoreCommand:
     """Tests for the trash restore command."""
 
     @patch("emdx.commands.trash.restore_document")
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     def test_restore_by_id(self, mock_db, mock_restore):
         """Restore a specific document."""
         mock_db.ensure_schema = Mock()
@@ -594,7 +594,7 @@ class TestRestoreCommand:
         assert "Restored" in _out(result)
 
     @patch("emdx.commands.trash.restore_document")
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     def test_restore_not_found(self, mock_db, mock_restore):
         """Restore a document not in trash."""
         mock_db.ensure_schema = Mock()
@@ -604,7 +604,7 @@ class TestRestoreCommand:
         assert result.exit_code == 0
         assert "Could not restore" in _out(result)
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     def test_restore_no_args(self, mock_db):
         """Restore with no ID and no --all should error."""
         mock_db.ensure_schema = Mock()
@@ -614,7 +614,7 @@ class TestRestoreCommand:
 
     @patch("emdx.commands.trash.list_deleted_documents")
     @patch("emdx.commands.trash.restore_document")
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     def test_restore_all(self, mock_db, mock_restore, mock_list_deleted):
         """Restore --all restores all deleted documents."""
         mock_db.ensure_schema = Mock()
@@ -636,7 +636,7 @@ class TestPurgeCommand:
     """Tests for the trash purge command."""
 
     @patch("emdx.commands.trash.list_deleted_documents")
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     def test_purge_empty_trash(self, mock_db, mock_list_deleted):
         """Purge with empty trash shows message."""
         mock_db.ensure_schema = Mock()
@@ -648,7 +648,7 @@ class TestPurgeCommand:
 
     @patch("emdx.commands.trash.purge_deleted_documents")
     @patch("emdx.commands.trash.list_deleted_documents")
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     def test_purge_with_force(self, mock_db, mock_list_deleted, mock_purge):
         """Purge --force skips confirmation."""
         mock_db.ensure_schema = Mock()

--- a/tests/test_commands_tags.py
+++ b/tests/test_commands_tags.py
@@ -24,8 +24,8 @@ class TestTagAddCommand:
 
     @patch("emdx.commands.tags.get_document_tags")
     @patch("emdx.commands.tags.add_tags_to_document")
-    @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.get_document")
+    @patch("emdx.commands._helpers.db")
     def test_add_tags_explicit(self, mock_db, mock_get_doc, mock_add_tags, mock_get_tags):
         """Add tags via explicit 'add' subcommand."""
         mock_db.ensure_schema = Mock()
@@ -69,8 +69,8 @@ class TestTagAddCommand:
         assert argv == ["emdx", "tag", "add", "42", "--auto"]
 
     @patch("emdx.commands.tags.get_document_tags")
-    @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.get_document")
+    @patch("emdx.commands._helpers.db")
     def test_tag_show_current(self, mock_db, mock_get_doc, mock_get_tags):
         """Tag with no tag arguments shows current tags."""
         mock_db.ensure_schema = Mock()
@@ -82,8 +82,8 @@ class TestTagAddCommand:
         assert result.exit_code == 0
         assert "Tags for #1" in out
 
-    @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.get_document")
+    @patch("emdx.commands._helpers.db")
     def test_tag_doc_not_found(self, mock_db, mock_get_doc):
         """Tag a nonexistent document shows error."""
         mock_db.ensure_schema = Mock()
@@ -95,8 +95,8 @@ class TestTagAddCommand:
 
     @patch("emdx.commands.tags.get_document_tags")
     @patch("emdx.commands.tags.add_tags_to_document")
-    @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.get_document")
+    @patch("emdx.commands._helpers.db")
     def test_tag_already_exists(self, mock_db, mock_get_doc, mock_add_tags, mock_get_tags):
         """Adding a tag that already exists shows message."""
         mock_db.ensure_schema = Mock()
@@ -117,8 +117,8 @@ class TestTagRemoveCommand:
 
     @patch("emdx.commands.tags.get_document_tags")
     @patch("emdx.commands.tags.remove_tags_from_document")
-    @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.get_document")
+    @patch("emdx.commands._helpers.db")
     def test_remove(self, mock_db, mock_get_doc, mock_remove_tags, mock_get_tags):
         """Remove tags from a document."""
         mock_db.ensure_schema = Mock()
@@ -132,8 +132,8 @@ class TestTagRemoveCommand:
 
     @patch("emdx.commands.tags.get_document_tags")
     @patch("emdx.commands.tags.remove_tags_from_document")
-    @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.get_document")
+    @patch("emdx.commands._helpers.db")
     def test_remove_not_on_doc(self, mock_db, mock_get_doc, mock_remove_tags, mock_get_tags):
         """Removing a tag that doesn't exist shows message."""
         mock_db.ensure_schema = Mock()
@@ -145,8 +145,8 @@ class TestTagRemoveCommand:
         assert result.exit_code == 0
         assert "No tags removed" in _out(result)
 
-    @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.get_document")
+    @patch("emdx.commands._helpers.db")
     def test_remove_doc_not_found(self, mock_db, mock_get_doc):
         """Remove tags from a nonexistent document shows error."""
         mock_db.ensure_schema = Mock()
@@ -164,7 +164,7 @@ class TestTagListCommand:
     """Tests for the tag list command."""
 
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.db")
     def test_tags_list(self, mock_db, mock_list_all):
         """List all tags."""
         mock_db.ensure_schema = Mock()
@@ -190,7 +190,7 @@ class TestTagListCommand:
         assert "testing" in out
 
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.db")
     def test_tags_list_empty(self, mock_db, mock_list_all):
         """No tags shows message."""
         mock_db.ensure_schema = Mock()
@@ -201,7 +201,7 @@ class TestTagListCommand:
         assert "No tags found" in _out(result)
 
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.db")
     def test_tags_sort_option(self, mock_db, mock_list_all):
         """Tags with --sort option."""
         mock_db.ensure_schema = Mock()
@@ -219,7 +219,7 @@ class TestTagRenameCommand:
 
     @patch("emdx.commands.tags.rename_tag")
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.db")
     def test_rename_with_force(self, mock_db, mock_list_all, mock_rename):
         """Rename a tag with --force."""
         mock_db.ensure_schema = Mock()
@@ -234,7 +234,7 @@ class TestTagRenameCommand:
         mock_rename.assert_called_once_with("old-tag", "new-tag")
 
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.db")
     def test_rename_not_found(self, mock_db, mock_list_all):
         """Rename a tag that doesn't exist shows error."""
         mock_db.ensure_schema = Mock()
@@ -246,7 +246,7 @@ class TestTagRenameCommand:
 
     @patch("emdx.commands.tags.rename_tag")
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.db")
     def test_rename_failure(self, mock_db, mock_list_all, mock_rename):
         """Rename that fails (e.g. target already exists) shows error."""
         mock_db.ensure_schema = Mock()
@@ -268,7 +268,7 @@ class TestTagMergeCommand:
 
     @patch("emdx.commands.tags.merge_tags")
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.db")
     def test_merge_tags_with_force(self, mock_db, mock_list_all, mock_merge):
         """Merge tags with --force."""
         mock_db.ensure_schema = Mock()
@@ -285,7 +285,7 @@ class TestTagMergeCommand:
         assert "Merged" in _out(result)
 
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
+    @patch("emdx.commands._helpers.db")
     def test_merge_tags_no_valid_sources(self, mock_db, mock_list_all):
         """Merge with no valid source tags shows error."""
         mock_db.ensure_schema = Mock()

--- a/tests/test_commands_trash.py
+++ b/tests/test_commands_trash.py
@@ -20,7 +20,7 @@ def _out(result) -> str:
 class TestTrashList:
     """Tests for trash list command."""
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.trash.list_deleted_documents")
     def test_list_empty_trash(self, mock_list, mock_db):
         mock_list.return_value = []
@@ -28,7 +28,7 @@ class TestTrashList:
         assert result.exit_code == 0
         assert "No documents in trash" in _out(result)
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.trash.list_deleted_documents")
     def test_list_empty_trash_with_days(self, mock_list, mock_db):
         mock_list.return_value = []
@@ -36,7 +36,7 @@ class TestTrashList:
         assert result.exit_code == 0
         assert "No documents deleted in the last 7 days" in _out(result)
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.trash.list_deleted_documents")
     def test_list_shows_documents(self, mock_list, mock_db):
         mock_list.return_value = [
@@ -55,7 +55,7 @@ class TestTrashList:
         assert "Test Document" in out
         assert "test-project" in out
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.trash.list_deleted_documents")
     def test_list_truncates_long_titles(self, mock_list, mock_db):
         mock_list.return_value = [
@@ -73,7 +73,7 @@ class TestTrashList:
         # Title gets truncated — either by our code ("...") or Rich table ("…")
         assert "..." in out or "…" in out
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.trash.list_deleted_documents")
     def test_callback_invokes_list(self, mock_list, mock_db):
         """Invoking `trash` without subcommand runs list."""
@@ -86,13 +86,13 @@ class TestTrashList:
 class TestTrashRestore:
     """Tests for trash restore command."""
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     def test_restore_no_args_exits(self, mock_db):
         result = runner.invoke(app, ["restore"])
         assert result.exit_code == 1
         assert "Provide document ID" in _out(result)
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.trash.restore_document")
     def test_restore_single_doc(self, mock_restore, mock_db):
         mock_restore.return_value = True
@@ -101,7 +101,7 @@ class TestTrashRestore:
         assert "Restored 1 document" in _out(result)
         mock_restore.assert_called_once_with("42")
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.trash.restore_document")
     def test_restore_not_found(self, mock_restore, mock_db):
         mock_restore.return_value = False
@@ -110,7 +110,7 @@ class TestTrashRestore:
         assert "Could not restore" in _out(result)
         assert "999" in _out(result)
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.trash.restore_document")
     def test_restore_multiple_docs(self, mock_restore, mock_db):
         mock_restore.side_effect = [True, False, True]
@@ -120,7 +120,7 @@ class TestTrashRestore:
         assert "Restored 2 document" in out
         assert "Could not restore 1 document" in out
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.trash.list_deleted_documents")
     def test_restore_all_empty(self, mock_list, mock_db):
         mock_list.return_value = []
@@ -132,7 +132,7 @@ class TestTrashRestore:
 class TestTrashPurge:
     """Tests for trash purge command."""
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.trash.list_deleted_documents")
     def test_purge_empty_trash(self, mock_list, mock_db):
         mock_list.return_value = []
@@ -140,7 +140,7 @@ class TestTrashPurge:
         assert result.exit_code == 0
         assert "No documents in trash to purge" in _out(result)
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.trash.list_deleted_documents")
     @patch("emdx.commands.trash.purge_deleted_documents")
     def test_purge_with_force(self, mock_purge, mock_list, mock_db):
@@ -150,7 +150,7 @@ class TestTrashPurge:
         assert result.exit_code == 0
         assert "Permanently deleted 1 document" in _out(result)
 
-    @patch("emdx.commands.trash.db")
+    @patch("emdx.commands._helpers.db")
     @patch("emdx.commands.trash.list_deleted_documents")
     def test_purge_cancelled(self, mock_list, mock_db):
         mock_list.return_value = [{"id": 1, "deleted_at": datetime(2026, 1, 1)}]


### PR DESCRIPTION
## Summary
- Introduces `emdx/commands/_helpers.py` with shared command helper utilities
- Refactors `browse`, `tags`, and `trash` commands to use the new helpers, reducing duplication
- Updates tests to match the refactored interfaces

## Test plan
- [ ] Run full test suite: `poetry run pytest tests/ -x -q`
- [ ] Verify `emdx browse`, `emdx tag`, and `emdx trash` commands work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)