### PR TITLE
refactor: Add ExecutionResultDict TypedDict (Issue #ARCH-2b)

### DIFF
--- a/emdx/services/types.py
+++ b/emdx/services/types.py
@@ -124,6 +124,27 @@ class BatchAutoTagResult(TypedDict):
     documents: list[DocumentTagResult]
 
 
+# ── Unified Executor types ────────────────────────────────────────────
+
+
+class ExecutionResultDict(TypedDict):
+    """Dict returned by ExecutionResult.to_dict()."""
+
+    success: bool
+    execution_id: int
+    log_file: str
+    output_doc_id: int | None
+    output_content: str | None
+    tokens_used: int
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    execution_time_ms: int
+    error_message: str | None
+    exit_code: int | None
+    cli_tool: str
+
+
 # ── Document Merger types ─────────────────────────────────────────────
 
 

--- a/emdx/services/unified_executor.py
+++ b/emdx/services/unified_executor.py
@@ -15,11 +15,12 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import IO, Any
+from typing import IO
 
 from ..config.cli_config import DEFAULT_ALLOWED_TOOLS
 from ..config.constants import EMDX_LOG_DIR
 from ..models.executions import create_execution, update_execution_status
+from ..services.types import ExecutionResultDict
 from ..utils.environment import get_subprocess_env
 from .cli_executor import get_cli_executor
 
@@ -210,7 +211,7 @@ class ExecutionResult:
     exit_code: int | None = None
     cli_tool: str = "claude"  # Which CLI was used
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> ExecutionResultDict:
         return {
             "success": self.success,
             "execution_id": self.execution_id,


### PR DESCRIPTION
## Summary

- Add `ExecutionResultDict` TypedDict to `emdx/services/types.py` for the dict returned by `ExecutionResult.to_dict()`
- Replace `dict[str, Any]` return annotation with the concrete TypedDict
- Remove unused `Any` import from `unified_executor.py`

Follows the established pattern from Phase 2b (PR #678) of adding TypedDicts for service-layer dicts.

## Test plan

- [x] `ruff check` passes with zero errors
- [x] `mypy` passes cleanly
- [x] Pre-commit hooks all pass
- [ ] Verify `test_to_dict` in `test_unified_executor.py` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)