### PR TITLE
feat: Add systematic --json output support to CLI commands

### DIFF
--- a/emdx/commands/tags.py
+++ b/emdx/commands/tags.py
@@ -23,7 +23,7 @@ from emdx.models.tags import (
 )
 from emdx.services.auto_tagger import AutoTagger
 from emdx.ui.formatting import format_tags
-from emdx.utils.output import console
+from emdx.utils.output import console, print_json
 from emdx.utils.text_formatting import truncate_title
 
 app = typer.Typer(help="Manage document tags")
@@ -184,6 +184,7 @@ def remove(
 def list_tags(
     sort: str = typer.Option("usage", "--sort", "-s", help="Sort by: usage, name, created"),
     limit: int = typer.Option(50, "--limit", "-n", help="Maximum tags to show"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
     """List all tags with statistics."""
     try:
@@ -192,6 +193,10 @@ def list_tags(
 
         # Get all tags
         all_tags = list_all_tags(sort_by=sort)
+
+        if json_output:
+            print_json(all_tags[:limit])
+            return
 
         if not all_tags:
             console.print("[yellow]No tags found[/yellow]")

--- a/emdx/utils/output.py
+++ b/emdx/utils/output.py
@@ -1,7 +1,18 @@
 """Shared console output utilities."""
 
+import json
+from typing import Any
+
 from rich.console import Console
 
 # Shared console instance for all CLI output
 # Uses force_terminal=True to ensure color output even when not connected to a terminal
 console = Console(force_terminal=True, color_system="auto")
+
+
+def print_json(data: Any) -> None:
+    """Print data as formatted JSON to stdout.
+
+    Handles common non-serializable types like datetime by converting them to strings.
+    """
+    print(json.dumps(data, indent=2, default=str))


### PR DESCRIPTION
## Summary
- Add `--json` flag to `task ready`, `task list`, `task done`, `status`, and `tag list` commands
- Create shared `print_json()` helper in `utils/output.py` for consistent JSON serialization
- Pattern: when `--json` is set, commands print `json.dumps(data, indent=2, default=str)` instead of Rich table output

## Commands Updated
| Command | Output |
|---------|--------|
| `emdx task ready --json` | Array of ready tasks |
| `emdx task list --json` | Array of filtered tasks |
| `emdx task done 42 --json` | Task completion result |
| `emdx status --json` | Object with active, recent, failed, cascade counts |
| `emdx tag list --json` | Array of tags with statistics |

## Test plan
- [x] `emdx task ready --json` outputs valid JSON
- [x] `emdx task list --json` outputs valid JSON
- [x] `emdx status --json` outputs valid JSON with nested task children
- [x] `emdx tag list --json` outputs valid JSON
- [x] `poetry run ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)