### PR TITLE
ci: Add bandit and pip-audit security scanning (Issue #DEBT-11)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,3 +121,44 @@ jobs:
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: latest
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v5
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-3.13-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Install dependencies
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      run: poetry install --no-interaction --no-root
+
+    - name: Install project
+      run: poetry install --no-interaction
+
+    - name: Run bandit security scan
+      run: |
+        pip install bandit
+        bandit -r emdx/ -c pyproject.toml
+
+    - name: Run pip-audit dependency scan
+      run: |
+        pip install pip-audit
+        pip-audit --local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,20 @@ markers = [
 
 [tool.coverage.run]
 source = ["emdx"]
+
+[tool.bandit]
+# Skip common false positives in CLI applications
+skips = [
+    "B101",  # assert_used - asserts are fine in non-production code
+    "B110",  # try_except_pass - intentional silent exception handling in UI code
+    "B301",  # pickle - used for local cache files only, not untrusted data
+    "B311",  # random - used for non-security purposes (branch names, etc.)
+    "B324",  # hashlib_insecure_hash - MD5 used for non-security hashing (build IDs)
+    "B403",  # import_pickle - used for local cache files only
+    "B404",  # blacklist import subprocess - necessary for CLI tools
+    "B603",  # subprocess_without_shell_equals_true - safe when using list args
+    "B607",  # start_process_with_partial_path - tools like 'git' are expected in PATH
+    "B608",  # hardcoded_sql_expressions - using parameterized queries with dynamic conditionals
+]
+# Exclude test files from security scanning
+exclude_dirs = ["tests"]


### PR DESCRIPTION
## Summary
- Adds bandit code security scanner to CI pipeline
- Adds pip-audit dependency vulnerability scanner
- Configures bandit via pyproject.toml to skip common false positives in CLI apps

## Test plan
- [x] Bandit passes locally with no issues (28,148 lines scanned)
- [x] pip-audit runs successfully
- [ ] CI security job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)