### PR TITLE
refactor: Add missing __all__ exports to emdx/services/__init__.py

### DIFF
--- a/emdx/services/__init__.py
+++ b/emdx/services/__init__.py
@@ -5,13 +5,24 @@ from .claude_executor import (
     execute_claude_detached,
 )
 from .duplicate_detector import DuplicateDetector
+from .execution_service import Execution, get_agent_executions, get_recent_executions
+from .log_stream import LogStream, LogStreamSubscriber
 from .similarity import IndexStats, SimilarDocument, SimilarityService
+from .unified_executor import ExecutionConfig, ExecutionResult, UnifiedExecutor
 
 __all__ = [
-    'AutoTagger',
-    'DuplicateDetector',
-    'IndexStats',
-    'SimilarDocument',
-    'SimilarityService',
-    'execute_claude_detached',
+    "AutoTagger",
+    "DuplicateDetector",
+    "Execution",
+    "ExecutionConfig",
+    "ExecutionResult",
+    "IndexStats",
+    "LogStream",
+    "LogStreamSubscriber",
+    "SimilarDocument",
+    "SimilarityService",
+    "UnifiedExecutor",
+    "execute_claude_detached",
+    "get_agent_executions",
+    "get_recent_executions",
 ]


### PR DESCRIPTION
## Summary

- Add 9 publicly-used symbols to `emdx/services/__init__.py` `__all__` that were missing
- No changes to `emdx/services/cli_executor/__init__.py` — its exports are already complete

### Added exports

| Symbol | Source Module | Used By |
|--------|--------------|---------|
| `Execution` | `execution_service` | `ui/log_browser.py`, `ui/log_browser_display.py`, `ui/log_browser_filtering.py` |
| `get_recent_executions` | `execution_service` | `ui/log_browser.py` |
| `get_agent_executions` | `execution_service` | `ui/activity/activity_data.py`, tests |
| `LogStream` | `log_stream` | `ui/log_browser.py`, `ui/activity/activity_view.py` |
| `LogStreamSubscriber` | `log_stream` | `ui/log_browser.py`, `ui/activity/activity_view.py` |
| `ExecutionResult` | `unified_executor` | `synthesis_service.py`, tests |
| `ExecutionConfig` | `unified_executor` | `synthesis_service.py`, tests |
| `UnifiedExecutor` | `unified_executor` | `synthesis_service.py`, tests |

Only symbols with optional dependencies (numpy, psutil, watchdog) or only lazy-imported were excluded.

## Test plan

- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `mypy` passes
- [x] All imports verified working
- [x] Tests pass (35 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)