### PR TITLE
fix: Resolve UI race conditions in document browser and search presenter (Issue #625, #628)

### DIFF
--- a/emdx/ui/search/search_presenter.py
+++ b/emdx/ui/search/search_presenter.py
@@ -197,8 +197,9 @@ class SearchPresenter:
             await self._notify_update()
             return
 
-        # Check cache
-        cache_key = f"{self._state.mode.value}:{query}"
+        # Check cache - include active filters and tags in the key
+        filters_str = ",".join(sorted(self._state.active_filters)) if self._state.active_filters else ""  # noqa: E501
+        cache_key = f"{self._state.mode.value}:{query}:filters={filters_str}"
         if cache_key in self._cache:
             self._state.results = self._cache[cache_key]
             self._state.total_count = len(self._state.results)


### PR DESCRIPTION
## Summary
- Add `_save_in_progress` flag to prevent double-save race condition in `action_save_and_exit_edit()` (#625)
- Include `active_filters` in search cache key to prevent stale results when filters change (#628)

## Test plan
- [ ] Edit a document and press Ctrl+S rapidly - should only save once
- [ ] Search with filters, change filters, search same query - should return fresh results

🤖 Generated with [Claude Code](https://claude.com/claude-code)