### PR TITLE
fix(qa): Fix FTS query — JOIN documents_fts instead of using as column

### DIFF
--- a/emdx/services/ask_service.py
+++ b/emdx/services/ask_service.py
@@ -304,13 +304,15 @@ class AskService:
             terms = re.sub(r"[^\w\s]", " ", question).strip()
             if terms and len(docs) < limit:
                 query = """
-                    SELECT id, title, content FROM documents
-                    WHERE documents_fts MATCH ? AND is_deleted = 0
+                    SELECT d.id, d.title, d.content
+                    FROM documents d
+                    JOIN documents_fts fts ON d.id = fts.rowid
+                    WHERE fts.documents_fts MATCH ? AND d.is_deleted = 0
                 """
                 params = [terms]
 
                 if project:
-                    query += " AND project = ?"
+                    query += " AND d.project = ?"
                     params.append(project)
 
                 query += " ORDER BY rank LIMIT ?"

--- a/emdx/ui/qa/qa_presenter.py
+++ b/emdx/ui/qa/qa_presenter.py
@@ -274,8 +274,9 @@ class QAPresenter:
             with db.get_connection() as conn:
                 cursor = conn.cursor()
                 cursor.execute(
-                    "SELECT id, title, content FROM documents "
-                    "WHERE documents_fts MATCH ? AND is_deleted = 0 "
+                    "SELECT d.id, d.title, d.content FROM documents d "
+                    "JOIN documents_fts fts ON d.id = fts.rowid "
+                    "WHERE fts.documents_fts MATCH ? AND d.is_deleted = 0 "
                     "ORDER BY rank LIMIT ?",
                     (terms, limit),
                 )


### PR DESCRIPTION
## Summary
- `documents_fts` is an FTS5 virtual table, not a column on `documents`
- Both `qa_presenter.py` and `ask_service.py` used `WHERE documents_fts MATCH ?` directly on the documents table, which threw `no such column: documents_fts`
- The exception was silently caught, returning 0 results — making Q&A always show "0 sources" despite Claude answering from its own knowledge
- Fix: use `JOIN documents_fts fts ON d.id = fts.rowid` matching the correct pattern already used in `database/search.py`

## Test plan
- [x] `ruff check .` — zero errors
- [x] `pytest tests/ -x -q` — 1181 passed
- [x] Verified retrieval returns 8 docs for test query (was 0 before fix)
- [ ] Manual: Run `emdx ai ask "question"` → verify sources shown in output
- [ ] Manual: TUI Q&A screen → verify status bar shows non-zero source count

🤖 Generated with [Claude Code](https://claude.com/claude-code)