### PR TITLE
docs: Add clarifying comment for _print_doc_content function

### DIFF
--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -403,6 +403,7 @@ def _load_doc_context(doc_id: int, prompt: str | None) -> str:
         return f"Execute the following document:\n\n# {title}\n\n{content}"
 
 
+# Note: _run_single already calls this internally, so callers don't need to print separately.
 def _print_doc_content(doc_id: int) -> None:
     """Print a document's content to stdout."""
     doc = get_document(doc_id)


### PR DESCRIPTION
## Summary
- Add a one-line comment above `_print_doc_content` in `delegate.py` explaining that `_run_single` already handles printing internally

## Test plan
- [x] Ran `ruff check` - all checks passed
- [x] Pre-commit hooks passed (ruff lint, ruff format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)