### PR TITLE
feat: Add emdx distill command for AI-powered document synthesis (Issue #6368)

### DIFF
--- a/emdx/commands/distill.py
+++ b/emdx/commands/distill.py
@@ -1,0 +1,297 @@
+"""
+Distill command for EMDX.
+
+Surface and synthesize the best knowledge base content for sharing.
+Supports audience-aware output: personal, documentation, or team briefings.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from ..utils.output import console
+
+app = typer.Typer(help="Distill knowledge base content into summaries")
+
+
+@app.callback(invoke_without_command=True)
+def distill(
+    ctx: typer.Context,
+    topic: str = typer.Argument(
+        None,
+        help="Topic or query to search for (e.g., 'authentication', 'API design')",
+    ),
+    tags: str | None = typer.Option(
+        None,
+        "--tags",
+        "-t",
+        help="Filter by tags (comma-separated, e.g., 'security,active')",
+    ),
+    audience: str = typer.Option(
+        "me",
+        "--for",
+        "-f",
+        help="Target audience: 'me' (personal), 'docs' (technical), 'coworkers' (team)",
+    ),
+    limit: int = typer.Option(
+        10,
+        "--limit",
+        "-n",
+        help="Maximum number of documents to include",
+    ),
+    save: bool = typer.Option(
+        False,
+        "--save",
+        "-s",
+        help="Save the synthesis to the knowledge base",
+    ),
+    save_tags: str | None = typer.Option(
+        None,
+        "--save-tags",
+        help="Tags to apply when saving (comma-separated)",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Output only the synthesis (no metadata)",
+    ),
+    model: str | None = typer.Option(
+        None,
+        "--model",
+        "-m",
+        help="Claude model to use (default: opus)",
+    ),
+) -> None:
+    """
+    Distill knowledge base content into a coherent summary.
+
+    Finds documents matching a topic or tags, then uses AI to synthesize
+    them into a well-organized summary tailored for your audience.
+
+    Examples:
+        emdx distill "authentication"
+        emdx distill --tags "security,active"
+        emdx distill "API design" --for docs
+        emdx distill "sprint progress" --for coworkers
+        emdx distill "auth" --save --save-tags "synthesis,auth"
+    """
+    # Validate inputs
+    if not topic and not tags:
+        console.print("[red]Error: Provide either a topic or --tags filter[/red]")
+        raise typer.Exit(1)
+
+    # Validate audience
+    valid_audiences = {"me", "docs", "coworkers"}
+    if audience not in valid_audiences:
+        console.print(
+            f"[red]Error: Invalid audience '{audience}'. "
+            f"Use one of: {', '.join(valid_audiences)}[/red]"
+        )
+        raise typer.Exit(1)
+
+    # Find relevant documents
+    documents = _find_documents(topic, tags, limit)
+
+    if not documents:
+        if topic:
+            console.print(f"[yellow]No documents found for topic: {topic}[/yellow]")
+        else:
+            console.print(f"[yellow]No documents found with tags: {tags}[/yellow]")
+        raise typer.Exit(1)
+
+    if not quiet:
+        console.print(f"[dim]Found {len(documents)} documents to synthesize...[/dim]")
+
+    # Perform synthesis
+    try:
+        from ..services.synthesis_service import SynthesisService
+
+        service = SynthesisService(model=model)
+
+        if not quiet:
+            with console.status("[bold blue]Synthesizing...", spinner="dots"):
+                result = service.synthesize_documents(
+                    documents=documents,
+                    audience=audience,
+                    topic=topic,
+                )
+        else:
+            result = service.synthesize_documents(
+                documents=documents,
+                audience=audience,
+                topic=topic,
+            )
+
+    except ImportError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1) from None
+
+    # Output the synthesis
+    if quiet:
+        print(result.content)
+    else:
+        console.print()
+        console.print(result.content)
+        console.print()
+        console.print(
+            f"[dim]Sources: {', '.join(f'#{id}' for id in result.source_ids)} | "
+            f"Tokens: {result.token_count:,}[/dim]"
+        )
+
+    # Save if requested
+    if save:
+        _save_synthesis(result, topic, tags, audience, save_tags, quiet)
+
+
+def _find_documents(
+    topic: str | None, tags: str | None, limit: int
+) -> list[dict[str, Any]]:
+    """
+    Find documents matching topic and/or tags.
+
+    Uses hybrid search for topic queries, tag search for tag filters.
+    """
+    from ..database import db
+    from ..models.tags import search_by_tags
+    from ..utils.emoji_aliases import expand_alias_string
+
+    db.ensure_schema()
+
+    documents: list[dict[str, Any]] = []
+    seen_ids: set[int] = set()
+
+    # Search by topic using hybrid search
+    if topic:
+        try:
+            from ..services.hybrid_search import HybridSearchService
+
+            hybrid_service = HybridSearchService()
+            results = hybrid_service.search(
+                query=topic,
+                limit=limit * 2,  # Get extra for tag filtering
+                mode=None,  # Auto-detect best mode
+            )
+
+            for r in results:
+                if r.doc_id not in seen_ids:
+                    doc = _fetch_document(r.doc_id)
+                    if doc:
+                        documents.append(doc)
+                        seen_ids.add(r.doc_id)
+        except ImportError:
+            # Fall back to keyword search if hybrid not available
+            from ..models.documents import search_documents
+
+            results = search_documents(topic, limit=limit * 2)
+            for r in results:
+                if r["id"] not in seen_ids:
+                    doc = _fetch_document(r["id"])
+                    if doc:
+                        documents.append(doc)
+                        seen_ids.add(r["id"])
+
+    # Filter by tags if specified
+    if tags:
+        expanded_tags = expand_alias_string(tags)
+        tag_list = [t.strip() for t in expanded_tags.split(",") if t.strip()]
+
+        if tag_list:
+            tag_results = search_by_tags(
+                tag_names=tag_list,
+                mode="all",
+                limit=limit * 2,
+            )
+            tag_doc_ids = {r["id"] for r in tag_results}
+
+            if topic:
+                # Filter existing documents to only those matching tags
+                documents = [d for d in documents if d["id"] in tag_doc_ids]
+            else:
+                # No topic, just use tag results
+                for r in tag_results:
+                    if r["id"] not in seen_ids:
+                        doc = _fetch_document(r["id"])
+                        if doc:
+                            documents.append(doc)
+                            seen_ids.add(r["id"])
+
+    # Apply limit
+    return documents[:limit]
+
+
+def _fetch_document(doc_id: int) -> dict[str, Any] | None:
+    """Fetch a document by ID."""
+    from ..database import db
+
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, title, content, project
+            FROM documents
+            WHERE id = ? AND is_deleted = 0
+            """,
+            (doc_id,),
+        )
+        row = cursor.fetchone()
+
+        if row:
+            return {
+                "id": row[0],
+                "title": row[1],
+                "content": row[2],
+                "project": row[3],
+            }
+        return None
+
+
+def _save_synthesis(
+    result: Any,
+    topic: str | None,
+    tags: str | None,
+    audience: str,
+    save_tags: str | None,
+    quiet: bool,
+) -> None:
+    """Save the synthesis to the knowledge base."""
+    from ..models.documents import save_document
+    from ..models.tags import add_tags_to_document
+    from ..utils.emoji_aliases import expand_alias_string
+
+    # Generate title
+    if topic:
+        title = f"Synthesis: {topic}"
+    elif tags:
+        title = f"Synthesis: {tags}"
+    else:
+        title = "Synthesis"
+
+    # Add audience suffix
+    audience_labels = {
+        "me": "",
+        "docs": " (docs)",
+        "coworkers": " (team briefing)",
+    }
+    title += audience_labels.get(audience, "")
+
+    # Build content with metadata
+    content = result.content
+    content += f"\n\n---\n\n_Sources: {', '.join(f'#{id}' for id in result.source_ids)}_"
+
+    # Save document
+    doc_id = save_document(title=title, content=content, project=None)
+
+    # Apply tags
+    tag_list = ["synthesis"]
+    if save_tags:
+        expanded = expand_alias_string(save_tags)
+        tag_list.extend(t.strip() for t in expanded.split(",") if t.strip())
+
+    add_tags_to_document(doc_id, tag_list)
+
+    if not quiet:
+        console.print(f"\n[green]✅ Saved as #{doc_id}:[/green] [cyan]{title}[/cyan]")
+        console.print(f"   [dim]Tags: {', '.join(tag_list)}[/dim]")

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -28,6 +28,7 @@ LAZY_SUBCOMMANDS = {
     "delegate": "emdx.commands.delegate:app",
     # AI features (imports ML libraries, can be slow)
     "ai": "emdx.commands.ask:app",
+    "distill": "emdx.commands.distill:app",
 }
 
 # Pre-computed help strings so --help doesn't trigger imports
