### PR TITLE
chore: Add session knowledge — gotchas, merge-chain command, versioned memory

### DIFF
--- a/.claude/MEMORY.md
+++ b/.claude/MEMORY.md
@@ -1,0 +1,46 @@
+# EMDX Project Memory
+
+## Architecture Notes
+- TUI screens: 1=Activity, 2=Tasks, 3=Search, 4=Cascade (reordered Feb 2026)
+- Document browser removed; replaced by TaskBrowser (`task_browser.py` + `task_view.py`)
+- Activity view uses `Tree[ActivityItem]` widget (migrated from DataTable in Feb 2026)
+- `activity_tree.py` is the ActivityTree widget, `activity_view.py` is the main view
+- `cascade_browser.py` has its own separate `ActivityFeed` with `#activity-table` — independent
+- No tests exist for the activity module (all tests are for DB, CLI, workflows, etc.)
+
+## Key Patterns
+- `_get_selected_item()` returns the currently selected ActivityItem via `tree.cursor_node.data`
+- `refresh_from_items()` does diff-based updates using `set_label()` — never disrupts scroll
+- `populate_from_items()` is for initial full load (clears tree first)
+- Tree expansion loads children lazily via `item.load_children(wf_db, doc_db)`
+
+## Delegate System
+- Branch naming: `delegate/{slug}-{5char-hash}` via `generate_delegate_branch_name()` in `utils/git.py`
+- `slugify_for_branch()` strips common prefixes (Gameplan, Feature, Plan, Kink, etc.)
+- PR validation: `validate_pr_preconditions()` checks commits, push status, file changes before `gh pr create`
+- Streaming: `_reader_thread()` in `unified_executor.py` uses background threads + `queue.Queue` (not `select.select()`)
+
+## Development
+- Tests: `poetry run pytest tests/ -x -q` (1230+ tests, ~12s)
+- No `--timeout` flag available for pytest in this project
+- Always use `poetry run` for commands in the emdx project directory
+- Python requirement relaxed from ^3.13 to ^3.11
+- Pre-commit hooks active: ruff lint, ruff format, mypy (staged files only)
+- mypy has pre-existing errors in test files (missing type annotations); use `SKIP=mypy` if blocking
+
+## Textual Gotchas
+- `Separator` does NOT exist in `textual.widgets.option_list` in our Textual version. Use `Option("", disabled=True)` as a visual spacer instead.
+
+## emdx delegate — Known Issues & Usage Notes
+- **Don't use delegate for stateful git operations** (rebase, push, commit). Delegates start fresh sessions without checkout state. Only use for read-only research/analysis.
+- **`--synthesize` error**: One of 3 tasks reported "agent completed but no document was saved" before synthesis succeeded. Possible bug when using `--synthesize` with multiple tasks.
+- **All `--flags` must come BEFORE positional arguments** in `emdx delegate` calls.
+- **Appropriate use cases**: code review, PR evaluation, research, analysis. NOT: rebasing, committing, pushing.
+- **`select.select()` broken on macOS**: Root cause of 0-byte delegate logs and hung agents. Fixed with threaded reader approach.
+
+## Optional Dependencies (Split in Feb 2026)
+- Heavy deps (sklearn, datasketch, anthropic, numpy, sentence-transformers, google-*) are optional extras
+- Core install: `pip install emdx` or `poetry install` (lightweight, no ML/AI)
+- Extras: `[ai]`, `[similarity]`, `[google]`, `[all]`
+- Import guards: try/except + `from __future__ import annotations` + `_require_*()` helpers
+- `analyze`/`maintain` commands eagerly imported but deps guarded at method level

--- a/.claude/commands/merge-chain.md
+++ b/.claude/commands/merge-chain.md
@@ -1,0 +1,26 @@
+# Merge Chain
+
+Merge a sequence of dependent PRs in order, ensuring CI passes between each.
+
+## Usage
+
+`/merge-chain` with a list of PR numbers (e.g., `#638 #637`)
+
+## Steps
+
+1. For each PR in the chain (in order):
+   a. Check CI status with `gh pr checks <number>`
+   b. If CI is not yet complete, wait and re-check (up to 5 minutes)
+   c. If CI passes, merge with `gh pr merge <number> --squash --auto`
+   d. If CI fails, stop and report which PR failed and why
+
+2. After each merge (except the last):
+   a. Rebase the next PR's branch onto main: `git fetch origin main && git rebase origin/main`
+   b. Force push the rebased branch: `git push --force-with-lease`
+   c. Wait for CI to start on the rebased branch
+
+3. Report final status: which PRs merged, which (if any) failed
+
+## Output
+
+Summary table of each PR: number, title, CI status, merge result.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,11 @@ These commands work but are not yet stable:
 - **`emdx cascade`** — Autonomous idea-to-code pipeline. See [Cascade](docs/cascade.md).
 - **`emdx recipe`** — Run saved recipes (document-as-prompt) via delegate.
 
+## Known Gotchas
+
+- **`select.select()` on macOS**: Python's `select.select()` does not work reliably on `subprocess.Popen` stdout/stderr pipes on macOS. Use background threads with `queue.Queue` instead (see `_reader_thread()` in `unified_executor.py`).
+- **Delegate log monitoring**: When running parallel delegates, verify logs are non-zero with `wc -c` on the log files. Zero-byte logs indicate a streaming bug, not an empty task.
+
 ## Release Process
 
 ```bash


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Added "Known Gotchas" section documenting the `select.select()` macOS bug and delegate log monitoring practice
- **`.claude/commands/merge-chain.md`**: New `/merge-chain` command for merging dependent PR chains in order with CI checks between each
- **`.claude/MEMORY.md`**: Versioned project memory migrated from auto memory, including delegate system notes, architecture patterns, and development tips

## Context
Harvested from the delegate kinks debugging session (PRs #632, #634, #637, #638). These patterns are worth preserving for future sessions working in this codebase.

## Test plan
- [x] No code changes — docs/commands only
- [x] Ruff lint passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)