### PR TITLE
fix: Remove unused kwargs, tighten SQL param types, add ExecutionStatsDict

### DIFF
--- a/emdx/database/documents.py
+++ b/emdx/database/documents.py
@@ -153,7 +153,7 @@ def list_documents(
     with db_connection.get_connection() as conn:
         # Build query with filters
         conditions = ["is_deleted = FALSE", "archived_at IS NULL"]
-        params: list[Any] = []
+        params: list[str | int | None] = []
 
         # Parent filter
         if parent_id is None:
@@ -207,7 +207,7 @@ def count_documents(
     """
     with db_connection.get_connection() as conn:
         conditions = ["is_deleted = FALSE", "archived_at IS NULL"]
-        params: list[Any] = []
+        params: list[str | int | None] = []
 
         if parent_id is None:
             conditions.append("parent_id IS NULL")

--- a/emdx/database/groups.py
+++ b/emdx/database/groups.py
@@ -21,7 +21,6 @@ def create_group(
     project: str | None = None,
     description: str | None = None,
     created_by: str | None = None,
-    **kwargs: Any,
 ) -> int:
     """Create a new document group.
 
@@ -81,7 +80,6 @@ def list_groups(
     group_type: str | None = None,
     include_inactive: bool = False,
     top_level_only: bool = False,
-    **kwargs: Any,
 ) -> list[DocumentGroup]:
     """List groups with optional filters.
 
@@ -96,7 +94,7 @@ def list_groups(
         List of group dicts
     """
     conditions: list[str] = []
-    params: list[Any] = []
+    params: list[str | int | None] = []
 
     if not include_inactive:
         conditions.append("is_active = TRUE")

--- a/emdx/database/search.py
+++ b/emdx/database/search.py
@@ -71,7 +71,7 @@ def search_documents(
                 FROM documents d
                 WHERE d.deleted_at IS NULL
             """
-            params: list[str | int] = []
+            params: list[str | int | None] = []
         else:
             base_query = """
                 SELECT

--- a/emdx/models/executions.py
+++ b/emdx/models/executions.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from ..database.connection import db_connection
 from ..utils.datetime_utils import parse_timestamp
+from .types import ExecutionStatsDict
 
 
 @dataclass
@@ -342,7 +343,7 @@ def cleanup_old_executions(days: int = 7) -> int:
         conn.commit()
         return int(cursor.rowcount)
 
-def get_execution_stats() -> dict[str, Any]:
+def get_execution_stats() -> ExecutionStatsDict:
     """Get execution statistics."""
     with db_connection.get_connection() as conn:
         cursor = conn.cursor()

--- a/emdx/models/tags.py
+++ b/emdx/models/tags.py
@@ -1,7 +1,7 @@
 """Tag management operations for emdx."""
 
 import sqlite3
-from typing import Any, cast
+from typing import cast
 
 from emdx.database import db
 from emdx.models.types import TagSearchResultDict, TagStatsDict
@@ -291,7 +291,7 @@ def search_by_tags(
                 ",".join("?" * len(tag_names_lower))
             )
 
-            params: list[Any] = list(tag_names_lower) + [len(tag_names_lower)]
+            params: list[str | int | None] = list(tag_names_lower) + [len(tag_names_lower)]
         else:
             # Documents with ANY of the specified tags (or prefix matches)
             query = f"""

--- a/emdx/models/tasks.py
+++ b/emdx/models/tasks.py
@@ -133,7 +133,7 @@ def list_tasks(
         parent_task_id: Filter by parent task (epic) ID.
     """
     conditions: list[str] = ["1=1"]
-    params: list[Any] = []
+    params: list[str | int | None] = []
 
     if status:
         conditions.append(f"status IN ({','.join('?' * len(status))})")
@@ -259,7 +259,7 @@ def get_ready_tasks(
         epic_key: Filter by category key.
     """
     conditions = ["t.status = 'open'"]
-    params: list[Any] = []
+    params: list[str | int | None] = []
 
     if gameplan_id:
         conditions.append("t.gameplan_id = ?")

--- a/emdx/models/types.py
+++ b/emdx/models/types.py
@@ -92,3 +92,11 @@ class TagSearchResultDict(TypedDict):
     created_at: str | None
     access_count: int
     tags: str
+
+
+class ExecutionStatsDict(TypedDict):
+    total: int
+    recent_24h: int
+    running: int
+    completed: int
+    failed: int


### PR DESCRIPTION
## Summary

- Remove unused `**kwargs: Any` from `create_group()` and `list_groups()` in `emdx/database/groups.py` — these silently absorbed typos making bugs hard to detect
- Replace `params: list[Any]` with `params: list[str | int | None]` across database modules for tighter type checking of SQL parameters
- Add `ExecutionStatsDict` TypedDict to `emdx/models/types.py` and use it as return type for `get_execution_stats()`
- Remove unused `Any` import from `emdx/models/tags.py`

## Files Modified

| File | Changes |
|------|---------|
| `emdx/database/groups.py` | Remove unused `**kwargs`, tighten param types |
| `emdx/database/documents.py` | Tighten param types |
| `emdx/database/search.py` | Tighten param types |
| `emdx/models/tasks.py` | Tighten param types |
| `emdx/models/tags.py` | Tighten param types, remove unused import |
| `emdx/models/executions.py` | Add `ExecutionStatsDict` return type |
| `emdx/models/types.py` | Add `ExecutionStatsDict` TypedDict |

## Test Plan

- [x] `poetry run mypy emdx/ --no-error-summary` passes
- [x] `poetry run ruff check .` passes
- [x] `poetry run pytest tests/ -x -q` passes (1103 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)