### PR TITLE
chore(deps): Upgrade textual from ^4.0.0 to ^6.2.1 (Issue #6353)

### DIFF
--- a/emdx/ui/text_areas.py
+++ b/emdx/ui/text_areas.py
@@ -18,6 +18,10 @@ class SelectionTextArea(TextArea):
     """TextArea that captures 's' key to exit selection mode."""
 
     def __init__(self, app_instance, *args, **kwargs):
+        # Textual 6.x changed defaults - explicitly set the behavior we want
+        kwargs.setdefault("soft_wrap", False)
+        kwargs.setdefault("show_line_numbers", True)
+        kwargs.setdefault("tab_behavior", "indent")
         super().__init__(*args, **kwargs)
         self.app_instance = app_instance
 
@@ -64,6 +68,10 @@ class VimEditTextArea(TextArea):
     VIM_COMMAND = "COMMAND"
 
     def __init__(self, app_instance, *args, **kwargs):
+        # Textual 6.x changed defaults - explicitly set the behavior we want
+        kwargs.setdefault("soft_wrap", False)
+        kwargs.setdefault("show_line_numbers", True)
+        kwargs.setdefault("tab_behavior", "indent")
         super().__init__(*args, **kwargs)
         self.app_instance = app_instance
         self.vim_mode = self.VIM_NORMAL  # Start in normal mode like vim

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ python = "^3.11"
 typer = {extras = ["all"], version = "^0.15.0"}
 click = ">=8.1.0"  # Typer 0.15+ requires click 8.1+
 rich = "^13.0.0"
-textual = "^4.0.0"
+textual = "^6.2.1"
 psutil = "^7.0.0"
 pyyaml = ">=6.0"
 


### PR DESCRIPTION
## Summary

- Upgrade textual dependency from ^4.0.0 to ^6.2.1
- Add explicit TextArea defaults in `text_areas.py` to preserve consistent behavior after Textual 6.x default changes:
  - `soft_wrap=False` (was True in 6.x)
  - `show_line_numbers=True` (was False in 6.x)
  - `tab_behavior="indent"` (was "focus" in 6.x)

## Test plan

- [x] All 1037 tests pass
- [ ] Manual TUI testing: Launch emdx gui and verify document editing works
- [ ] Verify vim keybindings still work correctly
- [ ] Verify theme switching still works

## Notes

Migration based on analysis in emdx doc #6353. The codebase did not use any of the deprecated patterns (`.renderable` property access, `tab_behaviour` British spelling) so only the TextArea defaults needed explicit setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)