### PR TITLE
fix(db): Add COLLATE NOCASE index and optimize duplicate detection (Issue #DEBT-25)

### DIFF
--- a/emdx/database/migrations.py
+++ b/emdx/database/migrations.py
@@ -2130,6 +2130,26 @@ def migration_038_add_title_lower_index(conn: sqlite3.Connection):
     conn.commit()
 
 
+def migration_039_add_title_nocase_index(conn: sqlite3.Connection):
+    """Add COLLATE NOCASE index for case-insensitive title search (DEBT-25).
+
+    This complements the LOWER(title) index by adding a COLLATE NOCASE index
+    which allows case-insensitive comparisons directly using the standard
+    comparison operators (=, LIKE, etc.) without wrapping in LOWER().
+
+    Queries like `WHERE title = 'Example' COLLATE NOCASE` or
+    `WHERE title LIKE '%search%' COLLATE NOCASE` will use this index.
+    """
+    cursor = conn.cursor()
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_documents_title_nocase
+        ON documents(title COLLATE NOCASE)
+    """)
+
+    conn.commit()
+
+
 # List of all migrations in order
 MIGRATIONS: list[tuple[int, str, Callable]] = [
     (0, "Create documents table", migration_000_create_documents_table),
@@ -2171,6 +2191,7 @@ MIGRATIONS: list[tuple[int, str, Callable]] = [
     (36, "Add execution metrics and task linkage", migration_036_add_execution_metrics),
     (37, "Add ON DELETE CASCADE to foreign keys", migration_037_add_cascade_delete_fks),
     (38, "Add LOWER(title) index for case-insensitive search", migration_038_add_title_lower_index),
+    (39, "Add COLLATE NOCASE index for title search", migration_039_add_title_nocase_index),
 ]
 
 


### PR DESCRIPTION
## Summary

- Add migration_039 to create `idx_documents_title_nocase` index on documents table for case-insensitive title search without `LOWER()` wrapper
- Verified DEBT-28 (O(n²) duplicate detection) was already fixed in commit 4fafee9 — `find_near_duplicates()` now uses MinHash/LSH for O(n) approximate detection

## Details

### DEBT-25: COLLATE NOCASE index

The new index complements the existing `LOWER(title)` index by allowing queries like:
- `WHERE title = 'Example' COLLATE NOCASE`
- `WHERE title LIKE '%search%' COLLATE NOCASE`

### DEBT-28: O(n²) duplicate detection (already fixed)

Verified that the O(n²) nested loop comparison in `duplicate_detector.py` was already replaced with MinHash/LSH in PR #287. The current implementation:
- Uses `datasketch.MinHashLSH` for O(n) average-case candidate generation
- Keeps `find_near_duplicates_exact()` as legacy method for small datasets/verification only

## Test plan

- [x] `poetry run pytest tests/test_migrations.py -x -q` passes
- [x] `poetry run pytest tests/ -x -q --ignore=tests/test_commands_core.py` passes (989 tests)
- [ ] Note: `test_commands_core.py::TestFindCommand::test_find_basic` has a pre-existing failure unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)