### PR TITLE
docs: Add delegate debugging guide and batch-delegate command

### DIFF
--- a/.claude/commands/batch-delegate.md
+++ b/.claude/commands/batch-delegate.md
@@ -1,0 +1,46 @@
+# Batch Delegate
+
+Dispatch multiple emdx delegate tasks in parallel and monitor their completion.
+
+## Usage
+
+$ARGUMENTS should be a comma-separated list of doc IDs containing gameplans/specs, or a description of what to delegate.
+
+## Steps
+
+### 1. Identify Tasks
+If doc IDs provided, view each doc to extract the task title and scope.
+If descriptions provided, use those directly.
+
+### 2. Dispatch
+For each task, run as a background Bash command:
+```bash
+poetry run emdx delegate --pr --doc <id> --tags "enhancement,active" "<task description>" 2>&1
+```
+
+IMPORTANT:
+- Run each delegate as a **separate** background command — do NOT combine multiple `--doc` flags in one call
+- Keep prompts concise (<200 words) — long prompts can cause the claude CLI to hang
+- Do NOT use `--doc` if the document is very large; summarize key points in the prompt instead
+
+### 3. Monitor
+Check each background task periodically:
+- Read the output file for completion
+- Check `ps` for the claude process — verify it has TCP connections (healthy) vs 0 connections (stuck)
+- If stuck >8 minutes with 0% CPU and no TCP connections, kill and re-dispatch
+
+### 4. Report
+As each delegate completes, report:
+- PR URL and number
+- What was implemented
+- Any duplicates or mismatches (agent built wrong feature)
+
+### 5. Cleanup
+- Identify duplicate PRs and close them
+- List all resulting PRs in a summary table
+
+## Known Gotchas
+
+- Delegates share a virtualenv — if one delegate's worktree gets cleaned up while the editable install points to it, `poetry run pytest` breaks for everyone. Fix with `poetry install`.
+- The `--doc` flag injects the full document content into the CLI arguments. Very large docs can cause the claude CLI to hang.
+- Agents sometimes go off-script when given synthesis docs containing multiple gameplans — use the specific gameplan doc, not the synthesis.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,22 @@ These commands work but are not yet stable:
 - **`select.select()` on macOS**: Python's `select.select()` does not work reliably on `subprocess.Popen` stdout/stderr pipes on macOS. Use background threads with `queue.Queue` instead (see `_reader_thread()` in `unified_executor.py`).
 - **Delegate log monitoring**: When running parallel delegates, verify logs are non-zero with `wc -c` on the log files. Zero-byte logs indicate a streaming bug, not an empty task.
 
+## Delegate Debugging
+
+### Stuck Delegate Diagnostics
+If a delegate appears stuck (no output beyond worktree creation):
+
+1. Check process: `ps -o etime=,%cpu= -p <PID>`
+2. Check TCP connections: `lsof -p <PID> 2>/dev/null | grep TCP | wc -l`
+   - **2+ connections** = healthy, waiting on API response
+   - **0 connections** = stuck, kill and re-dispatch
+3. Check worktree: `cd <worktree> && git status` — see if files were created
+4. Kill: `kill <PID>` then clean up worktree: `git worktree remove <path> --force`
+
+### Common Causes of Hanging
+- Very large `--doc` content embedded in CLI arguments
+- Shared virtualenv editable install pointing to deleted worktree (fix: `poetry lock && poetry install`)
+
 ## Release Process
 
 ```bash


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Added "Delegate Debugging" section with stuck delegate diagnostics (check TCP connections, common causes of hanging, cleanup steps)
- **`.claude/commands/batch-delegate.md`**: New `/batch-delegate` command for dispatching and monitoring parallel delegate tasks with known gotchas

🤖 Generated with [Claude Code](https://claude.com/claude-code)