### PR TITLE
chore(deps): Upgrade 6 dependencies to latest major versions (Issue #677)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 python = "^3.11"
 typer = {extras = ["all"], version = "^0.23.1"}
 click = ">=8.1.0"  # Typer 0.15+ requires click 8.1+
-rich = "^13.0.0"
-textual = "^6.2.1"
+rich = "^14.3.0"
+textual = "^7.5.0"
 psutil = "^7.0.0"
 pyyaml = ">=6.0"
 
@@ -36,7 +36,7 @@ pyyaml = ">=6.0"
 scikit-learn = {version = "^1.6.0", optional = true}
 datasketch = {version = "^1.6.0", optional = true}
 sentence-transformers = {version = "^5.2.2", optional = true}
-anthropic = {version = "^0.40.0", optional = true}
+anthropic = {version = "^0.79.0", optional = true}
 numpy = {version = "^2.4.2", optional = true}
 google-api-python-client = {version = "^2.100.0", optional = true}
 google-auth-httplib2 = {version = "^0.3.0", optional = true}
@@ -51,9 +51,9 @@ all = ["sentence-transformers", "scikit-learn", "numpy", "anthropic",
        "google-auth-oauthlib"]
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.0.0"
-pytest-cov = "^4.0.0"
-pytest-asyncio = "^0.23.8"
+pytest = "^9.0.0"
+pytest-cov = "^7.0.0"
+pytest-asyncio = "^1.3.0"
 ruff = "^0.15.0"
 mypy = "^1.0.0"
 pre-commit = "^4.5.1"
@@ -113,9 +113,10 @@ module = "emdx.utils.lazy_group"
 disable_error_code = ["valid-type", "misc", "no-any-return", "arg-type", "attr-defined"]
 
 [tool.pytest.ini_options]
-minversion = "7.0.0"
+minversion = "9.0.0"
 addopts = "-v --tb=short --strict-markers"
 testpaths = ["tests"]
+asyncio_default_fixture_loop_scope = "function"
 markers = [
     "asyncio: marks tests as async (deselect with '-m \"not asyncio\"')",
     "integration: marks tests as integration tests requiring actual emdx commands (deselect with '-m \"not integration\"')",


### PR DESCRIPTION
## Summary

- Upgrades **pytest** ^7.0.0 → ^9.0.0 (two major versions)
- Upgrades **pytest-cov** ^4.0.0 → ^7.0.0 (three major versions)
- Upgrades **pytest-asyncio** ^0.23.8 → ^1.3.0 (major rewrite)
- Upgrades **rich** ^13.0.0 → ^14.3.0 (required by textual 7.x)
- Upgrades **textual** ^6.2.1 → ^7.5.0
- Upgrades **anthropic** ^0.40.0 → ^0.79.0 (optional AI dep)

Also adds `asyncio_default_fixture_loop_scope = "function"` config required by pytest-asyncio 1.x and updates pytest minversion to 9.0.0.

All 1051 tests pass with zero code changes required.

## Test plan

- [x] `poetry run ruff check .` passes
- [x] `poetry run pytest tests/ -x -q` — 1051 passed, 8 skipped
- [ ] CI passes
- [ ] Manual TUI smoke test (`emdx gui` visual check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)