### PR TITLE
refactor: Remove Cursor IDE references and dead code

### DIFF
--- a/emdx/services/claude_executor.py
+++ b/emdx/services/claude_executor.py
@@ -241,7 +241,7 @@ def execute_cli_sync(
 ) -> dict:
     """Execute a task with specified CLI tool synchronously, waiting for completion.
 
-    This is the unified function that supports both Claude and Cursor CLIs.
+    This is the unified function that supports CLI tools.
     Uses stream-json output format by default for real-time log streaming.
 
     Args:

--- a/emdx/services/unified_executor.py
+++ b/emdx/services/unified_executor.py
@@ -439,7 +439,7 @@ class UnifiedExecutor:
 
             result.execution_time_ms = int((time.time() - start_time) * 1000)
 
-            # Get token usage from CLI result (may be zero for Cursor)
+            # Get token usage from CLI result
             result.tokens_used = cli_result.total_tokens
             result.input_tokens = cli_result.input_tokens + cli_result.cache_read_tokens
             result.output_tokens = cli_result.output_tokens


### PR DESCRIPTION
## Summary
- Remove all references to the Cursor IDE/CLI product from comments, docstrings, string literals, and dead code
- Delete the entire Cursor CLI executor (`cursor.py`, 272 lines)
- Remove `CURSOR` enum value from `CliTool`, config entry from `CLI_CONFIGS`, model aliases, and environment validation code
- Clean up Cursor-specific branches in factory, UI activity detection, and icon rendering

SQLite `cursor` objects and TUI cursor navigation references are correctly preserved.

## Test plan
- [x] `ruff check .` passes with zero errors
- [x] All 1200 tests pass (0 failures)
- [x] Pre-commit hooks pass (ruff lint, ruff format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)