### PR TITLE
docs: Add pre-commit hooks note to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ poetry run pytest tests/ -x -q  # Run tests
 
 ## Code Quality — MANDATORY
 
+**Pre-commit hooks are active** (ruff lint, ruff format, mypy on staged files). They run automatically on `git commit`. Config: `.pre-commit-config.yaml`. To run manually: `poetry run pre-commit run --files <files>`.
+
 **Before every commit, run lint and fix errors:**
 
 ```bash


### PR DESCRIPTION
## Summary
- Documents that pre-commit hooks (ruff lint, ruff format, mypy) are active in the project
- Adds note about `.pre-commit-config.yaml` and how to run hooks manually

## Context
Pre-commit hooks were added in #626. This updates CLAUDE.md to document their existence.

## Test plan
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)