### PR TITLE
fix(delegate): Default draft=False and always clean up worktrees (Issue #617)

### DIFF
--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -308,7 +308,7 @@ def _run_single(
     quiet: bool,
     pr: bool = False,
     pr_branch: str | None = None,
-    draft: bool = True,
+    draft: bool = False,
     working_dir: str | None = None,
     source_doc_id: int | None = None,
     parent_task_id: int | None = None,
@@ -459,7 +459,7 @@ def _run_parallel(
     model: str | None,
     quiet: bool,
     pr: bool = False,
-    draft: bool = True,
+    draft: bool = False,
     base_branch: str = "main",
     source_doc_id: int | None = None,
     worktree: bool = False,
@@ -529,8 +529,8 @@ def _run_parallel(
                 epic_key=epic_key,
             )
         finally:
-            # Clean up worktree unless --pr (keep for the PR branch)
-            if task_worktree_path and not pr:
+            # Always clean up worktree — branch is pushed to remote for PRs
+            if task_worktree_path:
                 from ..utils.git import cleanup_worktree
                 cleanup_worktree(task_worktree_path)
 
@@ -628,7 +628,7 @@ def _run_chain(
     model: str | None,
     quiet: bool,
     pr: bool = False,
-    draft: bool = True,
+    draft: bool = False,
     working_dir: str | None = None,
     source_doc_id: int | None = None,
     epic_key: str | None = None,
@@ -982,7 +982,7 @@ def delegate(
                 epic_parent_id=epic_parent_id,
             )
     finally:
-        if worktree_path and not pr:
+        if worktree_path:
             from ..utils.git import cleanup_worktree
             if not quiet:
                 sys.stderr.write(f"delegate: cleaning up worktree {worktree_path}\n")

--- a/tests/test_delegate_commands.py
+++ b/tests/test_delegate_commands.py
@@ -1040,8 +1040,8 @@ class TestDelegateCommand:
 
         # Worktree should be created even though --worktree not set
         mock_create_wt.assert_called_once_with("develop")
-        # Worktree should NOT be cleaned up when --pr is set
-        mock_cleanup_wt.assert_not_called()
+        # Worktree IS cleaned up — branch is pushed to remote for PRs
+        mock_cleanup_wt.assert_called_once_with("/tmp/worktree")
 
     @patch("emdx.commands.delegate._run_parallel")
     def test_synthesize_flag_passed_to_parallel(self, mock_run_parallel):


### PR DESCRIPTION
## Summary

Two small fixes for delegate reliability:

- **Kink 2 — Always clean up worktrees:** Removes the `and not pr` guard from worktree cleanup. Since branches are pushed to remote before PR creation, the local worktree is no longer needed and was just accumulating on disk.
- **Kink 3 — Draft default mismatch:** Changes `draft: bool = True` → `False` in `_run_single`, `_run_parallel`, `_run_chain`. The CLI already defaulted to `False`, but the internal functions defaulted to `True`, causing PRs to silently be created as drafts.

## Test plan

- [x] 71 delegate tests pass (updated `test_pr_implies_worktree` assertion)
- [x] Ruff lint clean
- [ ] Manual: `emdx delegate --pr "task"` → verify PR is NOT a draft
- [ ] Manual: `emdx delegate --pr --draft "task"` → verify PR IS a draft
- [ ] Manual: verify worktree is cleaned up after `--pr` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)