### PR TITLE
feat: Add TypedDict definitions to models layer

### DIFF
--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -404,7 +404,11 @@ def find(
                     return
             else:
                 # Tag-only search
-                results = search_by_tags(tag_list, mode=tag_mode, project=project, limit=limit)
+                results = [
+                    dict(d) for d in search_by_tags(
+                        tag_list, mode=tag_mode, project=project, limit=limit,
+                    )
+                ]
                 if not results:
                     mode_desc = "all" if not any_tags else "any"
                     console.print(

--- a/emdx/commands/recipe.py
+++ b/emdx/commands/recipe.py
@@ -36,7 +36,7 @@ def _find_recipe(id_or_name: str) -> dict[str, Any] | None:
     recipes = search_by_tags(["📋"], limit=50, prefix_match=False)
     for r in recipes:
         if id_or_name.lower() in r.get("title", "").lower():
-            return r
+            return dict(r)
     if recipes:
         # Fall back to text search within recipes
         results = search_documents(id_or_name, limit=20)
@@ -59,10 +59,11 @@ def list_recipes() -> None:
         return
 
     console.print("[bold]Recipes[/bold]\n")
-    for doc in results:
+    for result in results:
+        doc: dict[str, Any] = dict(result)
         doc_id = doc["id"]
         title = doc.get("title", "Untitled")
-        content = doc.get("content", "")
+        content = str(doc.get("content", ""))
         # Show first line of content as description
         first_line = content.split("\n")[0].strip().lstrip("# ") if content else ""
         if first_line == title:

--- a/emdx/commands/status.py
+++ b/emdx/commands/status.py
@@ -230,12 +230,13 @@ def _collect_status_data() -> dict[str, Any]:
     cascade_counts = _get_cascade_counts()
 
     # Enrich active tasks with children
-    for task in active:
+    enriched: list[dict[str, Any]] = [dict(t) for t in active]
+    for task in enriched:
         if task.get("type") in ("group", "chain"):
             task["children"] = get_children(task["id"])
 
     return {
-        "active": active,
+        "active": enriched,
         "recent": recent,
         "failed": failed,
         "cascade": cascade_counts,

--- a/emdx/models/categories.py
+++ b/emdx/models/categories.py
@@ -1,6 +1,7 @@
 """Category operations for task epic numbering."""
 
 import re
+from typing import cast
 
 from emdx.database import db
 from emdx.models.types import CategoryDict, CategoryWithStatsDict
@@ -30,7 +31,7 @@ def get_category(key: str) -> CategoryDict | None:
     with db.get_connection() as conn:
         cursor = conn.execute("SELECT * FROM categories WHERE key = ?", (key,))
         row = cursor.fetchone()
-        return dict(row) if row else None
+        return cast(CategoryDict, dict(row)) if row else None
 
 
 def list_categories() -> list[CategoryWithStatsDict]:
@@ -51,7 +52,7 @@ def list_categories() -> list[CategoryWithStatsDict]:
             GROUP BY c.key
             ORDER BY c.key
         """)
-        return [dict(row) for row in cursor.fetchall()]
+        return [cast(CategoryWithStatsDict, dict(row)) for row in cursor.fetchall()]
 
 
 def ensure_category(key: str) -> str:

--- a/emdx/models/tags.py
+++ b/emdx/models/tags.py
@@ -1,7 +1,7 @@
 """Tag management operations for emdx."""
 
 import sqlite3
-from typing import Any
+from typing import Any, cast
 
 from emdx.database import db
 from emdx.models.types import TagSearchResultDict, TagStatsDict
@@ -229,15 +229,13 @@ def list_all_tags(sort_by: str = "usage") -> list[TagStatsDict]:
             # Normalize tag name to emoji for display
             normalized_name = normalize_tag_to_emoji(row[1])
 
-            tags.append(
-                {
-                    "id": row[0],
-                    "name": normalized_name,
-                    "count": row[2],
-                    "created_at": created_at,
-                    "last_used": last_used,
-                }
-            )
+            tags.append(cast(TagStatsDict, {
+                "id": row[0],
+                "name": normalized_name,
+                "count": row[2],
+                "created_at": created_at,
+                "last_used": last_used,
+            }))
 
         return tags
 
@@ -320,8 +318,10 @@ def search_by_tags(
 
         docs = []
         for row in cursor.fetchall():
-            doc = dict(zip([col[0] for col in cursor.description], row, strict=False))
-            docs.append(doc)
+            doc = dict(zip(
+                [col[0] for col in cursor.description], row, strict=False,
+            ))
+            docs.append(cast(TagSearchResultDict, doc))
 
         return docs
 

--- a/emdx/models/types.py
+++ b/emdx/models/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal, TypedDict
 
 TaskStatus = Literal['open', 'active', 'blocked', 'done', 'failed']
@@ -80,8 +81,8 @@ class TagStatsDict(TypedDict):
     id: int
     name: str
     count: int
-    created_at: str | None
-    last_used: str | None
+    created_at: datetime | None
+    last_used: datetime | None
 
 
 class TagSearchResultDict(TypedDict):

--- a/emdx/services/unified_search.py
+++ b/emdx/services/unified_search.py
@@ -321,7 +321,7 @@ class UnifiedSearchService:
                     score=0.8,  # High base score for tag matches
                     source="tags",
                     project=doc.get("project"),
-                    created_at=doc.get("created_at"),
+                    created_at=parse_datetime(doc.get("created_at")),
                 )
             )
 


### PR DESCRIPTION
## Summary

- Add `emdx/models/types.py` with TypedDict definitions for task, category, and tag structures
- Update return type annotations in `tasks.py`, `categories.py`, and `tags.py` to use TypedDicts
- Improves type safety and IDE autocomplete without changing runtime behavior

## Changes

**New file:** `emdx/models/types.py`
- `TaskDict`, `ActiveDelegateTaskDict`, `EpicTaskDict`, `EpicViewDict`
- `TaskLogEntryDict`, `GameplanStatsDict`
- `CategoryDict`, `CategoryWithStatsDict`
- `TagStatsDict`, `TagSearchResultDict`
- `TaskStatus` Literal type for strict status checking

**Updated annotations:**
- `tasks.py`: 15 functions updated to use TypedDicts
- `categories.py`: 2 functions updated
- `tags.py`: 2 functions updated

## Test plan

- [x] Run `poetry run ruff check` on changed files - passes
- [x] Run `poetry run mypy` - expected warnings from `dict(row)` patterns (not changed per spec)
- [ ] Verify existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)