### PR TITLE
fix(delegate): File-based output fallback for reliable doc saving (Issue #617)

### DIFF
--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -29,10 +29,12 @@ Dynamic discovery:
     emdx delegate --each "fd -e py src/" --do "Review {{item}}"
 """
 
+import os
 import re
 import shlex
 import subprocess
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
@@ -129,6 +131,62 @@ def _extract_pr_url(text: str | None) -> str | None:
         return None
     match = _PR_URL_RE.search(text)
     return match.group(0) if match else None
+
+
+def _make_output_file_id(working_dir: str | None, seq: int | None) -> str:
+    """Generate a traceable ID for the agent's output file.
+
+    Uses the worktree basename when available (so the file can be traced
+    back to its worktree), otherwise falls back to pid-seq-timestamp.
+    """
+    if working_dir:
+        basename = Path(working_dir).name
+        if "emdx-worktree-" in basename:
+            return basename
+    return f"{os.getpid()}-{seq or 0}-{int(time.time())}"
+
+
+def _make_output_file_path(file_id: str) -> Path:
+    """Build the /tmp path for a delegate output file."""
+    return Path(f"/tmp/emdx-delegate-{file_id}.md")
+
+
+def _save_output_fallback(
+    output_file: Path,
+    output_content: str | None,
+    title: str,
+    tags: list[str],
+) -> int | None:
+    """Try to save agent output via fallback methods.
+
+    Priority:
+    1. Read the output file the agent was asked to write
+    2. Save captured stdout/result content
+    Returns doc_id or None.
+    """
+    content = None
+
+    # Fallback 1: agent wrote the file
+    if output_file.exists() and output_file.stat().st_size > 0:
+        try:
+            content = output_file.read_text(encoding="utf-8")
+        except Exception as e:
+            sys.stderr.write(f"delegate: failed to read {output_file}: {e}\n")
+
+    # Fallback 2: captured output from executor
+    if not content and output_content and output_content.strip():
+        content = output_content
+
+    if not content:
+        return None
+
+    try:
+        doc_id: int = save_document(title=title, content=content, tags=tags)
+        return doc_id
+    except Exception as e:
+        sys.stderr.write(f"delegate: fallback save failed: {e}\n")
+        return None
+
 
 def _slugify_title(title: str) -> str:
     """Convert a document title to a git branch slug.
@@ -337,17 +395,17 @@ def _run_single(
     if "needs-review" not in all_tags:
         all_tags.append("needs-review")
 
-    cmd_parts = [f'emdx save --title "{doc_title}"']
-    cmd_parts.append(f'--tags "{",".join(all_tags)}"')
-    save_cmd = " ".join(cmd_parts)
+    # Generate a traceable output file path for the agent
+    file_id = _make_output_file_id(working_dir, seq)
+    output_file = _make_output_file_path(file_id)
+    tags_str = ",".join(all_tags)
 
     output_instruction = (
-        "\n\nIMPORTANT — SAVE YOUR OUTPUT: When done, pipe your complete "
-        "findings to emdx. Example:\n"
-        f"cat <<'RESULT' | {save_cmd}\n"
-        "Your full analysis/output here as markdown\n"
-        "RESULT\n"
-        "Report the document ID shown after saving."
+        "\n\nIMPORTANT — SAVE YOUR OUTPUT:\n"
+        f"1. Write your complete findings/analysis to: {output_file}\n"
+        f'2. Save it: emdx save {output_file} --title "{doc_title}" '
+        f'--tags "{tags_str}"\n'
+        "3. Report the document ID shown after saving."
     )
 
     if pr:
@@ -376,11 +434,21 @@ def _run_single(
     pr_url = _extract_pr_url(result.output_content)
 
     doc_id = result.output_doc_id
+
+    # Fallback: if agent didn't save, try output file then captured output
+    if not doc_id:
+        doc_id = _save_output_fallback(
+            output_file, result.output_content, doc_title, all_tags,
+        )
+        if doc_id:
+            sys.stderr.write(
+                f"delegate: auto-saved from fallback → #{doc_id}\n"
+            )
+
     if doc_id:
         _safe_update_task(task_id, status="done", output_doc_id=doc_id)
-        # Write doc_id back to execution so activity browser can show the output
         _safe_update_execution(result.execution_id, doc_id=doc_id)
-        # Also try to extract PR URL from saved doc content
+        # Try to extract PR URL from saved doc content
         if not pr_url:
             doc = get_document(doc_id)
             if doc:
@@ -389,46 +457,19 @@ def _run_single(
         if not quiet:
             pr_info = f" pr:{pr_url}" if pr_url else ""
             sys.stderr.write(
-                f"task_id:{task_id} doc_id:{doc_id} tokens:{result.tokens_used} "
+                f"task_id:{task_id} doc_id:{doc_id} "
+                f"tokens:{result.tokens_used} "
                 f"cost:${result.cost_usd:.4f} "
-                f"duration:{result.execution_time_ms / 1000:.1f}s{pr_info}\n"
+                f"duration:{result.execution_time_ms / 1000:.1f}s"
+                f"{pr_info}\n"
             )
     else:
-        # Agent didn't save — auto-save the output content
-        if result.output_content and result.output_content.strip():
-            try:
-                doc_id = save_document(
-                    title=doc_title,
-                    content=result.output_content,
-                    tags=all_tags,
-                )
-                _safe_update_task(
-                    task_id, status="done", output_doc_id=doc_id,
-                )
-                _safe_update_execution(result.execution_id, doc_id=doc_id)
-                _print_doc_content(doc_id)
-                if not quiet:
-                    pr_info = f" pr:{pr_url}" if pr_url else ""
-                    sys.stderr.write(
-                        f"task_id:{task_id} doc_id:{doc_id} "
-                        f"tokens:{result.tokens_used} "
-                        f"cost:${result.cost_usd:.4f} "
-                        f"duration:{result.execution_time_ms / 1000:.1f}s"
-                        f"{pr_info} (auto-saved)\n"
-                    )
-            except Exception as e:
-                _safe_update_task(task_id, status="done")
-                sys.stdout.write(result.output_content)
-                sys.stdout.write("\n")
-                sys.stderr.write(
-                    f"delegate: auto-save failed ({e}), "
-                    "output printed to stdout\n"
-                )
-        else:
-            _safe_update_task(task_id, status="done")
-            sys.stderr.write(
-                "delegate: agent completed with no output\n"
-            )
+        _safe_update_task(task_id, status="done")
+        # Last resort: print whatever we have to stdout
+        if result.output_content:
+            sys.stdout.write(result.output_content)
+            sys.stdout.write("\n")
+        sys.stderr.write("delegate: agent completed with no output\n")
 
     return SingleResult(doc_id=doc_id, task_id=task_id, pr_url=pr_url)
 

--- a/tests/test_delegate_commands.py
+++ b/tests/test_delegate_commands.py
@@ -23,12 +23,15 @@ from emdx.commands.delegate import (
     SingleResult,
     _extract_pr_url,
     _load_doc_context,
+    _make_output_file_id,
+    _make_output_file_path,
     _make_pr_instruction,
     _resolve_task,
     _run_chain,
     _run_discovery,
     _run_parallel,
     _run_single,
+    _save_output_fallback,
     _slugify_title,
     delegate,
 )
@@ -1392,3 +1395,248 @@ class TestErrorHandling:
                 each=None,
                 do=None,
             )
+
+
+# =============================================================================
+# Tests for output file helpers (kink 1 — file-based output fallback)
+# =============================================================================
+
+
+class TestOutputFileId:
+    """Tests for _make_output_file_id — generates traceable IDs for output files."""
+
+    def test_uses_worktree_basename(self):
+        """When working_dir is a worktree path, extract its basename."""
+        result = _make_output_file_id(
+            "/Users/alex/dev/worktrees/emdx-worktree-123-456-789", seq=1
+        )
+        assert result == "emdx-worktree-123-456-789"
+
+    def test_falls_back_to_pid_seq_timestamp(self):
+        """When working_dir is not a worktree path, use pid-seq-timestamp."""
+        result = _make_output_file_id("/some/regular/path", seq=5)
+        parts = result.split("-")
+        assert len(parts) == 3
+        # First part is PID (int), second is seq, third is timestamp
+        assert parts[1] == "5"
+
+    def test_none_working_dir(self):
+        """When working_dir is None, use pid-seq-timestamp."""
+        result = _make_output_file_id(None, seq=0)
+        parts = result.split("-")
+        assert len(parts) == 3
+        assert parts[1] == "0"
+
+
+class TestMakeOutputFilePath:
+    """Tests for _make_output_file_path — builds /tmp path for output file."""
+
+    def test_path_in_tmp(self):
+        path = _make_output_file_path("emdx-worktree-123-456-789")
+        assert str(path).startswith("/tmp/")
+        assert "emdx-delegate-" in str(path)
+
+    def test_md_extension(self):
+        path = _make_output_file_path("test-id")
+        assert str(path).endswith(".md")
+
+    def test_contains_file_id(self):
+        path = _make_output_file_path("my-unique-id")
+        assert "my-unique-id" in str(path)
+
+
+class TestSaveOutputFallback:
+    """Tests for _save_output_fallback — three-tier fallback save."""
+
+    @patch("emdx.commands.delegate.save_document")
+    def test_prefers_file_over_content(self, mock_save, tmp_path):
+        """File content takes priority over output_content."""
+        output_file = tmp_path / "output.md"
+        output_file.write_text("file content")
+        mock_save.return_value = 42
+
+        doc_id = _save_output_fallback(
+            output_file=output_file,
+            output_content="captured content",
+            title="Test",
+            tags=["test"],
+        )
+
+        assert doc_id == 42
+        mock_save.assert_called_once()
+        call_kwargs = mock_save.call_args[1]
+        assert call_kwargs["content"] == "file content"
+
+    @patch("emdx.commands.delegate.save_document")
+    def test_falls_back_to_content(self, mock_save, tmp_path):
+        """When file doesn't exist, falls back to output_content."""
+        output_file = tmp_path / "nonexistent.md"
+        mock_save.return_value = 43
+
+        doc_id = _save_output_fallback(
+            output_file=output_file,
+            output_content="captured content",
+            title="Test",
+            tags=["test"],
+        )
+
+        assert doc_id == 43
+        call_kwargs = mock_save.call_args[1]
+        assert call_kwargs["content"] == "captured content"
+
+    def test_returns_none_when_nothing_available(self, tmp_path):
+        """When no file and no content, returns None without saving."""
+        output_file = tmp_path / "nonexistent.md"
+
+        doc_id = _save_output_fallback(
+            output_file=output_file,
+            output_content=None,
+            title="Test",
+            tags=["test"],
+        )
+
+        assert doc_id is None
+
+    def test_returns_none_for_empty_content(self, tmp_path):
+        """Whitespace-only content is treated as empty."""
+        output_file = tmp_path / "nonexistent.md"
+
+        doc_id = _save_output_fallback(
+            output_file=output_file,
+            output_content="   \n  ",
+            title="Test",
+            tags=["test"],
+        )
+
+        assert doc_id is None
+
+    @patch("emdx.commands.delegate.save_document")
+    def test_skips_empty_file(self, mock_save, tmp_path):
+        """Empty file is skipped, falls back to content."""
+        output_file = tmp_path / "empty.md"
+        output_file.write_text("")
+        mock_save.return_value = 44
+
+        doc_id = _save_output_fallback(
+            output_file=output_file,
+            output_content="fallback content",
+            title="Test",
+            tags=["test"],
+        )
+
+        assert doc_id == 44
+        call_kwargs = mock_save.call_args[1]
+        assert call_kwargs["content"] == "fallback content"
+
+    @patch("emdx.commands.delegate.save_document")
+    def test_handles_save_failure(self, mock_save, tmp_path):
+        """When save_document raises, returns None gracefully."""
+        output_file = tmp_path / "output.md"
+        output_file.write_text("good content")
+        mock_save.side_effect = Exception("DB error")
+
+        doc_id = _save_output_fallback(
+            output_file=output_file,
+            output_content=None,
+            title="Test",
+            tags=["test"],
+        )
+
+        assert doc_id is None
+
+
+class TestRunSingleFallback:
+    """Tests for _run_single fallback integration."""
+
+    @patch("emdx.commands.delegate._save_output_fallback")
+    @patch("emdx.commands.delegate._print_doc_content")
+    @patch("emdx.commands.delegate._safe_update_task")
+    @patch("emdx.commands.delegate._safe_create_task")
+    @patch("emdx.commands.delegate.UnifiedExecutor")
+    def test_fallback_called_when_no_doc_id(
+        self, mock_executor_cls, mock_create, mock_update,
+        mock_print, mock_fallback
+    ):
+        """When executor returns no doc_id, fallback is attempted."""
+        mock_create.return_value = 1
+        mock_executor = MagicMock()
+        mock_executor.execute.return_value = ExecutionResult(
+            success=True,
+            execution_id=100,
+            log_file=Path("/tmp/test.log"),
+            output_doc_id=None,
+            output_content="some captured output",
+        )
+        mock_executor_cls.return_value = mock_executor
+        mock_fallback.return_value = 99
+
+        result = _run_single(
+            prompt="test task",
+            tags=[],
+            title=None,
+            model=None,
+            quiet=False,
+        )
+
+        mock_fallback.assert_called_once()
+        assert result.doc_id == 99
+
+    @patch("emdx.commands.delegate._save_output_fallback")
+    @patch("emdx.commands.delegate._print_doc_content")
+    @patch("emdx.commands.delegate._safe_update_task")
+    @patch("emdx.commands.delegate._safe_create_task")
+    @patch("emdx.commands.delegate.UnifiedExecutor")
+    def test_fallback_not_called_when_doc_id_present(
+        self, mock_executor_cls, mock_create, mock_update,
+        mock_print, mock_fallback
+    ):
+        """When executor returns a doc_id, fallback is NOT called."""
+        mock_create.return_value = 1
+        mock_executor = MagicMock()
+        mock_executor.execute.return_value = ExecutionResult(
+            success=True,
+            execution_id=100,
+            log_file=Path("/tmp/test.log"),
+            output_doc_id=42,
+        )
+        mock_executor_cls.return_value = mock_executor
+
+        result = _run_single(
+            prompt="test task",
+            tags=[],
+            title=None,
+            model=None,
+            quiet=False,
+        )
+
+        mock_fallback.assert_not_called()
+        assert result.doc_id == 42
+
+    @patch("emdx.commands.delegate._save_output_fallback")
+    @patch("emdx.commands.delegate._safe_update_task")
+    @patch("emdx.commands.delegate._safe_create_task")
+    @patch("emdx.commands.delegate.UnifiedExecutor")
+    def test_fallback_returns_none_still_fails(
+        self, mock_executor_cls, mock_create, mock_update, mock_fallback
+    ):
+        """When fallback also returns None, doc_id stays None."""
+        mock_create.return_value = 1
+        mock_executor = MagicMock()
+        mock_executor.execute.return_value = ExecutionResult(
+            success=True,
+            execution_id=100,
+            log_file=Path("/tmp/test.log"),
+            output_doc_id=None,
+        )
+        mock_executor_cls.return_value = mock_executor
+        mock_fallback.return_value = None
+
+        result = _run_single(
+            prompt="test task",
+            tags=[],
+            title=None,
+            model=None,
+            quiet=False,
+        )
+
+        assert result.doc_id is None


### PR DESCRIPTION
## Summary

Replaces the fragile `echo | emdx save` piping instruction with a file-based approach that dramatically improves delegate output reliability.

**The problem (Kink 1):** Agents were instructed to pipe output via `cat <<'RESULT' | emdx save ...`, which frequently failed silently — agents would complete work (even create PRs) but save nothing to the knowledge base.

**The fix:**
- Agent is now instructed to **write output to a file** (`/tmp/emdx-delegate-{id}.md`) then run `emdx save <file>`
- Three-tier fallback when agent doesn't save: **output file → captured executor content → None**
- File IDs are traceable: derived from worktree basename (e.g., `emdx-worktree-123-456-789`) or `pid-seq-timestamp`
- Simplifies the post-execution save logic from ~40 lines of nested try/except to a clean function call

**New functions:**
- `_make_output_file_id()` — generates traceable ID from worktree or pid
- `_make_output_file_path()` — builds `/tmp/emdx-delegate-{id}.md` path
- `_save_output_fallback()` — three-tier fallback save logic

## Test plan

- [x] 86 delegate tests pass (15 new tests for fallback behavior)
- [x] 1177 total tests pass, 0 failures
- [x] Ruff lint clean
- [ ] Manual: `emdx delegate "analyze something"` → verify doc saved via file fallback
- [ ] Manual: `emdx delegate --pr "fix something"` → verify PR created and doc saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)