### PR TITLE
chore: Remove dead cascade/chain references

### DIFF
--- a/docs/adr/003-textual-tui.md
+++ b/docs/adr/003-textual-tui.md
@@ -29,7 +29,7 @@ We chose **Textual** as the TUI framework.
 ### Key implementation details:
 
 - **Multi-modal browser** in `emdx/ui/browser_container.py`
-- **Specialized browsers**: DocumentBrowser, LogBrowser, ActivityView, CascadeBrowser
+- **Specialized browsers**: DocumentBrowser, LogBrowser, ActivityView
 - **Vim-style keybindings**: j/k navigation, g/G for top/bottom, modal selection
 - **Reactive data binding**: UI automatically updates when data changes
 - **Theme system** in `emdx/ui/themes.py` for visual customization
@@ -50,9 +50,6 @@ App (emdx gui)
     ├── ActivityView (press 'a')
     │   ├── ActivityTree
     │   └── ContextPanel
-    └── CascadeBrowser (press '4')
-        ├── Stage columns
-        └── Document controls
 ```
 
 ## Consequences

--- a/emdx/utils/lazy_group.py
+++ b/emdx/utils/lazy_group.py
@@ -4,7 +4,7 @@ This module provides a LazyTyperGroup class that extends Typer's group
 to support lazy loading of subcommands. This significantly improves
 startup performance for CLI applications with many heavy dependencies.
 
-Heavy commands (cascade, delegate, ai, etc.) are only imported
+Heavy commands (delegate, ai, etc.) are only imported
 when actually invoked, not on every CLI call.
 """
 
@@ -80,6 +80,7 @@ class LazyCommand(click.MultiCommand):
         except ImportError as e:
             # Create an error command
             import_err = str(e)
+
             @click.command(name=self.name)
             def error_cmd() -> None:
                 click.echo(f"Command '{self.name}' is not available: {import_err}", err=True)
@@ -93,6 +94,7 @@ class LazyCommand(click.MultiCommand):
             return self._real_command
         except Exception as e:
             load_err = str(e)
+
             @click.command(name=self.name)
             def error_cmd() -> None:
                 click.echo(f"Command '{self.name}' failed to load: {load_err}", err=True)
@@ -110,10 +112,7 @@ class LazyCommand(click.MultiCommand):
             from typer.main import get_command, get_group
 
             # Check if it has multiple commands (use group) or single (use command)
-            if (
-                len(cmd_object.registered_commands) > 1
-                or cmd_object.registered_groups
-            ):
+            if len(cmd_object.registered_commands) > 1 or cmd_object.registered_groups:
                 cmd: click.BaseCommand = get_group(cmd_object)
             else:
                 cmd = get_command(cmd_object)

--- a/tests/test_commands_prime.py
+++ b/tests/test_commands_prime.py
@@ -295,27 +295,6 @@ class TestPrimeVerbose:
         assert "Design Doc" in result.stdout
 
     @patch(_SCHEMA_PATCH)
-    @patch("emdx.commands.prime._get_cascade_status")
-    @patch("emdx.commands.prime._get_recent_docs")
-    @patch("emdx.commands.prime._get_active_epics")
-    @patch("emdx.commands.prime._get_ready_tasks")
-    @patch("emdx.commands.prime._get_in_progress_tasks")
-    @patch("emdx.commands.prime.get_git_project")
-    def test_verbose_shows_cascade_status(
-        self, mock_project, mock_ip, mock_ready, mock_epics, mock_docs, mock_cascade, _
-    ):
-        mock_project.return_value = None
-        mock_epics.return_value = []
-        mock_ready.return_value = []
-        mock_ip.return_value = []
-        mock_docs.return_value = []
-        mock_cascade.return_value = {"idea": 3, "prompt": 1, "analyzed": 0, "planned": 0, "done": 5}
-
-        result = runner.invoke(app, ["--verbose"])
-        assert "CASCADE QUEUE" in result.stdout
-        assert "idea: 3" in result.stdout
-
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_recent_docs")
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
@@ -397,7 +376,6 @@ class TestPrimeJson:
         data = json.loads(result.stdout)
         assert "execution_methods" not in data
         assert "recent_docs" not in data
-        assert "cascade_status" not in data
 
 
 # ---------------------------------------------------------------------------
@@ -626,7 +604,6 @@ class TestPrimeWithKeyDocs:
 
     @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_key_docs")
-    @patch("emdx.commands.prime._get_cascade_status")
     @patch("emdx.commands.prime._get_recent_docs")
     @patch("emdx.commands.prime._get_git_context")
     @patch("emdx.commands.prime._get_active_epics")
@@ -641,7 +618,6 @@ class TestPrimeWithKeyDocs:
         mock_epics,
         mock_git,
         mock_recent,
-        mock_cascade,
         mock_key_docs,
         _,
     ):
@@ -651,7 +627,6 @@ class TestPrimeWithKeyDocs:
         mock_ip.return_value = []
         mock_git.return_value = {"branch": None, "commits": [], "prs": [], "error": None}
         mock_recent.return_value = []
-        mock_cascade.return_value = {}
         mock_key_docs.return_value = [
             {"id": 1, "title": "Important Doc", "access_count": 100},
             {"id": 2, "title": "Another Doc", "access_count": 50},
@@ -665,7 +640,6 @@ class TestPrimeWithKeyDocs:
 
     @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_key_docs")
-    @patch("emdx.commands.prime._get_cascade_status")
     @patch("emdx.commands.prime._get_recent_docs")
     @patch("emdx.commands.prime._get_git_context")
     @patch("emdx.commands.prime._get_active_epics")
@@ -680,7 +654,6 @@ class TestPrimeWithKeyDocs:
         mock_epics,
         mock_git,
         mock_recent,
-        mock_cascade,
         mock_key_docs,
         _,
     ):
@@ -690,7 +663,6 @@ class TestPrimeWithKeyDocs:
         mock_ip.return_value = []
         mock_git.return_value = {"branch": None, "commits": [], "prs": [], "error": None}
         mock_recent.return_value = []
-        mock_cascade.return_value = {}
         mock_key_docs.return_value = [{"id": 1, "title": "Doc", "access_count": 10}]
 
         result = runner.invoke(app, ["--format", "json", "--verbose"])


### PR DESCRIPTION
## Summary
- Remove all dead cascade system references (functions, tests, docs, comments) left behind after the cascade system was removed in d0456e8
- Remove stale `--chain` flag references from delegate help text
- Database migrations left intact since they're historical

## Changes
- `emdx/commands/status.py` — Remove `_get_cascade_counts()`, `_show_cascade_status()`, cascade from JSON output
- `emdx/commands/prime.py` — Remove `_get_cascade_status()`, CASCADE QUEUE output, `--chain` from help
- `tests/test_commands_prime.py` — Remove cascade test and cascade mocks from key_docs tests
- `docs/architecture.md`, `docs/adr/003-textual-tui.md` — Remove CascadeBrowser references
- `emdx/utils/lazy_group.py` — Update comment

## Test plan
- [x] All 1181 tests pass (one cascade test intentionally removed)
- [x] Ruff lint/format clean
- [x] mypy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)