@@ -36,6 +37,7 @@ LAZY_HELP = {
     "cascade": "Cascade ideas through stages to working code",
     "delegate": "One-shot AI execution (parallel, chain, worktree, PR)",
     "ai": "AI-powered Q&A and semantic search",
+    "distill": "Synthesize KB content for sharing (personal, docs, team)",
 }
 
 

--- a/emdx/services/synthesis_service.py
+++ b/emdx/services/synthesis_service.py
@@ -1,0 +1,203 @@
+"""
+Synthesis service for EMDX.
+
+Provides AI-powered document synthesis using Claude Opus API.
+Used by `emdx distill` and `emdx compact` commands.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    import anthropic
+
+    HAS_ANTHROPIC = True
+except ImportError:
+    anthropic = None  # type: ignore[assignment]
+    HAS_ANTHROPIC = False
+
+logger = logging.getLogger(__name__)
+
+
+# Default model for synthesis (Opus for quality-critical tasks)
+DEFAULT_SYNTHESIS_MODEL = "claude-opus-4-5-20251101"
+
+
+@dataclass
+class SynthesisResult:
+    """Result of a synthesis operation."""
+
+    content: str
+    source_ids: list[int]  # Document IDs that were synthesized
+    token_count: int  # Input tokens used
+    model: str
+
+
+class SynthesisService:
+    """
+    AI-powered document synthesis service.
+
+    Uses Claude Opus API to intelligently combine and synthesize
+    multiple documents into coherent summaries.
+    """
+
+    def __init__(self, model: str | None = None):
+        """
+        Initialize the synthesis service.
+
+        Args:
+            model: Claude model to use. Defaults to Opus for quality.
+        """
+        self.model = model or DEFAULT_SYNTHESIS_MODEL
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        """Lazy load Anthropic client."""
+        if not HAS_ANTHROPIC:
+            raise ImportError(
+                "anthropic is required for synthesis features. "
+                "Install it with: pip install 'emdx[ai]'"
+            )
+        if self._client is None:
+            self._client = anthropic.Anthropic()
+        return self._client
+
+    def synthesize_documents(
+        self,
+        documents: list[dict[str, Any]],
+        audience: str = "me",
+        topic: str | None = None,
+        max_tokens: int = 4000,
+    ) -> SynthesisResult:
+        """
+        Synthesize multiple documents into a coherent summary.
+
+        Args:
+            documents: List of documents with 'id', 'title', 'content' keys.
+            audience: Target audience - 'me' (personal), 'docs' (technical),
+                     or 'coworkers' (team briefing).
+            topic: Optional topic/focus for the synthesis.
+            max_tokens: Maximum tokens for the response.
+
+        Returns:
+            SynthesisResult with the synthesized content.
+        """
+        if not documents:
+            return SynthesisResult(
+                content="No documents provided for synthesis.",
+                source_ids=[],
+                token_count=0,
+                model=self.model,
+            )
+
+        # Build context from documents
+        context_parts = []
+        source_ids = []
+        for doc in documents:
+            doc_id = doc.get("id", 0)
+            title = doc.get("title", "Untitled")
+            content = doc.get("content", "")
+
+            # Truncate very long documents (keep first 6000 chars)
+            if len(content) > 6000:
+                content = content[:6000] + "\n\n[...content truncated...]"
+
+            context_parts.append(f"# Document #{doc_id}: {title}\n\n{content}")
+            source_ids.append(doc_id)
+
+        context = "\n\n---\n\n".join(context_parts)
+
+        # Build the system prompt based on audience
+        system_prompt = self._build_system_prompt(audience, topic)
+
+        # Build the user prompt
+        user_prompt = self._build_user_prompt(context, audience, topic)
+
+        try:
+            client = self._get_client()
+            response = client.messages.create(
+                model=self.model,
+                max_tokens=max_tokens,
+                system=system_prompt,
+                messages=[{"role": "user", "content": user_prompt}],
+            )
+
+            # Extract token usage
+            input_tokens = response.usage.input_tokens if response.usage else 0
+
+            return SynthesisResult(
+                content=response.content[0].text,
+                source_ids=source_ids,
+                token_count=input_tokens,
+                model=self.model,
+            )
+
+        except Exception as e:
+            if HAS_ANTHROPIC and isinstance(e, anthropic.APIError):
+                logger.error(f"Claude API error during synthesis: {e}")
+                return SynthesisResult(
+                    content=f"Error during synthesis: {e}",
+                    source_ids=source_ids,
+                    token_count=0,
+                    model=self.model,
+                )
+            raise
+
+    def _build_system_prompt(self, audience: str, topic: str | None) -> str:
+        """Build the system prompt based on audience."""
+        base_prompt = """You are an expert at synthesizing knowledge from multiple documents.
+Your task is to create a coherent, well-organized synthesis of the provided documents."""
+
+        audience_instructions = {
+            "me": """
+Target audience: Personal reference
+- Write in a direct, concise style
+- Focus on actionable insights and key takeaways
+- Include specific details and references you might need later
+- Organize by themes or concepts, not by source document
+- Use bullet points and headers for scannability""",
+            "docs": """
+Target audience: Technical documentation
+- Write in a professional, technical style
+- Focus on accuracy and completeness
+- Include code examples, configurations, or specifications where relevant
+- Use proper documentation formatting (headers, code blocks, lists)
+- Organize logically with clear sections
+- Cite document IDs for traceability""",
+            "coworkers": """
+Target audience: Team briefing
+- Write in a clear, accessible style
+- Focus on what's relevant for the team to know
+- Highlight key decisions, blockers, and action items
+- Summarize context without excessive detail
+- Use a professional but approachable tone
+- Organize with clear sections and bullet points""",
+        }
+
+        instructions = audience_instructions.get(audience, audience_instructions["me"])
+
+        topic_clause = ""
+        if topic:
+            topic_clause = f"\n\nFocus particularly on aspects related to: {topic}"
+
+        return f"{base_prompt}\n{instructions}{topic_clause}"
+
+    def _build_user_prompt(
+        self, context: str, audience: str, topic: str | None
+    ) -> str:
+        """Build the user prompt."""
+        prompt = f"""Here are the documents to synthesize:
+
+{context}
+
+---
+
+Please synthesize these documents into a single, coherent summary."""
+
+        if topic:
+            prompt += f"\n\nFocus on: {topic}"
+
+        return prompt

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -1,0 +1,200 @@
+"""Tests for the distill command and SynthesisService."""
+
+import re
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from emdx.commands.distill import app
+from emdx.services.synthesis_service import SynthesisResult, SynthesisService
+
+runner = CliRunner()
+
+
+def _out(result) -> str:
+    """Strip ANSI escape sequences from CliRunner output for assertions."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# SynthesisService tests
+# ---------------------------------------------------------------------------
+class TestSynthesisService:
+    """Tests for the SynthesisService."""
+
+    def test_init_default_model(self):
+        """Service initializes with default Opus model."""
+        service = SynthesisService()
+        assert "opus" in service.model.lower()
+
+    def test_init_custom_model(self):
+        """Service accepts custom model."""
+        service = SynthesisService(model="claude-sonnet-4-5-20250929")
+        assert "sonnet" in service.model.lower()
+
+    def test_synthesize_empty_documents(self):
+        """Synthesizing empty document list returns appropriate message."""
+        service = SynthesisService()
+        result = service.synthesize_documents(documents=[])
+
+        assert "No documents" in result.content
+        assert result.source_ids == []
+        assert result.token_count == 0
+
+    @patch("emdx.services.synthesis_service.HAS_ANTHROPIC", True)
+    def test_synthesize_documents_success(self):
+        """Successful synthesis returns result with content."""
+        # Mock the client
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text="Synthesized content here")]
+        mock_response.usage = MagicMock(input_tokens=500)
+        mock_client.messages.create.return_value = mock_response
+
+        service = SynthesisService()
+        service._client = mock_client
+
+        documents = [
+            {"id": 1, "title": "Doc 1", "content": "Content 1"},
+            {"id": 2, "title": "Doc 2", "content": "Content 2"},
+        ]
+
+        result = service.synthesize_documents(documents=documents, audience="me")
+
+        assert result.content == "Synthesized content here"
+        assert result.source_ids == [1, 2]
+        assert result.token_count == 500
+
+    def test_build_system_prompt_me(self):
+        """System prompt for 'me' audience includes personal reference style."""
+        service = SynthesisService()
+        prompt = service._build_system_prompt("me", None)
+
+        assert "Personal reference" in prompt
+        assert "concise" in prompt.lower()
+
+    def test_build_system_prompt_docs(self):
+        """System prompt for 'docs' audience includes technical style."""
+        service = SynthesisService()
+        prompt = service._build_system_prompt("docs", None)
+
+        assert "Technical documentation" in prompt
+        assert "code" in prompt.lower()
+
+    def test_build_system_prompt_coworkers(self):
+        """System prompt for 'coworkers' audience includes team briefing style."""
+        service = SynthesisService()
+        prompt = service._build_system_prompt("coworkers", None)
+
+        assert "Team briefing" in prompt
+        assert "action items" in prompt.lower()
+
+    def test_build_system_prompt_with_topic(self):
+        """System prompt includes topic focus when provided."""
+        service = SynthesisService()
+        prompt = service._build_system_prompt("me", "authentication")
+
+        assert "authentication" in prompt
+
+    def test_build_user_prompt(self):
+        """User prompt includes context and synthesis request."""
+        service = SynthesisService()
+        prompt = service._build_user_prompt("document content", "me", None)
+
+        assert "document content" in prompt
+        assert "synthesize" in prompt.lower()
+
+    def test_build_user_prompt_with_topic(self):
+        """User prompt includes topic focus when provided."""
+        service = SynthesisService()
+        prompt = service._build_user_prompt("content", "me", "security")
+
+        assert "security" in prompt
+        assert "Focus on" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Distill command tests
+# ---------------------------------------------------------------------------
+class TestDistillCommand:
+    """Tests for the distill command via CLI runner."""
+
+    @patch("emdx.commands.distill._find_documents")
+    def test_distill_no_args_shows_error(self, mock_find):
+        """Distill with no topic or tags shows error."""
+        result = runner.invoke(app, [])
+        assert result.exit_code != 0
+        out = _out(result)
+        # The error message should mention providing topic or tags
+        assert "topic" in out.lower() or "tags" in out.lower() or "error" in out.lower()
+
+    @patch("emdx.commands.distill._find_documents")
+    def test_distill_no_documents_found(self, mock_find):
+        """Distill with no matching documents shows message."""
+        mock_find.return_value = []
+
+        result = runner.invoke(app, ["nonexistent"])
+        assert result.exit_code != 0
+        assert "No documents found" in _out(result)
+
+    @patch("emdx.services.synthesis_service.SynthesisService.synthesize_documents")
+    @patch("emdx.commands.distill._find_documents")
+    def test_distill_success(self, mock_find, mock_synthesize):
+        """Successful distill outputs synthesis."""
+        mock_find.return_value = [
+            {"id": 1, "title": "Doc 1", "content": "Content 1"},
+            {"id": 2, "title": "Doc 2", "content": "Content 2"},
+        ]
+
+        mock_synthesize.return_value = SynthesisResult(
+            content="This is the synthesized content.",
+            source_ids=[1, 2],
+            token_count=500,
+            model="claude-opus-4-5-20251101",
+        )
+
+        result = runner.invoke(app, ["test topic"])
+        assert result.exit_code == 0
+        out = _out(result)
+        assert "synthesized content" in out.lower()
+
+    @patch("emdx.commands.distill._find_documents")
+    def test_distill_with_tags_only(self, mock_find):
+        """Distill with --tags only (no topic) works."""
+        mock_find.return_value = [{"id": 1, "title": "Doc", "content": "Test"}]
+
+        with patch(
+            "emdx.services.synthesis_service.SynthesisService.synthesize_documents"
+        ) as mock_synth:
+            mock_synth.return_value = SynthesisResult(
+                content="Tag-based synthesis.",
+                source_ids=[1],
+                token_count=100,
+                model="claude-opus-4-5-20251101",
+            )
+
+            result = runner.invoke(app, ["--tags", "security,active"])
+            assert result.exit_code == 0
+            out = _out(result)
+            assert "Tag-based synthesis" in out
+
+
+# ---------------------------------------------------------------------------
+# SynthesisResult dataclass tests
+# ---------------------------------------------------------------------------
+class TestSynthesisResult:
+    """Tests for the SynthesisResult dataclass."""
+
+    def test_synthesis_result_creation(self):
+        """SynthesisResult can be created with all fields."""
+        result = SynthesisResult(
+            content="Test content",
+            source_ids=[1, 2, 3],
+            token_count=100,
+            model="claude-opus-4-5-20251101",
+        )
+
+        assert result.content == "Test content"
+        assert result.source_ids == [1, 2, 3]
+        assert result.token_count == 100
+        assert result.model == "claude-opus-4-5-20251101"


### PR DESCRIPTION
## Summary

Implements the `emdx distill` command as specified in gameplan #6368. This command surfaces and synthesizes knowledge base content for sharing, with audience-aware output for personal, documentation, or team use.

- **SynthesisService** - Shared synthesis logic using Claude Opus API
- **distill command** - CLI implementation with topic/tag search and audience targeting
- **15 unit tests** covering service and command behavior

## Features

- Search documents by topic query or tag filters
- Audience-aware synthesis: `--for me` (personal), `--for docs` (technical), `--for coworkers` (team briefing)
- Quiet mode (`-q`) for piping output
- Optional save to KB with `--save` and auto-tagging

## Usage

```bash
# Search by topic
emdx distill "authentication"

# Search by tags  
emdx distill --tags "security,active"

# For documentation audience
emdx distill "API design" --for docs

# For team briefing
emdx distill "sprint progress" --for coworkers

# Save synthesis to KB
emdx distill "auth" --save --save-tags "summary,auth"
```

## Test plan

- [x] Unit tests pass (`poetry run pytest tests/test_distill.py`)
- [x] Ruff linting passes
- [x] Full test suite passes (1113 passed)
- [ ] Manual testing with real KB documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)