### PR TITLE
fix(tui): Single-click highlights, double-click opens fullscreen (Issue #6526)

### DIFF
--- a/emdx/ui/activity/activity_tree.py
+++ b/emdx/ui/activity/activity_tree.py
@@ -14,12 +14,20 @@ Tree's guide prefix, always fills the widget width:
 
 Title fills available space. Time and id are right-justified and
 aligned across all rows regardless of depth.
+
+Click behavior:
+- Single click: highlights/selects node (moves cursor, updates preview)
+- Double click: opens fullscreen document preview
+- Enter key: opens fullscreen document preview (unchanged)
 """
 
 import logging
+import time
 
 from rich.style import Style
 from rich.text import Text
+from textual.events import Click
+from textual.message import Message
 from textual.widgets import Tree
 from textual.widgets._tree import TreeNode
 
@@ -35,12 +43,14 @@ ItemKey = tuple[str, int]  # (item_type, item_id)
 GUIDE_DEPTH = 2
 
 # Right-side column widths
-TIME_WIDTH = 3   # "2m", "1h", "3d" — compact
-ID_WIDTH = 6     # " #5921" / "   #42" right-aligned
+TIME_WIDTH = 3  # "2m", "1h", "3d" — compact
+ID_WIDTH = 6  # " #5921" / "   #42" right-aligned
+
 
 def _item_key(item: ActivityItem) -> ItemKey:
     """Return a unique key for an ActivityItem."""
     return (item.item_type, item.item_id)
+
 
 def _node_depth(node: TreeNode) -> int:
     """Compute depth of a node (0 = direct child of root)."""
@@ -51,6 +61,7 @@ def _node_depth(node: TreeNode) -> int:
         n = n._parent
     return depth
 
+
 class ActivityTree(Tree[ActivityItem]):
     """Tree widget for the activity stream.
 
@@ -59,7 +70,22 @@ class ActivityTree(Tree[ActivityItem]):
     preservation natively — no manual ViewState needed.
 
     Rows are rendered with aligned columns via render_label().
+
+    Click behavior is customized:
+    - Single click: moves cursor (highlights node, triggers NodeHighlighted)
+    - Double click: posts DoubleClicked message (opens fullscreen)
+    - Enter key: posts NodeSelected (opens fullscreen, unchanged)
     """
+
+    # Double-click detection threshold in seconds
+    DOUBLE_CLICK_THRESHOLD = 0.4
+
+    class DoubleClicked(Message):
+        """Posted when a tree node is double-clicked."""
+
+        def __init__(self, node: TreeNode) -> None:
+            self.node = node
+            super().__init__()
 
     show_root = False  # type: ignore[assignment]
     show_guides = False  # type: ignore[assignment]
@@ -71,6 +97,47 @@ class ActivityTree(Tree[ActivityItem]):
     ICON_NODE_EXPANDED = ""
 
     BINDINGS = []  # Parent ActivityView owns all bindings
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        # Track last click time and node for double-click detection
+        self._last_click_time: float = 0.0
+        self._last_click_node: TreeNode | None = None
+
+    async def _on_click(self, event: Click) -> None:
+        """Handle click events with custom single/double-click behavior.
+
+        Overrides Tree's default click handling to:
+        - Single click: just move cursor (no NodeSelected, no fullscreen)
+        - Double click: post DoubleClicked message (opens fullscreen)
+        """
+        # Find which node was clicked
+        meta = self.get_style_at(event.x, event.y).meta
+        if not meta or "line" not in meta:
+            return
+
+        line = meta["line"]
+        node = self.get_node_at_line(line)
+        if node is None:
+            return
+
+        current_time = time.monotonic()
+        time_since_last = current_time - self._last_click_time
+
+        # Check for double-click: same node, within threshold
+        if self._last_click_node is node and time_since_last < self.DOUBLE_CLICK_THRESHOLD:
+            # Double-click detected — post message and reset
+            self.post_message(self.DoubleClicked(node))
+            self._last_click_time = 0.0
+            self._last_click_node = None
+        else:
+            # Single click — just move cursor (triggers NodeHighlighted)
+            self.move_cursor(node)
+            self._last_click_time = current_time
+            self._last_click_node = node
+
+        # Stop event propagation to prevent Tree's default NodeSelected behavior
+        event.stop()
 
     def get_label_width(self, node: TreeNode[ActivityItem]) -> int:
         """Return label width so virtual_size equals the viewport.
@@ -122,9 +189,7 @@ class ActivityTree(Tree[ActivityItem]):
         id_str = self._get_id_str(item)
         return f"{icon}|{time_str}|{item.title}{suffix}|{id_str}"
 
-    def render_label(
-        self, node: TreeNode[ActivityItem], base_style: Style, style: Style
-    ) -> Text:
+    def render_label(self, node: TreeNode[ActivityItem], base_style: Style, style: Style) -> Text:
         """Render a fixed-width table row with aligned columns.
 
         Layout: [expand][icon] title...  [time] [  id]
@@ -251,9 +316,7 @@ class ActivityTree(Tree[ActivityItem]):
 
         fresh_keys = {_item_key(item) for item in fresh_items}
         existing_keys = [
-            _item_key(child.data)
-            for child in parent.children
-            if child.data is not None
+            _item_key(child.data) for child in parent.children if child.data is not None
         ]
 
         # Compute the expected order of keys that already exist
@@ -309,9 +372,7 @@ class ActivityTree(Tree[ActivityItem]):
                                 self._refresh_children(child, item.children)
                             break
 
-    def find_node_by_item_key(
-        self, item_type: str, item_id: int
-    ) -> TreeNode[ActivityItem] | None:
+    def find_node_by_item_key(self, item_type: str, item_id: int) -> TreeNode[ActivityItem] | None:
         """Walk the tree to find a node matching (item_type, item_id)."""
         target_key = (item_type, item_id)
 
@@ -326,9 +387,7 @@ class ActivityTree(Tree[ActivityItem]):
 
         return _search(self.root)
 
-    def find_node_by_doc_id(
-        self, doc_id: int
-    ) -> TreeNode[ActivityItem] | None:
+    def find_node_by_doc_id(self, doc_id: int) -> TreeNode[ActivityItem] | None:
         """Walk the tree to find a node with a matching doc_id."""
 
         def _search(node: TreeNode[ActivityItem]) -> TreeNode[ActivityItem] | None:

--- a/emdx/ui/activity/activity_view.py
+++ b/emdx/ui/activity/activity_view.py
@@ -957,6 +957,10 @@ class ActivityView(HelpMixin, Widget):
         """Handle tree node selection (Enter key) — open fullscreen."""
         self.action_fullscreen()
 
+    def on_activity_tree_double_clicked(self, event: ActivityTree.DoubleClicked) -> None:
+        """Handle double-click on tree node — open fullscreen."""
+        self.action_fullscreen()
+
     async def on_tree_node_expanded(self, event: Tree.NodeExpanded) -> None:
         """Handle lazy child loading when a node is expanded."""
         node = event.node


### PR DESCRIPTION
## Summary

Fixes the Activity TUI tree click behavior:
- Single click now only highlights/selects nodes (moves cursor, updates preview) 
- Double click opens fullscreen document preview
- Enter key continues to open fullscreen (unchanged)

## Changes

### `emdx/ui/activity/activity_tree.py`
- Added `DoubleClicked` message class for double-click events
- Added `DOUBLE_CLICK_THRESHOLD = 0.4` (400ms) constant
- Added `_on_click()` override that:
  - Tracks click timing and target node
  - Detects double-click (same node clicked within threshold)
  - Single click: calls `move_cursor()` only
  - Double click: posts `DoubleClicked` message
  - Stops event to prevent Tree's default `NodeSelected` behavior

### `emdx/ui/activity/activity_view.py`
- Added `on_activity_tree_double_clicked()` handler that calls `action_fullscreen()`

## Test plan

- [ ] Single click on tree item → cursor moves, preview updates, NO fullscreen
- [ ] Double click on tree item → fullscreen opens
- [ ] Enter key on tree item → fullscreen opens
- [ ] Keyboard navigation (j/k) → still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)