### PR TITLE
docs: Add Typer upgrade analysis (0.15.0 → 0.23.1)

### DIFF
--- a/docs/upgrade-typer.md
+++ b/docs/upgrade-typer.md
@@ -1,0 +1,267 @@
+# Typer Upgrade Analysis: 0.15.0 → 0.23.1
+
+**Date:** 2026-02-15
+**Current Version:** ^0.15.0
+**Target Version:** ^0.23.1
+**Risk Level:** 🟡 Medium (some breaking changes, but mitigated by our Python version)
+
+## Executive Summary
+
+This is a major version upgrade spanning **8 minor releases** (0.15 → 0.23). The most significant breaking changes relate to Python version support (dropped 3.8), `typer-slim` restructuring, and error traceback behavior. Our codebase is well-positioned for this upgrade since we already require Python 3.11+.
+
+---
+
+## 1. Breaking Changes That Affect Us
+
+### 1.1 🔴 CliRunner `mix_stderr` Parameter Removed (v0.16.0)
+
+**Change:** Click 8.2 compatibility removed the `mix_stderr` parameter from `CliRunner`.
+
+**Impact:** We use `CliRunner` in 11 test files:
+- `tests/test_task_commands.py`
+- `tests/test_browse.py`
+- `tests/test_commands_tags.py`
+- `tests/test_commands_recipe.py`
+- `tests/test_commands_cascade.py`
+- `tests/test_commands_core.py`
+- `tests/test_cli.py`
+- `tests/test_commands_groups.py`
+- `tests/test_commands_trash.py`
+- `tests/test_lazy_loading.py`
+
+**Assessment:** ✅ **No action needed** - our test files do not use the `mix_stderr` parameter.
+
+```bash
+# Verified: No usage of mix_stderr
+rg "mix_stderr" tests/
+# No matches
+```
+
+### 1.2 🟡 Error Traceback Locals Hidden by Default (v0.23.0)
+
+**Change:** When printing error tracebacks with Rich, local variables are no longer shown by default.
+
+**Impact:** This affects debugging output. If we rely on seeing local variables in error traces for debugging, we may need to opt back in.
+
+**Assessment:** 🟡 **Behavioral change** - may affect debugging experience but not functionality. Can be restored via configuration if needed.
+
+### 1.3 🟡 `typer-slim` Package Restructured (v0.22.0)
+
+**Change:** `typer-slim` is now a shallow wrapper requiring `rich` and `shellingham` dependencies.
+
+**Impact:** We use `typer[all]` in pyproject.toml, so this doesn't affect us directly:
+```toml
+typer = {extras = ["all"], version = "^0.15.0"}
+```
+
+**Assessment:** ✅ **No action needed** - we already include all extras.
+
+### 1.4 ✅ Python 3.8 Support Dropped (v0.21.0)
+
+**Change:** Typer now requires Python 3.9+.
+
+**Impact:** None - we require Python 3.11+:
+```toml
+python = "^3.11"
+```
+
+**Assessment:** ✅ **No action needed**.
+
+---
+
+## 2. New Features We Could Adopt
+
+### 2.1 `typing.Literal` Support (v0.19.0)
+
+**Feature:** Use `typing.Literal` to define predefined choice sets for CLI parameters.
+
+**Current Pattern:**
+```python
+group_role: str = typer.Option(
+    "member", "--group-role",
+    help="Role in group (primary, exploration, synthesis, variant, member)"
+)
+```
+
+**Could Become:**
+```python
+from typing import Literal
+
+GroupRole = Literal["primary", "exploration", "synthesis", "variant", "member"]
+
+group_role: GroupRole = typer.Option("member", "--group-role")
+```
+
+**Files that could benefit:**
+- `emdx/commands/core.py` (group_role parameter)
+- `emdx/commands/tags.py` (tag operations)
+- `emdx/commands/cascade.py` (cascade stage options)
+
+**Priority:** 🟢 Low - nice to have, better type safety
+
+### 2.2 Command Suggestions on Typo (v0.20.0)
+
+**Feature:** Now enabled by default - suggests similar commands when user makes a typo.
+
+**Impact:** ✅ **Free improvement** - no code changes needed, users get better UX.
+
+### 2.3 `TYPER_STANDARD_TRACEBACK` Environment Variable (v0.20.1)
+
+**Feature:** Control traceback format via environment variable.
+
+**Could use for:** Better debugging in CI/development environments.
+
+### 2.4 `TYPER_USE_RICH` Environment Variable (v0.23.1)
+
+**Feature:** Toggle Rich formatting on/off via environment variable.
+
+**Could use for:** Plain text output for piping/scripting.
+
+### 2.5 Lazy Loading `rich_utils` (v0.17.0)
+
+**Feature:** Optimized startup performance by lazy-loading rich utilities.
+
+**Impact:** ✅ **Free improvement** - complements our existing lazy loading system in `LazyTyperGroup`.
+
+---
+
+## 3. Migration Steps
+
+### Phase 1: Pre-Migration Verification
+
+```bash
+# 1. Ensure all tests pass on current version
+poetry run pytest tests/ -x -q
+
+# 2. Capture current CLI behavior for regression testing
+poetry run emdx --help > /tmp/help_before.txt
+poetry run emdx save --help >> /tmp/help_before.txt
+poetry run emdx find --help >> /tmp/help_before.txt
+```
+
+### Phase 2: Version Bump
+
+```bash
+# 1. Update pyproject.toml
+# Change: typer = {extras = ["all"], version = "^0.15.0"}
+# To:     typer = {extras = ["all"], version = "^0.23.1"}
+
+# 2. Update click constraint (0.23.1 requires click >=8.1.0)
+# Already satisfied: click = ">=8.1.0"
+
+# 3. Update lock file
+poetry lock
+poetry install
+```
+
+### Phase 3: Test Suite
+
+```bash
+# 1. Run full test suite
+poetry run pytest tests/ -v
+
+# 2. Run specific CLI tests
+poetry run pytest tests/test_cli.py tests/test_lazy_loading.py -v
+
+# 3. Test CliRunner usage explicitly
+poetry run pytest -k "CliRunner" -v
+```
+
+### Phase 4: Manual Verification
+
+```bash
+# 1. Compare help output
+poetry run emdx --help > /tmp/help_after.txt
+diff /tmp/help_before.txt /tmp/help_after.txt
+
+# 2. Test core commands
+poetry run emdx version
+poetry run emdx list
+poetry run emdx find "test"
+
+# 3. Test lazy loading still works
+time poetry run emdx --help  # Should be fast
+poetry run emdx delegate --help  # Should lazy-load
+
+# 4. Test error handling
+poetry run emdx invalid-command  # Should suggest alternatives (new feature!)
+```
+
+### Phase 5: Optional Enhancements
+
+1. **Adopt `Literal` types** for choice parameters (low priority)
+2. **Document new env vars** (`TYPER_STANDARD_TRACEBACK`, `TYPER_USE_RICH`)
+3. **Update ADR** in `docs/adr/002-typer-cli-framework.md`
+
+---
+
+## 4. Risk Assessment
+
+| Risk | Severity | Likelihood | Mitigation |
+|------|----------|------------|------------|
+| CliRunner API changes | Medium | Low | Verified no `mix_stderr` usage |
+| TyperGroup internals changed | Medium | Low | Our `LazyTyperGroup` extends `TyperGroup` - test thoroughly |
+| Error traceback behavior | Low | High | Acceptable UX change |
+| `add_typer` behavior | Low | Low | Used in 6 places, well-tested pattern |
+| Test failures | Medium | Low | Comprehensive test suite exists |
+
+### Confidence Level: **High** ✅
+
+- Python version requirement already exceeded (3.11+ vs 3.9+)
+- No usage of deprecated/removed APIs
+- Core patterns (`typer.Typer`, `typer.Option`, `typer.Argument`, `typer.Context`) unchanged
+- `CliRunner` usage is standard, no exotic parameters
+
+---
+
+## 5. Files to Monitor During Upgrade
+
+### Critical (custom Typer extensions):
+- `emdx/utils/lazy_group.py` - Custom `LazyTyperGroup` class
+
+### High (main CLI entry):
+- `emdx/main.py` - Main app definition, `add_typer` calls
+
+### Medium (heavy Typer usage):
+- `emdx/commands/core.py` - 20+ Option/Argument definitions
+- `emdx/commands/delegate.py` - Complex callback with many options
+- `emdx/commands/cascade.py` - Multi-command app
+
+### Tests:
+- All 11 test files using `CliRunner`
+
+---
+
+## 6. Rollback Plan
+
+If issues are discovered post-upgrade:
+
+```bash
+# 1. Revert pyproject.toml
+git checkout HEAD -- pyproject.toml
+
+# 2. Reinstall
+poetry lock
+poetry install
+
+# 3. Verify
+poetry run pytest tests/ -x
+```
+
+---
+
+## References
+
+- [Typer Release Notes](https://typer.tiangolo.com/release-notes/)
+- [GitHub Releases](https://github.com/fastapi/typer/releases)
+- [Migration from Click 8.2](https://github.com/fastapi/typer/discussions/784)
+
+---
+
+## Recommendation
+
+**Proceed with upgrade.** The changes are well-understood, our codebase is compatible, and the new features (command suggestions, performance improvements) provide immediate value with no code changes required.
+
+**Estimated effort:** 30 minutes for version bump + testing
+**Risk:** Low-Medium
+**Benefit:** Improved UX, performance, and future compatibility


### PR DESCRIPTION
## Summary
- Comprehensive analysis of upgrading Typer from ^0.15.0 to ^0.23.1
- Covers breaking changes, new features, migration steps, and risk assessment
- Recommendation: Proceed with upgrade (low-medium risk, immediate UX benefits)

## Analysis Highlights
- **Breaking changes**: CliRunner `mix_stderr` removed (not used by us), error traceback locals hidden by default
- **New features**: `typing.Literal` support, command suggestions on typo, env var controls
- **Risk level**: Low-Medium - our Python 3.11+ requirement mitigates most concerns

## Test plan
- [ ] Review analysis document for accuracy
- [ ] Verify breaking change assessment is correct
- [ ] Approve for merge (this is documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)