### PR TITLE
chore: Add code quality guardrails — ruff pre-commit hook + CLAUDE.md lint rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,24 @@ poetry run emdx --help  # Always use poetry run in project dir
 poetry run pytest tests/ -x -q  # Run tests
 ```
 
+## Code Quality — MANDATORY
+
+**Before every commit, run lint and fix errors:**
+
+```bash
+poetry run ruff check . --fix   # Auto-fix what it can
+poetry run ruff check .         # Verify zero errors remain
+```
+
+**Rules:**
+- Line length limit: **100 characters** (configured in pyproject.toml)
+- Enabled rule sets: E, W, F, I, B, C4, UP (pycodestyle, pyflakes, isort, bugbear, comprehensions, pyupgrade)
+- B904: Always use `raise ... from err` or `raise ... from None` inside `except` blocks
+- B008 is ignored (typer pattern for function call defaults)
+- `ruff check` must pass with **zero errors** before pushing any branch
+- When writing SQL strings that exceed 100 chars, break across lines or use implicit string concatenation
+- All `--flags` must come BEFORE positional arguments in `emdx delegate` calls
+
 ## Claude Code Integration - MANDATORY
 
 ### Session Start Protocol

--- a/justfile
+++ b/justfile
@@ -60,7 +60,7 @@ lint:
 
 # Format code
 format:
-    poetry run black .
+    poetry run ruff format .
 
 # Run type checking
 typecheck:
@@ -70,10 +70,16 @@ typecheck:
 check: lint typecheck test
     @echo "All checks passed!"
 
+# Install git hooks (ruff pre-commit)
+install-hooks:
+    cp scripts/pre-commit .git/hooks/pre-commit
+    chmod +x .git/hooks/pre-commit
+    @echo "Pre-commit hook installed (ruff lint check)"
+
 # Fix all auto-fixable issues
 fix:
-    poetry run black .
     poetry run ruff check --fix .
+    poetry run ruff format .
 
 # Clean up cache and build files
 clean:

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+# emdx pre-commit hook — runs ruff lint on staged Python files
+#
+# Install: cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+# Or:      just install-hooks
+#
+# Prevents commits with lint errors. Auto-fixes are NOT applied;
+# run `poetry run ruff check . --fix` manually if needed.
+
+# Find staged .py files
+STAGED_PY=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$')
+
+if [ -z "$STAGED_PY" ]; then
+    exit 0
+fi
+
+# Run ruff on staged files only
+if command -v poetry >/dev/null 2>&1; then
+    poetry run ruff check $STAGED_PY
+else
+    ruff check $STAGED_PY
+fi
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "Pre-commit: ruff lint errors found. Fix with:"
+    echo "  poetry run ruff check . --fix"
+    echo ""
+    echo "To bypass (emergency only): git commit --no-verify"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add "Code Quality — MANDATORY" section to CLAUDE.md so delegates always run `ruff check` before commits
- Add tracked `scripts/pre-commit` hook that runs ruff lint on staged .py files
- Add `just install-hooks` to install the hook
- Replace old bd (beads) pre-commit shim with ruff-based check
- Switch `just format` and `just fix` from black to ruff format

## Why
All 11 open PRs were failing lint CI because delegates were committing without running ruff. This adds guardrails at two levels:
1. **CLAUDE.md** — delegates read this and will run lint before committing
2. **Pre-commit hook** — catches errors even if the delegate forgets (works in worktrees too since they share `.git/hooks/`)

## Test plan
- [ ] `just install-hooks` installs the hook correctly
- [ ] `just lint` still works
- [ ] `just fix` auto-fixes lint issues
- [ ] Pre-commit hook blocks commits with lint errors
- [ ] Pre-commit hook passes clean commits through

🤖 Generated with [Claude Code](https://claude.com/claude-code)