### PR TITLE
fix: Resolve remaining 9 ruff lint errors on main

### DIFF
--- a/emdx/main.py
+++ b/emdx/main.py
@@ -90,12 +90,12 @@ register_lazy_commands(get_lazy_subcommands(), get_lazy_help())
 # Imports are after lazy registration - this is intentional for the loading pattern
 # =============================================================================
 from emdx.commands.browse import app as browse_app  # noqa: E402
+from emdx.commands.categories import app as categories_app  # noqa: E402
 from emdx.commands.core import app as core_app  # noqa: E402
+from emdx.commands.epics import app as epics_app  # noqa: E402
 from emdx.commands.executions import app as executions_app  # noqa: E402
 from emdx.commands.gist import app as gist_app  # noqa: E402
 from emdx.commands.groups import app as groups_app  # noqa: E402
-from emdx.commands.epics import app as epics_app  # noqa: E402
-from emdx.commands.categories import app as categories_app  # noqa: E402
 from emdx.commands.maintain import app as maintain_app  # noqa: E402
 from emdx.commands.prime import prime as prime_command  # noqa: E402
 from emdx.commands.status import status as status_command  # noqa: E402

--- a/emdx/utils/claude_wrapper.py
+++ b/emdx/utils/claude_wrapper.py
@@ -18,7 +18,7 @@ from pathlib import Path
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from emdx.models.executions import update_execution_heartbeat, update_execution_status
+from emdx.models.executions import update_execution_heartbeat, update_execution_status  # noqa: E402
 
 
 def heartbeat_thread(exec_id: int, stop_event: threading.Event) -> None:

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,15 +1,12 @@
 """Tests for the categories model and CLI."""
 
 import re
-import sqlite3
-from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
 
-from emdx.models import categories, tasks
 from emdx.commands.categories import app
-
+from emdx.models import categories, tasks
 
 runner = CliRunner()
 
@@ -119,7 +116,7 @@ class TestAdoptCategory:
 
     def test_adopt_with_name(self):
         categories.ensure_category("ANME")
-        result = categories.adopt_category("ANME", name="Adopted Name")
+        categories.adopt_category("ANME", name="Adopted Name")
         cat = categories.get_category("ANME")
         assert cat["name"] == "Adopted Name"
 

--- a/tests/test_epics.py
+++ b/tests/test_epics.py
@@ -1,15 +1,13 @@
 """Tests for the epics model and CLI."""
 
 import re
-from unittest.mock import patch
 
-import pytest
 from typer.testing import CliRunner
 
-from emdx.models import tasks, categories
 from emdx.commands.epics import app as epics_app
-from emdx.commands.tasks import app as tasks_app, ICONS
-
+from emdx.commands.tasks import ICONS
+from emdx.commands.tasks import app as tasks_app
+from emdx.models import categories, tasks
 
 runner = CliRunner()
 


### PR DESCRIPTION
## Summary
- Fix unsorted imports (I001) in main.py, test_categories.py, test_epics.py
- Remove unused imports: sqlite3, patch, pytest (F401)
- Remove unused local variable (F841) in test_categories.py
- Add noqa for unavoidable E402 in claude_wrapper.py

`ruff check .` now passes with zero errors on main.

## Test plan
- [ ] `poetry run ruff check .` returns zero errors
- [ ] `poetry run pytest tests/ -x -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)