### PR TITLE
fix(delegate): Prevent flag-as-task parsing and increase timeout

### DIFF
--- a/emdx/config/constants.py
+++ b/emdx/config/constants.py
@@ -197,7 +197,7 @@ DEFAULT_CLAUDE_SONNET_MODEL = "claude-sonnet-4-5-20250929"
 # SUBPROCESS & NETWORK TIMEOUTS (in seconds)
 # =============================================================================
 
-DELEGATE_EXECUTION_TIMEOUT = 600  # 10 min - delegate agent timeout
+DELEGATE_EXECUTION_TIMEOUT = 1800  # 30 min - delegates need time for complex tasks
 SUBPROCESS_DEFAULT_TIMEOUT = 30  # Default subprocess timeout
 SUBPROCESS_SHORT_TIMEOUT = 10  # Short operations (git status, gist check)
 NETWORK_REQUEST_TIMEOUT = 30  # HTTP request timeout


### PR DESCRIPTION
## Summary
- Fix Typer/Click greedy argument parsing that consumed `--tags` and `--title` flags as positional task arguments when placed after task prompts
- Set `allow_interspersed_args=False` to enforce flags-before-args convention
- Add safety guard that detects known flags in the task list with a clear error message
- Increase delegate execution timeout from 10min to 30min for complex tasks

## Bug Details
When running:
```bash
emdx delegate --synthesize "task1" "task2" "task3" --tags "gameplan,active" --title "Title"
```
Click's variadic argument parser consumed `--tags`, `gameplan,active`, `--title`, and `Title` as additional task arguments, creating tasks titled `--tags [4/7]` and `--title [6/7]` that immediately failed. This has been observed twice in production.

## Test plan
- [x] 1092 tests pass
- [ ] Verify `emdx delegate --synthesize --tags "x" --title "y" "task1" "task2"` works correctly
- [ ] Verify `emdx delegate "task1" "task2" --tags "x"` shows the new error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)