### PR TITLE
feat: Add emdx next command for single next-action recommendations (Issue #FEAT-7)

### DIFF
--- a/emdx/commands/next.py
+++ b/emdx/commands/next.py
@@ -1,0 +1,156 @@
+"""
+Next command - Return the single best next action for an AI agent.
+
+Outputs exactly one actionable command to stdout. Reasoning goes to stderr.
+Designed for machine consumption: pipe stdout directly into shell or use --json.
+
+Priority order:
+1. In-progress tasks (finish what you started)
+2. Ready tasks (unblocked, highest priority first)
+3. Stale gameplans (tagged active + gameplan, older than 7 days)
+4. Fallback: emdx prime
+"""
+
+import sys
+from datetime import datetime, timedelta
+
+import typer
+
+from ..database import db
+from ..models.tags import search_by_tags
+from ..models.tasks import get_ready_tasks
+from ..models.types import TagSearchResultDict, TaskDict
+from ..utils.output import print_json
+
+STALE_DAYS = 7
+
+
+def next_action(
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed reasoning"),
+) -> None:
+    """
+    Return the single next action for an AI agent.
+
+    Prints exactly one emdx command to stdout. Reasoning goes to stderr.
+    Use this at session start to pick up where you left off.
+
+    Priority:
+    1. In-progress tasks → emdx task view <id>
+    2. Ready tasks → emdx task active <id>
+    3. Stale gameplans → emdx view <id>
+    4. Fallback → emdx prime
+
+    Examples:
+        emdx next
+        emdx next --json
+        eval $(emdx next)
+    """
+    db.ensure_schema()
+
+    action, reasoning, priority = _decide_next()
+
+    if json_output:
+        print_json(
+            {
+                "action": action,
+                "reasoning": reasoning,
+                "priority": priority,
+            }
+        )
+    else:
+        # Action to stdout (machine-readable)
+        print(action)
+        # Reasoning to stderr (human-readable)
+        if verbose:
+            print(f"reason: {reasoning}", file=sys.stderr)
+            print(f"priority: {priority}", file=sys.stderr)
+        else:
+            print(reasoning, file=sys.stderr)
+
+
+def _decide_next() -> tuple[str, str, str]:
+    """Decide the next action. Returns (action, reasoning, priority)."""
+
+    # 1. In-progress tasks — finish what you started
+    in_progress = _get_in_progress_tasks()
+    if in_progress:
+        task = in_progress[0]
+        task_id = task["id"]
+        title = task.get("title", "Untitled")
+        return (
+            f"emdx task view {task_id}",
+            f"Continue in-progress task #{task_id}: {title}",
+            "in_progress",
+        )
+
+    # 2. Ready tasks — pick up unblocked work
+    ready = get_ready_tasks()
+    if ready:
+        ready_task: TaskDict = ready[0]
+        return (
+            f"emdx task active {ready_task['id']}",
+            f"Start ready task #{ready_task['id']}: {ready_task['title']}",
+            "ready",
+        )
+
+    # 3. Stale gameplans — gameplans tagged active older than 7 days
+    stale = _get_stale_gameplans()
+    if stale:
+        doc = stale[0]
+        doc_id = doc["id"]
+        title = doc.get("title", "Untitled")
+        return (
+            f"emdx view {doc_id}",
+            f"Review stale gameplan #{doc_id}: {title}",
+            "stale_gameplan",
+        )
+
+    # 4. Fallback
+    return (
+        "emdx prime",
+        "No tasks or stale gameplans found. Run prime for full context.",
+        "fallback",
+    )
+
+
+def _get_in_progress_tasks() -> list[dict[str, object]]:
+    """Get non-delegate tasks with status='active' (in-progress)."""
+    with db.get_connection() as conn:
+        cursor = conn.execute("""
+            SELECT * FROM tasks
+            WHERE status = 'active'
+            AND parent_task_id IS NULL
+            AND prompt IS NULL
+            ORDER BY priority ASC, updated_at DESC
+            LIMIT 5
+        """)
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def _get_stale_gameplans() -> list[TagSearchResultDict]:
+    """Get gameplan documents tagged active that are older than STALE_DAYS."""
+    cutoff = datetime.now() - timedelta(days=STALE_DAYS)
+    cutoff_str = cutoff.isoformat()
+
+    # Find docs tagged both "gameplan" and "active"
+    results = search_by_tags(
+        ["gameplan", "active"],
+        mode="all",
+        prefix_match=False,
+        limit=10,
+    )
+
+    # Filter to docs older than cutoff
+    stale: list[TagSearchResultDict] = []
+    for doc in results:
+        created = doc.get("created_at", "")
+        if created and str(created) < cutoff_str:
+            stale.append(doc)
+
+    return stale
+
+
+# Typer app for test invocation
+app = typer.Typer(help="Return the single next action for an AI agent")
+app.command()(next_action)

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -72,11 +72,10 @@ def get_lazy_help() -> dict[str, str]:
 
 def create_disabled_command(name: str) -> Callable[[], None]:
     """Create a command that shows a disabled message in safe mode."""
+
     def disabled_command() -> None:
         typer.echo(
-            f"Command '{name}' is disabled in safe mode. "
-            f"Set EMDX_SAFE_MODE=0 to enable.",
-            err=True
+            f"Command '{name}' is disabled in safe mode. Set EMDX_SAFE_MODE=0 to enable.", err=True
         )
         raise typer.Exit(1)
 
@@ -101,6 +100,7 @@ from emdx.commands.executions import app as executions_app  # noqa: E402
 from emdx.commands.gist import app as gist_app  # noqa: E402
 from emdx.commands.groups import app as groups_app  # noqa: E402
 from emdx.commands.maintain import app as maintain_app  # noqa: E402
+from emdx.commands.next import next_action as next_command  # noqa: E402
 from emdx.commands.prime import prime as prime_command  # noqa: E402
 from emdx.commands.review import app as review_app  # noqa: E402
 from emdx.commands.stale import app as stale_app  # noqa: E402
@@ -173,6 +173,9 @@ app.add_typer(stale_app, name="stale", help="Knowledge decay and staleness track
 # Add touch as a top-level command for convenience
 app.command(name="touch")(touch_command)
 
+# Add the next command for single next-action recommendations
+app.command(name="next")(next_command)
+
 # Add the prime command for Claude session priming
 app.command(name="prime")(prime_command)
 
@@ -184,7 +187,6 @@ app.command(name="briefing")(briefing_command)
 
 # Add the gui command for interactive TUI browser
 app.command(name="gui")(gui_command)
-
 
 
 # =============================================================================
@@ -217,8 +219,10 @@ def main(
         None, "--db-url", envvar="EMDX_DATABASE_URL", help="Database connection URL"
     ),
     safe_mode: bool = typer.Option(
-        False, "--safe-mode", envvar="EMDX_SAFE_MODE",
-        help="Disable execution commands (delegate, recipe)"
+        False,
+        "--safe-mode",
+        envvar="EMDX_SAFE_MODE",
+        help="Disable execution commands (delegate, recipe)",
     ),
 ) -> None:
     """
@@ -309,10 +313,7 @@ def _rewrite_tag_shorthand(argv: list[str]) -> None:
     """
     # Find the position of 'tag' in argv (skip argv[0] which is the program name)
     try:
-        tag_idx = next(
-            i for i in range(1, len(argv))
-            if argv[i] == "tag"
-        )
+        tag_idx = next(i for i in range(1, len(argv)) if argv[i] == "tag")
     except StopIteration:
         return
 

--- a/tests/test_next.py
+++ b/tests/test_next.py
@@ -1,0 +1,258 @@
+"""Tests for the emdx next command."""
+# mypy: disable-error-code="no-untyped-def"
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from emdx.commands.next import (
+    _decide_next,
+    _get_in_progress_tasks,
+    _get_stale_gameplans,
+    app,
+)
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_task(
+    id=1,
+    title="Test task",
+    status="active",
+    priority=5,
+    parent_task_id=None,
+    prompt=None,
+    updated_at="2026-02-16T10:00:00",
+):
+    return {
+        "id": id,
+        "title": title,
+        "status": status,
+        "priority": priority,
+        "parent_task_id": parent_task_id,
+        "prompt": prompt,
+        "updated_at": updated_at,
+    }
+
+
+def _make_doc(
+    id=100,
+    title="My Gameplan",
+    created_at="2026-01-01T10:00:00",
+    project="emdx",
+    access_count=3,
+    tags="🗺️, 🟢",
+):
+    return {
+        "id": id,
+        "title": title,
+        "created_at": created_at,
+        "project": project,
+        "access_count": access_count,
+        "tags": tags,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _decide_next tests
+# ---------------------------------------------------------------------------
+
+
+class TestDecideNext:
+    """Test the priority decision logic."""
+
+    @patch("emdx.commands.next._get_stale_gameplans", return_value=[])
+    @patch("emdx.commands.next.get_ready_tasks", return_value=[])
+    @patch("emdx.commands.next._get_in_progress_tasks")
+    def test_in_progress_takes_priority(self, mock_ip, mock_ready, mock_stale):
+        mock_ip.return_value = [_make_task(id=42, title="Fix auth bug")]
+        action, reasoning, priority = _decide_next()
+        assert action == "emdx task view 42"
+        assert priority == "in_progress"
+        assert "42" in reasoning
+
+    @patch("emdx.commands.next._get_stale_gameplans", return_value=[])
+    @patch("emdx.commands.next.get_ready_tasks")
+    @patch("emdx.commands.next._get_in_progress_tasks", return_value=[])
+    def test_ready_when_no_in_progress(self, mock_ip, mock_ready, mock_stale):
+        mock_ready.return_value = [_make_task(id=7, title="Add tests", status="open")]
+        action, reasoning, priority = _decide_next()
+        assert action == "emdx task active 7"
+        assert priority == "ready"
+
+    @patch("emdx.commands.next._get_stale_gameplans")
+    @patch("emdx.commands.next.get_ready_tasks", return_value=[])
+    @patch("emdx.commands.next._get_in_progress_tasks", return_value=[])
+    def test_stale_gameplan_when_no_tasks(self, mock_ip, mock_ready, mock_stale):
+        mock_stale.return_value = [_make_doc(id=200, title="Old Plan")]
+        action, reasoning, priority = _decide_next()
+        assert action == "emdx view 200"
+        assert priority == "stale_gameplan"
+
+    @patch("emdx.commands.next._get_stale_gameplans", return_value=[])
+    @patch("emdx.commands.next.get_ready_tasks", return_value=[])
+    @patch("emdx.commands.next._get_in_progress_tasks", return_value=[])
+    def test_fallback_to_prime(self, mock_ip, mock_ready, mock_stale):
+        action, reasoning, priority = _decide_next()
+        assert action == "emdx prime"
+        assert priority == "fallback"
+
+    @patch("emdx.commands.next._get_stale_gameplans")
+    @patch("emdx.commands.next.get_ready_tasks")
+    @patch("emdx.commands.next._get_in_progress_tasks")
+    def test_in_progress_beats_ready(self, mock_ip, mock_ready, mock_stale):
+        """In-progress tasks should always take priority over ready tasks."""
+        mock_ip.return_value = [_make_task(id=1, title="Active")]
+        mock_ready.return_value = [_make_task(id=2, title="Ready", status="open")]
+        mock_stale.return_value = [_make_doc(id=3, title="Stale")]
+        action, _, priority = _decide_next()
+        assert action == "emdx task view 1"
+        assert priority == "in_progress"
+
+
+# ---------------------------------------------------------------------------
+# _get_in_progress_tasks tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetInProgressTasks:
+    """Test the in-progress task query."""
+
+    @patch("emdx.commands.next.db")
+    def test_returns_active_non_delegate_tasks(self, mock_db):
+        mock_conn = mock_db.get_connection.return_value.__enter__.return_value
+        mock_cursor = mock_conn.execute.return_value
+        mock_cursor.fetchall.return_value = [
+            {"id": 1, "title": "Task A", "status": "active", "prompt": None},
+        ]
+        result = _get_in_progress_tasks()
+        assert len(result) == 1
+        assert result[0]["id"] == 1
+        # Verify the SQL filters for active, non-delegate, top-level
+        sql = mock_conn.execute.call_args[0][0]
+        assert "status = 'active'" in sql
+        assert "prompt IS NULL" in sql
+        assert "parent_task_id IS NULL" in sql
+
+    @patch("emdx.commands.next.db")
+    def test_returns_empty_when_none(self, mock_db):
+        mock_conn = mock_db.get_connection.return_value.__enter__.return_value
+        mock_cursor = mock_conn.execute.return_value
+        mock_cursor.fetchall.return_value = []
+        result = _get_in_progress_tasks()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _get_stale_gameplans tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetStaleGameplans:
+    """Test stale gameplan detection."""
+
+    @patch("emdx.commands.next.search_by_tags")
+    def test_filters_by_age(self, mock_search):
+        old_date = (datetime.now() - timedelta(days=30)).isoformat()
+        new_date = datetime.now().isoformat()
+        mock_search.return_value = [
+            _make_doc(id=1, title="Old", created_at=old_date),
+            _make_doc(id=2, title="New", created_at=new_date),
+        ]
+        result = _get_stale_gameplans()
+        assert len(result) == 1
+        assert result[0]["id"] == 1
+
+    @patch("emdx.commands.next.search_by_tags")
+    def test_empty_when_no_stale(self, mock_search):
+        new_date = datetime.now().isoformat()
+        mock_search.return_value = [
+            _make_doc(id=1, created_at=new_date),
+        ]
+        result = _get_stale_gameplans()
+        assert result == []
+
+    @patch("emdx.commands.next.search_by_tags")
+    def test_empty_when_no_gameplans(self, mock_search):
+        mock_search.return_value = []
+        result = _get_stale_gameplans()
+        assert result == []
+
+    @patch("emdx.commands.next.search_by_tags")
+    def test_calls_with_correct_tags(self, mock_search):
+        mock_search.return_value = []
+        _get_stale_gameplans()
+        mock_search.assert_called_once_with(
+            ["gameplan", "active"],
+            mode="all",
+            prefix_match=False,
+            limit=10,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI output tests
+# ---------------------------------------------------------------------------
+
+
+class TestNextCLI:
+    """Test CLI output formatting."""
+
+    @patch("emdx.commands.next.db")
+    @patch("emdx.commands.next._decide_next")
+    def test_text_output_action_to_stdout(self, mock_decide, mock_db):
+        mock_decide.return_value = ("emdx task view 42", "Continue task", "in_progress")
+        result = runner.invoke(app, [])
+        assert result.exit_code == 0
+        assert "emdx task view 42" in result.output
+
+    @patch("emdx.commands.next.db")
+    @patch("emdx.commands.next._decide_next")
+    def test_json_output(self, mock_decide, mock_db):
+        mock_decide.return_value = (
+            "emdx task active 7",
+            "Start ready task",
+            "ready",
+        )
+        result = runner.invoke(app, ["--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["action"] == "emdx task active 7"
+        assert data["reasoning"] == "Start ready task"
+        assert data["priority"] == "ready"
+
+    @patch("emdx.commands.next.db")
+    @patch("emdx.commands.next._decide_next")
+    def test_verbose_output(self, mock_decide, mock_db):
+        mock_decide.return_value = ("emdx prime", "No tasks found", "fallback")
+        result = runner.invoke(app, ["--verbose"])
+        assert result.exit_code == 0
+        assert "emdx prime" in result.output
+
+    @patch("emdx.commands.next.db")
+    @patch("emdx.commands.next._decide_next")
+    def test_fallback_output(self, mock_decide, mock_db):
+        mock_decide.return_value = (
+            "emdx prime",
+            "No tasks or stale gameplans found. Run prime for full context.",
+            "fallback",
+        )
+        result = runner.invoke(app, [])
+        assert result.exit_code == 0
+        assert "emdx prime" in result.output
+
+    @patch("emdx.commands.next.db")
+    @patch("emdx.commands.next._decide_next")
+    def test_json_fallback(self, mock_decide, mock_db):
+        mock_decide.return_value = ("emdx prime", "No tasks", "fallback")
+        result = runner.invoke(app, ["--json"])
+        data = json.loads(result.output)
+        assert data["action"] == "emdx prime"
+        assert data["priority"] == "fallback"


### PR DESCRIPTION
## Summary

Adds `emdx next` — a command that returns the single best next action for an AI agent.

- Outputs exactly one `emdx` command to **stdout** (machine-readable)
- Reasoning goes to **stderr** (human-readable)  
- Supports `--json` and `--verbose` flags

### Priority Logic

1. **In-progress tasks** → `emdx task view <id>` (finish what you started)
2. **Ready tasks** → `emdx task active <id>` (pick up unblocked work)
3. **Stale gameplans** (tagged `active` + `gameplan`, older than 7 days) → `emdx view <id>`
4. **Fallback** → `emdx prime`

### Files

- `emdx/commands/next.py` — New command implementation
- `emdx/main.py` — Register the command
- `tests/test_next.py` — 16 tests covering priority logic, query functions, and CLI output

### Usage

```bash
emdx next              # Print next action to stdout
emdx next --json       # JSON output with action, reasoning, priority
emdx next --verbose    # Detailed reasoning on stderr
eval $(emdx next)      # Execute the recommended action directly
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)