### PR TITLE
feat(delegate): Unified branch naming and PR validation (kinks 5+6)

### DIFF
--- a/emdx/utils/git.py
+++ b/emdx/utils/git.py
@@ -2,9 +2,11 @@
 Git utility functions for emdx
 """
 
+import hashlib
 import logging
 import os
 import random
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -12,34 +14,142 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-def create_worktree(base_branch: str = "main") -> tuple[str, str]:
+def slugify_for_branch(text: str, max_length: int = 40) -> str:
+    """Convert text to a git branch-safe slug.
+
+    Examples:
+        "Gameplan #1: Contextual Save" -> "contextual-save"
+        "Smart Priming (context-aware)" -> "smart-priming-context-aware"
+        "Fix the auth bug in login.py" -> "fix-the-auth-bug-in-loginpy"
+    """
+    slug = re.sub(
+        r"^(?:gameplan|feature|plan|doc(?:ument)?|kink\s*\d*[:\s—-]*)\s*#?\d*[:\s—-]*",
+        "",
+        text,
+        flags=re.IGNORECASE,
+    ).strip()
+    slug = re.sub(r"[^a-zA-Z0-9\s-]", "", slug)
+    slug = re.sub(r"\s+", "-", slug).strip("-").lower()
+    return slug[:max_length].rstrip("-") or "task"
+
+
+def generate_delegate_branch_name(task_title: str) -> str:
+    """Generate a consistent delegate branch name.
+
+    Pattern: delegate/{slug}-{short-hash}
+
+    The 5-char hash (title + timestamp) prevents collisions for similar titles.
+    """
+    slug = slugify_for_branch(task_title)
+    hash_input = f"{task_title}-{time.time()}"
+    short_hash = hashlib.sha1(hash_input.encode()).hexdigest()[:5]  # noqa: S324
+    return f"delegate/{slug}-{short_hash}"
+
+
+def validate_pr_preconditions(
+    working_dir: str | None = None,
+    base_branch: str = "main",
+) -> dict:
+    """Check whether a branch is ready for PR creation.
+
+    Returns dict with keys: has_commits, commit_count, is_pushed,
+    branch_name, files_changed, error.
+    """
+    cwd_kwargs: dict = {"cwd": working_dir} if working_dir else {}
+    try:
+        branch_result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            **cwd_kwargs,
+        )
+        branch_name = branch_result.stdout.strip()
+
+        log_result = subprocess.run(
+            ["git", "log", f"{base_branch}..HEAD", "--oneline"],
+            capture_output=True,
+            text=True,
+            **cwd_kwargs,
+        )
+        commits = [ln for ln in log_result.stdout.strip().splitlines() if ln]
+
+        remote_result = subprocess.run(
+            ["git", "ls-remote", "--heads", "origin", branch_name],
+            capture_output=True,
+            text=True,
+            **cwd_kwargs,
+        )
+        is_pushed = branch_name in remote_result.stdout
+
+        diff_result = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_branch}..HEAD"],
+            capture_output=True,
+            text=True,
+            **cwd_kwargs,
+        )
+        files = [ln for ln in diff_result.stdout.strip().splitlines() if ln]
+
+        return {
+            "has_commits": len(commits) > 0,
+            "commit_count": len(commits),
+            "is_pushed": is_pushed,
+            "branch_name": branch_name,
+            "files_changed": len(files),
+            "error": None,
+        }
+    except Exception as e:
+        return {
+            "has_commits": False,
+            "commit_count": 0,
+            "is_pushed": False,
+            "branch_name": None,
+            "files_changed": 0,
+            "error": str(e),
+        }
+
+
+def create_worktree(
+    base_branch: str = "main",
+    task_title: str | None = None,
+) -> tuple[str, str]:
     """Create a unique git worktree for isolated execution.
 
     Args:
         base_branch: Branch to base the worktree on
+        task_title: Optional title for meaningful branch naming.
+                    Uses delegate/{slug}-{hash} when provided.
 
     Returns:
         Tuple of (worktree_path, branch_name)
     """
-    # Get the repo root
     result = subprocess.run(
         ["git", "rev-parse", "--show-toplevel"],
-        capture_output=True, text=True, check=True
+        capture_output=True,
+        text=True,
+        check=True,
     )
     repo_root = result.stdout.strip()
 
-    # Create unique branch and worktree names with timestamp + random + pid
+    if task_title:
+        branch_name = generate_delegate_branch_name(task_title)
+    else:
+        timestamp = int(time.time())
+        random_suffix = random.randint(1000, 9999)
+        pid = os.getpid()
+        branch_name = f"worktree-{timestamp}-{pid}-{random_suffix}"
+
     timestamp = int(time.time())
     random_suffix = random.randint(1000, 9999)
     pid = os.getpid()
     unique_id = f"{timestamp}-{pid}-{random_suffix}"
-    branch_name = f"worktree-{unique_id}"
     worktree_dir = Path(repo_root).parent / f"emdx-worktree-{unique_id}"
 
-    # Create the worktree
     subprocess.run(
         ["git", "worktree", "add", "-b", branch_name, str(worktree_dir), base_branch],
-        capture_output=True, text=True, check=True
+        capture_output=True,
+        text=True,
+        check=True,
     )
 
     return str(worktree_dir), branch_name
@@ -53,8 +163,7 @@ def cleanup_worktree(worktree_path: str) -> None:
     """
     try:
         subprocess.run(
-            ["git", "worktree", "remove", worktree_path, "--force"],
-            capture_output=True, text=True
+            ["git", "worktree", "remove", worktree_path, "--force"], capture_output=True, text=True
         )
     except Exception as e:
         logger.warning("Could not clean up worktree %s: %s", worktree_path, e)


### PR DESCRIPTION
## Summary

- **Kink 5**: All delegate-created branches now follow `delegate/{slug}-{hash}` pattern instead of inconsistent `feat/`, `fix/`, `worktree-` prefixes
- **Kink 6**: PR validation checks for commits, pushed branch, and file changes before `gh pr create` — warns on stderr

## Changes

### `emdx/utils/git.py`
- Added `slugify_for_branch()` — extracts and cleans text into branch-safe slugs
- Added `generate_delegate_branch_name()` — produces `delegate/{slug}-{5char-hash}`
- Added `validate_pr_preconditions()` — checks commits, push status, file changes
- Updated `create_worktree()` — accepts optional `task_title` for meaningful branch names

### `emdx/commands/delegate.py`
- Removed `_slugify_title()` (replaced by `slugify_for_branch` in utils)
- Added `_validate_pr_and_warn()` — logs warnings before PR creation
- Updated `_resolve_task()`, `_run_parallel()`, and `delegate()` to use unified naming
- Single-task worktree now passes `pr_branch` to `_run_single`

### `tests/test_delegate_commands.py`
- Updated `TestSlugifyTitle` → `TestSlugifyForBranch` with new import
- Added `TestGenerateDelegateBranchName` with pattern, hash, and uniqueness tests
- Updated worktree creation assertions to include `task_title` kwarg

## Test plan

- [x] All 1230 tests pass, lint clean
- [x] 97 delegate-specific tests pass
- [ ] Manual: `emdx delegate --pr "fix something"` creates `delegate/fix-something-{hash}` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)