### PR TITLE
refactor: Centralize config constants (timeouts, models, env vars) (Issue #DEBT-7)

### DIFF
--- a/emdx/commands/cascade.py
+++ b/emdx/commands/cascade.py
@@ -20,7 +20,11 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from ..config.constants import EMDX_LOG_DIR
+from ..config.constants import (
+    EMDX_LOG_DIR,
+    STAGE_DEFAULT_TIMEOUT,
+    STAGE_IMPLEMENTATION_TIMEOUT,
+)
 from ..database import cascade as cascade_db
 from ..database.connection import db_connection
 from ..database.documents import get_document, save_document
@@ -169,7 +173,7 @@ def _process_stage(doc: dict, stage: str, cascade_run_id: int = None) -> tuple[b
         execution_id = cursor.lastrowid
 
     # Implementation stage needs longer timeout
-    timeout = 1800 if stage == "planned" else 300
+    timeout = STAGE_IMPLEMENTATION_TIMEOUT if stage == "planned" else STAGE_DEFAULT_TIMEOUT
 
     try:
         result = execute_cli_sync(

--- a/emdx/commands/gist.py
+++ b/emdx/commands/gist.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 import typer
 
+from emdx.config.constants import ENV_GITHUB_TOKEN
 from emdx.database import db
 from emdx.models.documents import get_document
 from emdx.utils.output import console
@@ -47,7 +48,7 @@ def get_github_auth() -> str | None:
 
     # 2. Fall back to environment variable GITHUB_TOKEN
     # Note: Environment variables are less secure than gh auth
-    token = os.getenv("GITHUB_TOKEN")
+    token = os.getenv(ENV_GITHUB_TOKEN)
     if token:
         return token
 

--- a/emdx/config/cli_config.py
+++ b/emdx/config/cli_config.py
@@ -9,6 +9,12 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List
 
+from .constants import (
+    DEFAULT_CLAUDE_MODEL,
+    DEFAULT_CLAUDE_SONNET_MODEL,
+    ENV_CLI_TOOL,
+)
+
 # Default tools allowed for Claude CLI execution
 # These are the standard tools that most agents need for basic operations
 DEFAULT_ALLOWED_TOOLS: List[str] = [
@@ -76,7 +82,7 @@ CLI_CONFIGS: Dict[CliTool, CliConfig] = {
         default_output_format="stream-json",
         requires_verbose_for_stream=True,
         model_flag="--model",
-        default_model="claude-opus-4-5-20251101",
+        default_model=DEFAULT_CLAUDE_MODEL,
         supports_allowed_tools=True,
         allowed_tools_flag="--allowedTools",
         force_flag=None,
@@ -106,19 +112,19 @@ CLI_CONFIGS: Dict[CliTool, CliConfig] = {
 # Use these aliases for portable commands that work with either CLI
 MODEL_ALIASES: Dict[str, Dict[str, str]] = {
     "opus": {
-        "claude": "claude-opus-4-5-20251101",
+        "claude": DEFAULT_CLAUDE_MODEL,
         "cursor": "opus-4.5",
     },
     "sonnet": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": DEFAULT_CLAUDE_SONNET_MODEL,
         "cursor": "sonnet-4.5",
     },
     "auto": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": DEFAULT_CLAUDE_SONNET_MODEL,
         "cursor": "auto",
     },
     "fast": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": DEFAULT_CLAUDE_SONNET_MODEL,
         "cursor": "auto",
     },
 }
@@ -129,7 +135,7 @@ def get_default_cli_tool() -> CliTool:
 
     Checks EMDX_CLI_TOOL environment variable first.
     """
-    env_value = os.environ.get("EMDX_CLI_TOOL", "claude").lower()
+    env_value = os.environ.get(ENV_CLI_TOOL, "claude").lower()
     try:
         return CliTool(env_value)
     except ValueError:

--- a/emdx/config/constants.py
+++ b/emdx/config/constants.py
@@ -198,6 +198,30 @@ DEFAULT_CLAUDE_SONNET_MODEL = "claude-sonnet-4-5-20250929"
 # =============================================================================
 
 DELEGATE_EXECUTION_TIMEOUT = 600  # 10 min - delegate agent timeout
+CLI_SYNC_DEFAULT_TIMEOUT = 300  # 5 min - default timeout for execute_cli_sync
+STAGE_IMPLEMENTATION_TIMEOUT = 1800  # 30 min - longer timeout for implementation stages
+STAGE_DEFAULT_TIMEOUT = 300  # 5 min - default timeout for non-implementation stages
 SUBPROCESS_DEFAULT_TIMEOUT = 30  # Default subprocess timeout
 SUBPROCESS_SHORT_TIMEOUT = 10  # Short operations (git status, gist check)
 NETWORK_REQUEST_TIMEOUT = 30  # HTTP request timeout
+
+# =============================================================================
+# ENVIRONMENT VARIABLE NAMES
+# =============================================================================
+
+ENV_CLI_TOOL = "EMDX_CLI_TOOL"  # Which CLI tool to use (claude/cursor)
+ENV_SAFE_MODE = "EMDX_SAFE_MODE"  # Enable safe mode (disable execution commands)
+ENV_TEST_DB = "EMDX_TEST_DB"  # Test database path
+ENV_CODE_THEME = "EMDX_CODE_THEME"  # Code syntax highlighting theme
+ENV_ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY"  # Anthropic API key
+ENV_CURSOR_API_KEY = "CURSOR_API_KEY"  # Cursor API key
+ENV_GITHUB_TOKEN = "GITHUB_TOKEN"  # GitHub token for gist operations
+
+# =============================================================================
+# UI DEBOUNCE & TIMING (in milliseconds)
+# =============================================================================
+
+DEBOUNCE_FTS_MS = 300  # Full-text search debounce
+DEBOUNCE_TAGS_MS = 300  # Tag search debounce
+DEBOUNCE_SEMANTIC_MS = 500  # Semantic search debounce
+DEBOUNCE_COMBINED_MS = 400  # Combined search debounce

--- a/emdx/config/settings.py
+++ b/emdx/config/settings.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 # Re-export constants for backward compatibility
-from .constants import EMDX_CONFIG_DIR
+from .constants import EMDX_CONFIG_DIR, ENV_TEST_DB
 
 
 def get_db_path() -> Path:
@@ -13,7 +13,7 @@ def get_db_path() -> Path:
     When running tests, set EMDX_TEST_DB to a temp file path to prevent
     tests from polluting the real database.
     """
-    test_db = os.environ.get("EMDX_TEST_DB")
+    test_db = os.environ.get(ENV_TEST_DB)
     if test_db:
         return Path(test_db)
 

--- a/emdx/database/connection.py
+++ b/emdx/database/connection.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
-from ..config.constants import EMDX_CONFIG_DIR
+from ..config.constants import EMDX_CONFIG_DIR, ENV_TEST_DB
 from . import migrations
 
 
@@ -18,7 +18,7 @@ def get_db_path() -> Path:
     When running tests, set EMDX_TEST_DB to a temp file path to prevent
     tests from polluting the real database.
     """
-    test_db = os.environ.get("EMDX_TEST_DB")
+    test_db = os.environ.get(ENV_TEST_DB)
     if test_db:
         return Path(test_db)
 

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -13,6 +13,7 @@ import os
 import typer
 
 from emdx import __build_id__, __version__
+from emdx.config.constants import ENV_SAFE_MODE
 from emdx.utils.lazy_group import LazyTyperGroup, register_lazy_commands
 
 # =============================================================================
@@ -44,7 +45,7 @@ def is_safe_mode() -> bool:
     Safe mode disables execution commands (cascade, delegate, recipe).
     Enable with EMDX_SAFE_MODE=1 environment variable.
     """
-    return os.environ.get("EMDX_SAFE_MODE", "0").lower() in ("1", "true", "yes")
+    return os.environ.get(ENV_SAFE_MODE, "0").lower() in ("1", "true", "yes")
 
 
 # Commands disabled in safe mode
@@ -242,7 +243,7 @@ def main(
     # Note: This is checked at import time, so the flag mainly serves as documentation
     # and for future commands that might check at runtime
     if safe_mode:
-        os.environ["EMDX_SAFE_MODE"] = "1"
+        os.environ[ENV_SAFE_MODE] = "1"
 
 
 # Known subcommands of `emdx tag` — used for shorthand routing

--- a/emdx/services/ask_service.py
+++ b/emdx/services/ask_service.py
@@ -20,6 +20,7 @@ except ImportError:
     anthropic = None  # type: ignore[assignment]
     HAS_ANTHROPIC = False
 
+from ..config.constants import DEFAULT_CLAUDE_SONNET_MODEL
 from ..database import db
 
 logger = logging.getLogger(__name__)
@@ -38,11 +39,10 @@ class Answer:
 class AskService:
     """Answer questions using your knowledge base."""
 
-    DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
     MIN_EMBEDDINGS_FOR_SEMANTIC = 50  # Use semantic only if we have enough coverage
 
     def __init__(self, model: str | None = None):
-        self.model = model or self.DEFAULT_MODEL
+        self.model = model or DEFAULT_CLAUDE_SONNET_MODEL
         self._client = None
         self._embedding_service = None
 

--- a/emdx/services/cascade_service.py
+++ b/emdx/services/cascade_service.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Dict, List
 
+from emdx.config.constants import STAGE_DEFAULT_TIMEOUT, STAGE_IMPLEMENTATION_TIMEOUT
 from emdx.database import cascade as cascade_db
 from emdx.database.connection import db_connection
 from emdx.database.documents import get_document
@@ -95,7 +96,7 @@ def monitor_execution_completion(
     from emdx.models.executions import get_execution, update_execution_status
 
     poll_interval = 2.0
-    max_wait = 1800 if stage == "planned" else 300
+    max_wait = STAGE_IMPLEMENTATION_TIMEOUT if stage == "planned" else STAGE_DEFAULT_TIMEOUT
     start_time = time.time()
 
     while True:

--- a/emdx/services/claude_executor.py
+++ b/emdx/services/claude_executor.py
@@ -22,6 +22,7 @@ from typing import List
 logger = logging.getLogger(__name__)
 
 from ..config.cli_config import DEFAULT_ALLOWED_TOOLS
+from ..config.constants import CLI_SYNC_DEFAULT_TIMEOUT
 from ..utils.environment import ensure_claude_in_path
 from ..utils.structured_logger import ProcessType, StructuredLogger
 from .cli_executor import get_cli_executor
@@ -228,7 +229,7 @@ def execute_cli_sync(
     allowed_tools: List[str] | None = None,
     working_dir: str | None = None,
     doc_id: str | None = None,
-    timeout: int = 300,
+    timeout: int = CLI_SYNC_DEFAULT_TIMEOUT,
 ) -> dict:
     """Execute a task with specified CLI tool synchronously, waiting for completion.
 
@@ -244,7 +245,7 @@ def execute_cli_sync(
         allowed_tools: List of allowed tools (defaults to DEFAULT_ALLOWED_TOOLS)
         working_dir: Working directory for execution
         doc_id: Document ID (for logging)
-        timeout: Maximum seconds to wait (default 300 = 5 minutes)
+        timeout: Maximum seconds to wait (default CLI_SYNC_DEFAULT_TIMEOUT = 5 minutes)
 
     Returns:
         Dict with 'success' (bool), 'output' (str) or 'error' (str), and 'exit_code' (int)

--- a/emdx/services/cli_executor/factory.py
+++ b/emdx/services/cli_executor/factory.py
@@ -4,6 +4,7 @@ import os
 from typing import Union
 
 from ...config.cli_config import CliTool
+from ...config.constants import ENV_CLI_TOOL
 from .base import CliExecutor
 from .claude import ClaudeCliExecutor
 from .cursor import CursorCliExecutor
@@ -35,7 +36,7 @@ def get_cli_executor(cli_tool: Union[str, CliTool] | None = None) -> CliExecutor
     # Determine which CLI to use
     if cli_tool is None:
         # Check environment variable, default to Claude
-        env_value = os.environ.get("EMDX_CLI_TOOL", "claude").lower()
+        env_value = os.environ.get(ENV_CLI_TOOL, "claude").lower()
         cli_tool = env_value
 
     # Convert string to enum if needed

--- a/emdx/services/unified_executor.py
+++ b/emdx/services/unified_executor.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from ..config.cli_config import DEFAULT_ALLOWED_TOOLS
-from ..config.constants import EMDX_LOG_DIR
+from ..config.constants import CLI_SYNC_DEFAULT_TIMEOUT, EMDX_LOG_DIR
 from ..models.executions import create_execution, update_execution_status
 from ..utils.environment import get_subprocess_env
 from .cli_executor import get_cli_executor
@@ -145,7 +145,7 @@ class ExecutionConfig:
     doc_id: int | None = None
     output_instruction: str | None = None
     allowed_tools: List[str] = field(default_factory=lambda: DEFAULT_ALLOWED_TOOLS.copy())
-    timeout_seconds: int = 300
+    timeout_seconds: int = CLI_SYNC_DEFAULT_TIMEOUT
     cli_tool: str = "claude"  # "claude" or "cursor"
     model: str | None = None  # Override default model for the CLI
     verbose: bool = False  # Stream output in real-time

--- a/emdx/ui/markdown_config.py
+++ b/emdx/ui/markdown_config.py
@@ -10,6 +10,7 @@ import os
 
 from rich.markdown import Markdown
 
+from ..config.constants import ENV_CODE_THEME
 from ..utils.output import console as shared_console
 
 
@@ -32,7 +33,7 @@ class MarkdownConfig:
     def get_code_theme():
         """Get the appropriate code theme based on UI config or terminal background."""
         # Check environment variable for user preference (highest priority)
-        theme = os.environ.get("EMDX_CODE_THEME")
+        theme = os.environ.get(ENV_CODE_THEME)
         if theme:
             return theme
 

--- a/emdx/ui/search/search_presenter.py
+++ b/emdx/ui/search/search_presenter.py
@@ -10,6 +10,13 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Set
 
+from ...config.constants import (
+    DEBOUNCE_COMBINED_MS,
+    DEBOUNCE_FTS_MS,
+    DEBOUNCE_SEMANTIC_MS,
+    DEBOUNCE_TAGS_MS,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -68,10 +75,10 @@ class SearchPresenter:
 
     # Debounce times by mode (milliseconds) - wait for user to stop typing
     DEBOUNCE_TIMES = {
-        SearchMode.FTS: 300,
-        SearchMode.TAGS: 300,
-        SearchMode.SEMANTIC: 500,
-        SearchMode.COMBINED: 400,
+        SearchMode.FTS: DEBOUNCE_FTS_MS,
+        SearchMode.TAGS: DEBOUNCE_TAGS_MS,
+        SearchMode.SEMANTIC: DEBOUNCE_SEMANTIC_MS,
+        SearchMode.COMBINED: DEBOUNCE_COMBINED_MS,
     }
 
     # Minimum query length before searching (avoids searching on every keystroke)

--- a/emdx/utils/environment.py
+++ b/emdx/utils/environment.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-from emdx.config.constants import EMDX_CONFIG_DIR
+from emdx.config.constants import EMDX_CONFIG_DIR, ENV_ANTHROPIC_API_KEY, ENV_CURSOR_API_KEY
 from emdx.utils.output import console
 
 
@@ -176,7 +176,7 @@ class EnvironmentValidator:
             self.warnings.append("Claude config file not found - claude might not be properly configured")
 
         # Check ANTHROPIC_API_KEY
-        if os.environ.get("ANTHROPIC_API_KEY"):
+        if os.environ.get(ENV_ANTHROPIC_API_KEY):
             self.info["api_key"] = "set"
         else:
             # Check if claude works without explicit API key
@@ -188,14 +188,14 @@ class EnvironmentValidator:
                     timeout=5
                 )
                 if result.returncode != 0:
-                    self.warnings.append("ANTHROPIC_API_KEY not set and claude might not work")
+                    self.warnings.append(f"{ENV_ANTHROPIC_API_KEY} not set and claude might not work")
             except Exception as e:
                 self.warnings.append(f"Cannot verify claude installation: {e}")
 
     def _check_cursor_config(self) -> None:
         """Check Cursor-specific configuration."""
         # Check CURSOR_API_KEY
-        if os.environ.get("CURSOR_API_KEY"):
+        if os.environ.get(ENV_CURSOR_API_KEY):
             self.info["cursor_api_key"] = "set"
 
         # Check authentication status


### PR DESCRIPTION
## Summary
Centralizes scattered configuration constants (timeouts, model names, environment variable names) into `emdx/config/constants.py`.

## Changes Made

### Added new constants to `emdx/config/constants.py`:

**Timeout constants:**
- `CLI_SYNC_DEFAULT_TIMEOUT = 300` - 5 min default timeout for execute_cli_sync
- `STAGE_IMPLEMENTATION_TIMEOUT = 1800` - 30 min for implementation stages
- `STAGE_DEFAULT_TIMEOUT = 300` - 5 min for non-implementation stages

**Environment variable name constants:**
- `ENV_CLI_TOOL = "EMDX_CLI_TOOL"` - Which CLI tool to use
- `ENV_SAFE_MODE = "EMDX_SAFE_MODE"` - Enable safe mode
- `ENV_TEST_DB = "EMDX_TEST_DB"` - Test database path
- `ENV_CODE_THEME = "EMDX_CODE_THEME"` - Code syntax theme
- `ENV_ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY"` - Anthropic API key
- `ENV_CURSOR_API_KEY = "CURSOR_API_KEY"` - Cursor API key
- `ENV_GITHUB_TOKEN = "GITHUB_TOKEN"` - GitHub token

**UI debounce constants:**
- `DEBOUNCE_FTS_MS = 300` - Full-text search debounce
- `DEBOUNCE_TAGS_MS = 300` - Tag search debounce
- `DEBOUNCE_SEMANTIC_MS = 500` - Semantic search debounce
- `DEBOUNCE_COMBINED_MS = 400` - Combined search debounce

### Updated 15 files to use centralized constants:

| File | Change |
|------|--------|
| `emdx/services/cascade_service.py` | Use STAGE_*_TIMEOUT constants |
| `emdx/services/claude_executor.py` | Use CLI_SYNC_DEFAULT_TIMEOUT |
| `emdx/commands/cascade.py` | Use STAGE_*_TIMEOUT constants |
| `emdx/services/unified_executor.py` | Use CLI_SYNC_DEFAULT_TIMEOUT |
| `emdx/services/ask_service.py` | Use DEFAULT_CLAUDE_SONNET_MODEL |
| `emdx/config/cli_config.py` | Use DEFAULT_CLAUDE_MODEL, DEFAULT_CLAUDE_SONNET_MODEL, ENV_CLI_TOOL |
| `emdx/services/cli_executor/factory.py` | Use ENV_CLI_TOOL |
| `emdx/main.py` | Use ENV_SAFE_MODE |
| `emdx/commands/gist.py` | Use ENV_GITHUB_TOKEN |
| `emdx/utils/environment.py` | Use ENV_ANTHROPIC_API_KEY, ENV_CURSOR_API_KEY |
| `emdx/config/settings.py` | Use ENV_TEST_DB |
| `emdx/database/connection.py` | Use ENV_TEST_DB |
| `emdx/ui/markdown_config.py` | Use ENV_CODE_THEME |
| `emdx/ui/search/search_presenter.py` | Use DEBOUNCE_*_MS constants |

## Test plan
- [x] All 989 tests pass (excluding one pre-existing flaky test in test_commands_core.py)
- [x] Verified imports work correctly with `python -c "from emdx.config.constants import ..."`

## Benefits
- Single source of truth for configuration values
- Easier to find and modify constants
- Better IDE support for refactoring
- Clear documentation of all configurable values

🤖 Generated with [Claude Code](https://claude.com/claude-code)