### PR TITLE
feat(task): Add task introspection commands and fix list output

### DIFF
--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -123,7 +123,7 @@ def done(
 @app.command()
 def view(
     task_id: int = typer.Argument(..., help="Task ID"),
-):
+) -> None:
     """View full task details.
 
     Shows title, description, status, epic/category, source doc,
@@ -191,7 +191,7 @@ def view(
 def active(
     task_id: int = typer.Argument(..., help="Task ID"),
     note: str | None = typer.Option(None, "-n", "--note", help="Progress note"),
-):
+) -> None:
     """Mark a task as in-progress.
 
     Use this at session start after picking a task from 'emdx task ready'.
@@ -216,7 +216,7 @@ def active(
 def log(
     task_id: int = typer.Argument(..., help="Task ID"),
     message: str | None = typer.Argument(None, help="Log message (omit to view log)"),
-):
+) -> None:
     """View or add to a task's work log.
 
     Without a message, shows the log history.
@@ -251,7 +251,7 @@ def log(
 def note(
     task_id: int = typer.Argument(..., help="Task ID"),
     message: str = typer.Argument(..., help="Progress note"),
-):
+) -> None:
     """Log a progress note on a task without changing its status.
 
     Shorthand for 'emdx task log <id> "message"'.
@@ -273,7 +273,7 @@ def note(
 def blocked(
     task_id: int = typer.Argument(..., help="Task ID"),
     reason: str = typer.Option("", "-r", "--reason", help="Why the task is blocked"),
-):
+) -> None:
     """Mark a task as blocked.
 
     Optionally provide a reason, which is logged to the work log.

--- a/emdx/models/tasks.py
+++ b/emdx/models/tasks.py
@@ -367,9 +367,11 @@ def get_active_delegate_tasks() -> list[dict[str, Any]]:
                 (SELECT COUNT(*) FROM tasks c
                  WHERE c.parent_task_id = t.id) as child_count,
                 (SELECT COUNT(*) FROM tasks c
-                 WHERE c.parent_task_id = t.id AND c.status = 'done') as children_done,
+                 WHERE c.parent_task_id = t.id
+                 AND c.status = 'done') as children_done,
                 (SELECT COUNT(*) FROM tasks c
-                 WHERE c.parent_task_id = t.id AND c.status = 'active') as children_active
+                 WHERE c.parent_task_id = t.id
+                 AND c.status = 'active') as children_active
             FROM tasks t
             WHERE t.status = 'active' AND t.parent_task_id IS NULL
             ORDER BY t.updated_at DESC


### PR DESCRIPTION
## Summary

### New commands (high value)
- **`emdx task view <id>`** — Full task inspection: title, description, status, epic/category, source doc, dependencies, and recent work log entries
- **`emdx task active <id>`** — Mark a task as in-progress (with optional `--note/-n`). Use at session start after picking from `emdx task ready`
- **`emdx task log <id> [message]`** — Dual-mode: view the work log (no message) or append an entry (with message)

### New commands (medium value)
- **`emdx task note <id> "msg"`** — Quick progress note without status change (shorthand for `log <id> "msg"`)
- **`emdx task blocked <id>`** — Mark blocked with optional `--reason/-r` logged to work log

### Fix task list output
- Default to showing only **actionable tasks** (open/active/blocked) — done/failed hidden unless `--done` flag used
- Add **Status text column** with color coding alongside icons
- Add **Cat column** (shown when any tasks have categories)
- **Remove 50-char title truncation** — let Rich handle wrapping
- **Sort by status priority**: active > blocked > open > failed > done
- Handle `closed` status in icons and styles

## Before / After

**Before** (`emdx task list`):
```
     ID     Title                                              Doc
 ✓   67     EPIC: Exception Handling (7 parallel tasks)
 ✓   63     EPIC: Security Hardening (3 combined tasks)
 ✓   62     QW-10: Fix get_pattern_stats() placeholder
 ⊘   59     QW-7: Add COLLATE NOCASE index for search
 ?   53     QW-1: Fix bare except in zoom02_main.py
```
Problems: mostly done tasks, no status text, `?` for unknown status, titles truncated at 50 chars

**After** (`emdx task list`):
```
     ID     Status   Title
 ⊘   59     blocked  QW-7: Add COLLATE NOCASE index for search
 ⊘   87     blocked  REFACTOR-8: Split agent_stats()
 ○   599    open     Fix all mypy type errors on main
 ○   598    open     Fix all lint errors on main
 ○   594    open     Add --draft flag to emdx delegate --pr
```
Only actionable tasks, status text with color, full titles, sorted by status

## Typical Claude Code session flow
```
emdx prime                              # See ready tasks
emdx task view 42                       # Inspect before starting
emdx task active 42 -n "Starting work"  # Mark in-progress
emdx task note 42 "Found root cause"    # Record progress mid-session
emdx task done 42 -n "Fixed in PR #580" # Complete
```

## Test plan

- [x] 27 new tests across view, active, log, note, blocked, and list improvements
- [x] Full suite passes (1082 passed)
- [x] Synced with main (3 commits merged, 1 conflict resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)