### PR TITLE
fix(delegate): add --cleanup flag, always clean up worktrees (Issue #594)

### DIFF
--- a/tests/test_delegate_commands.py
+++ b/tests/test_delegate_commands.py
@@ -1043,7 +1043,7 @@ class TestDelegateCommand:
 
         # Worktree should be created even though --worktree not set
         mock_create_wt.assert_called_once_with("develop")
-        # Worktree IS cleaned up — branch is pushed to remote for PRs
+        # Worktree IS cleaned up after PR (branch already pushed to remote)
         mock_cleanup_wt.assert_called_once_with("/tmp/worktree")
 
     @patch("emdx.commands.delegate._run_parallel")


### PR DESCRIPTION
## Summary
- Add `_cleanup_stale_worktrees()` function and `--cleanup` flag to remove delegate worktrees older than 1 hour
- Always clean up worktrees after execution (even with `--pr`, since branch is already pushed)
- Update known_flags list to include `--cleanup`

Re-creation of #617 with clean base from current main.

## Test plan
- [x] All 71 delegate tests pass
- [x] ruff clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>