### PR TITLE
fix(delegate): default draft=False, always clean up worktrees (Issue #594)

### DIFF
--- a/tests/test_delegate_commands.py
+++ b/tests/test_delegate_commands.py
@@ -1040,8 +1040,8 @@ class TestDelegateCommand:
 
         # Worktree should be created even though --worktree not set
         mock_create_wt.assert_called_once_with("develop")
-        # Worktree should NOT be cleaned up when --pr is set
-        mock_cleanup_wt.assert_not_called()
+        # Worktree IS cleaned up after PR (branch already pushed to remote)
+        mock_cleanup_wt.assert_called_once_with("/tmp/worktree")
 
     @patch("emdx.commands.delegate._run_parallel")
     def test_synthesize_flag_passed_to_parallel(self, mock_run_parallel):


### PR DESCRIPTION
## Summary
- Change `draft` default from `True` to `False` in `_run_single`, `_run_parallel`, and `_run_chain` to match CLI default — internal callers no longer accidentally create draft PRs
- Always clean up worktrees after execution, even with `--pr` (branch is already pushed to remote)
- Add `--cleanup` flag to remove stale delegate worktrees older than 1 hour

## Test plan
- [x] 71 delegate tests pass
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)