### PR TITLE
feat(typing): Add TypedDicts for UI layer (Any removal Phase 2)

### DIFF
--- a/emdx/ui/activity/activity_data.py
+++ b/emdx/ui/activity/activity_data.py
@@ -5,8 +5,9 @@ Produces typed ActivityItem subclasses from activity_items.py.
 
 import logging
 from datetime import datetime, timedelta
-from typing import Any
+from typing import cast
 
+from emdx.ui.types import CascadeRunDict, GroupDict
 from emdx.utils.datetime_utils import parse_datetime
 
 from .activity_items import (
@@ -31,6 +32,7 @@ except ImportError:
     group_svc = None  # type: ignore[assignment]
     HAS_DOCS = False
     HAS_GROUPS = False
+
 
 class ActivityDataLoader:
     """Loads activity data from DB and returns typed ActivityItem instances."""
@@ -60,9 +62,7 @@ class ActivityDataLoader:
 
         # Sort: running items first (pinned), then by timestamp descending
         def sort_key(item: ActivityItem) -> tuple:
-            is_running = (
-                item.item_type == "agent_execution" and item.status == "running"
-            )
+            is_running = item.item_type == "agent_execution" and item.status == "running"
             return (
                 0 if is_running else 1,
                 -item.timestamp.timestamp() if item.timestamp else 0,
@@ -92,7 +92,7 @@ class ActivityDataLoader:
                     item_id=group_id,
                     title=group["name"],
                     timestamp=created,
-                    group=dict(group),
+                    group=cast(GroupDict, dict(group)),
                     doc_count=group["doc_count"],
                     total_cost=group["total_cost_usd"] or 0,
                     total_tokens=group["total_tokens"],
@@ -177,7 +177,7 @@ class ActivityDataLoader:
                     doc_title = run["initial_doc_title"]
                     title = (doc_title or f"Cascade Run #{run_id}")[:40]
                     executions = get_cascade_run_executions(run_id)
-                    run_dict: dict[str, Any] = dict(run)
+                    run_dict = cast(CascadeRunDict, dict(run))
 
                     item = CascadeRunItem(
                         item_id=run_id,

--- a/emdx/ui/types.py
+++ b/emdx/ui/types.py
@@ -1,0 +1,87 @@
+"""TypedDict definitions for the UI layer.
+
+These types provide proper typing for dict-style data structures used
+in UI components, replacing Any annotations.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class CascadeRunDict(TypedDict, total=False):
+    """Cascade run data used by CascadeRunItem in the activity view.
+
+    Contains both database fields and display-derived fields.
+    """
+
+    id: int
+    status: str
+    started_at: str | None
+    completed_at: str | None
+    pipeline_name: str
+    pipeline_display_name: str
+    current_stage: str
+    initial_doc_title: str | None
+    doc_id: int | None
+    error_message: str | None
+
+
+class GroupDict(TypedDict, total=False):
+    """Document group data used by GroupItem in the activity view.
+
+    Mirrors DocumentGroupWithCounts from database/types.py but with
+    only the fields actually used by the UI layer.
+    """
+
+    id: int
+    name: str
+    description: str | None
+    group_type: str
+    created_at: str | None
+    doc_count: int
+    total_cost_usd: float | None
+    total_tokens: int
+    child_group_count: int
+    project: str | None
+    parent_group_id: int | None
+    is_active: int
+
+
+class AgentExecutionDict(TypedDict, total=False):
+    """Agent execution data used by AgentExecutionItem in the activity view.
+
+    Contains execution record fields plus derived display fields.
+    """
+
+    id: int
+    doc_id: int | None
+    doc_title: str | None
+    status: str
+    started_at: str | None
+    completed_at: str | None
+    log_file: str | None
+    exit_code: int | None
+    working_dir: str | None
+    cost_usd: float
+    tokens_used: int
+
+
+class PipelineActivityDict(TypedDict, total=False):
+    """Pipeline activity data used in cascade_view.py.
+
+    Mirrors PipelineActivityItem from database/types.py.
+    """
+
+    exec_id: int
+    input_id: int | None
+    input_title: str | None
+    output_id: int | None
+    output_title: str | None
+    output_stage: str | None
+    from_stage: str
+    status: str | None
+    started_at: str | None
+    completed_at: str | None
+    log_file: str | None
+    doc_title: str | None


### PR DESCRIPTION
## Summary

- Create `emdx/ui/types.py` with TypedDicts for UI layer data structures
- Replace `dict[str, Any]` annotations with proper TypedDicts in activity and cascade views
- Improve type safety and editor autocomplete support

## Changes

### New file: `emdx/ui/types.py`

TypedDicts for UI data structures:
- `CascadeRunDict` - cascade run data in activity view
- `GroupDict` - document group data in activity view
- `AgentExecutionDict` - agent execution data in activity view
- `PipelineActivityDict` - pipeline activity in cascade view

### Updated: `emdx/ui/activity/activity_items.py`

- `CascadeRunItem.cascade_run` now uses `CascadeRunDict`
- `GroupItem.group` now uses `GroupDict`
- `AgentExecutionItem.execution` now uses `AgentExecutionDict`

### Updated: `emdx/ui/activity/activity_data.py`

- Add casts for `dict()` conversions to TypedDicts
- Import the new TypedDicts

### Updated: `emdx/ui/cascade/cascade_view.py`

- Replace `dict[str, Any]` with `PipelineActivityDict`
- Type `_pipeline_data`, `_selected_exec`, and related methods
- Fix None handling for `.get()` calls

## Test plan

- [x] `poetry run ruff check --fix emdx/` passes
- [x] `poetry run ruff format emdx/` passes
- [x] `poetry run mypy` on changed files passes
- [x] `poetry run pytest tests/ -x -q --ignore=tests/test_delegate_flags.py` passes (1 pre-existing failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)