### PR TITLE
refactor: Simplify command helpers and centralize ensure_schema

### DIFF
--- a/emdx/commands/browse.py
+++ b/emdx/commands/browse.py
@@ -27,8 +27,6 @@ def list(
     try:
         import json
 
-        # Ensure database schema exists
-        db.ensure_schema()
 
         # Query database
         docs = list_documents(project=project, limit=limit)
@@ -99,8 +97,6 @@ def recent(
 ) -> None:
     """Show recently accessed documents"""
     try:
-        # Ensure database schema exists
-        db.ensure_schema()
 
         # Query database for recently accessed documents
         docs = get_recent_documents(limit=limit)
@@ -148,8 +144,6 @@ def stats(
 ) -> None:
     """Show knowledge base statistics"""
     try:
-        # Ensure database schema exists
-        db.ensure_schema()
 
         # Query database for statistics
         stats_data = get_stats(project=project)

--- a/emdx/commands/compact.py
+++ b/emdx/commands/compact.py
@@ -343,9 +343,6 @@ def compact(
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1) from e
 
-    # Ensure database schema
-    db.ensure_schema()
-
     # Fetch all documents
     documents = _fetch_all_documents()
     if not documents:

--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -137,13 +137,6 @@ def detect_project(input_content: InputContent, provided_project: str | None) ->
 
 def create_document(title: str, content: str, project: str | None) -> int:
     """Save document to database and return document ID"""
-    # Ensure database schema exists
-    try:
-        db.ensure_schema()
-    except Exception as e:
-        console.print(f"[red]Database error: {e}[/red]")
-        raise typer.Exit(1) from e
-
     # Save to database
     try:
         doc_id = save_document(title, content, project)
@@ -449,8 +442,6 @@ def find(
     search_query = " ".join(query) if query else ""
 
     try:
-        # Ensure database schema exists
-        db.ensure_schema()
 
         # Validate that we have something to search for
         has_date_filters = any([created_after, created_before, modified_after, modified_before])
@@ -858,8 +849,6 @@ def view(
 ) -> None:
     """View a document from the knowledge base"""
     try:
-        # Ensure database schema exists
-        db.ensure_schema()
 
         # Fetch document
         doc = get_document(identifier)
@@ -1003,8 +992,6 @@ def edit(
 ) -> None:
     """Edit a document in the knowledge base"""
     try:
-        # Ensure database schema exists
-        db.ensure_schema()
 
         # Fetch document
         doc = get_document(identifier)
@@ -1120,8 +1107,6 @@ def delete(
 ) -> None:
     """Delete one or more documents (soft delete by default)"""
     try:
-        # Ensure database schema exists
-        db.ensure_schema()
 
         # Collect documents to delete
         docs_to_delete = []

--- a/emdx/commands/distill.py
+++ b/emdx/commands/distill.py
@@ -169,8 +169,6 @@ def distill(
     if ctx.invoked_subcommand is not None:
         return
 
-    db.ensure_schema()
-
     # Validate input
     if not topic and not tags:
         console.print(

--- a/emdx/commands/gist.py
+++ b/emdx/commands/gist.py
@@ -184,9 +184,6 @@ def create(
     update: str | None = typer.Option(None, "--update", "-u", help="Update existing gist ID"),
 ) -> None:
     """Create or update a GitHub Gist from a document."""
-    # Ensure database schema is up to date
-    db.ensure_schema()
-
     # Check for conflicting options
     if public and secret:
         console.print("[red]Error: Cannot use both --public and --secret options[/red]")

--- a/emdx/commands/groups.py
+++ b/emdx/commands/groups.py
@@ -11,7 +11,7 @@ import typer
 from rich.table import Table
 from rich.tree import Tree
 
-from emdx.database import db, groups
+from emdx.database import groups
 from emdx.models.documents import get_document
 from emdx.utils.output import console
 
@@ -37,7 +37,6 @@ def create(
 ) -> None:
     """Create a new document group."""
     try:
-        db.ensure_schema()
 
         # Validate parent exists if specified
         if parent is not None:
@@ -82,7 +81,6 @@ def add(
 ) -> None:
     """Add documents to a group."""
     try:
-        db.ensure_schema()
 
         # Verify group exists
         group = groups.get_group(group_id)
@@ -136,7 +134,6 @@ def remove(
 ) -> None:
     """Remove documents from a group."""
     try:
-        db.ensure_schema()
 
         # Verify group exists
         group = groups.get_group(group_id)
@@ -189,7 +186,6 @@ def list_groups_cmd(
 ) -> None:
     """List document groups."""
     try:
-        db.ensure_schema()
 
         if tree:
             _display_groups_tree(project, include_inactive)
@@ -296,7 +292,6 @@ def show(
 ) -> None:
     """Show detailed information about a group."""
     try:
-        db.ensure_schema()
 
         group = groups.get_group(group_id)
         if not group:
@@ -372,7 +367,6 @@ def delete(
 ) -> None:
     """Delete a document group."""
     try:
-        db.ensure_schema()
 
         group = groups.get_group(group_id)
         if not group:
@@ -418,7 +412,6 @@ def edit(
 ) -> None:
     """Edit group properties."""
     try:
-        db.ensure_schema()
 
         group = groups.get_group(group_id)
         if not group:

--- a/emdx/commands/prime.py
+++ b/emdx/commands/prime.py
@@ -57,7 +57,6 @@ def prime(
         # For session hooks
         emdx prime >> /tmp/claude-context.md
     """
-    db.ensure_schema()
     project = get_git_project()
 
     if format == "json":

--- a/emdx/commands/review.py
+++ b/emdx/commands/review.py
@@ -16,7 +16,6 @@ from typing import Any
 import typer
 from rich.table import Table
 
-from emdx.database import db
 from emdx.models.documents import get_document
 from emdx.models.tags import (
     add_tags_to_document,
@@ -71,7 +70,6 @@ def list_cmd(
         emdx review list --json
     """
     try:
-        db.ensure_schema()
 
         docs = search_by_tags(["needs-review"], limit=limit, prefix_match=False)
 
@@ -136,7 +134,6 @@ def approve(
         emdx review approve 42 --note "LGTM"
     """
     try:
-        db.ensure_schema()
 
         doc = get_document(str(doc_id))
         if not doc:
@@ -207,7 +204,6 @@ def reject(
         emdx review reject 42 -r "Missing error handling"
     """
     try:
-        db.ensure_schema()
 
         doc = get_document(str(doc_id))
         if not doc:
@@ -273,7 +269,6 @@ def stats(
         emdx review stats --json
     """
     try:
-        db.ensure_schema()
 
         needs_review = _get_tag_count("needs-review")
         reviewed = _get_tag_count("reviewed")

--- a/emdx/commands/stale.py
+++ b/emdx/commands/stale.py
@@ -237,7 +237,6 @@ def stale_list(
         emdx stale --critical-days 15  # Custom threshold
     """
     try:
-        db.ensure_schema()
 
         stale_docs = _get_stale_documents(
             critical_days=critical_days,
@@ -343,7 +342,6 @@ def touch(
         emdx touch 42 43 44     # Touch multiple documents
     """
     try:
-        db.ensure_schema()
 
         touched = []
         not_found = []

--- a/emdx/commands/tags.py
+++ b/emdx/commands/tags.py
@@ -11,7 +11,6 @@ import typer
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
-from emdx.database import db
 from emdx.models.documents import get_document
 from emdx.models.tags import (
     add_tags_to_document,
@@ -37,8 +36,6 @@ def _add_tags_impl(
 ) -> None:
     """Shared implementation for adding tags (used by both callback and add subcommand)."""
     try:
-        # Ensure database schema exists
-        db.ensure_schema()
 
         # Check if document exists
         doc = get_document(str(doc_id))
@@ -148,8 +145,6 @@ def remove(
 ) -> None:
     """Remove tags from a document."""
     try:
-        # Ensure database schema exists
-        db.ensure_schema()
 
         # Check if document exists
         doc = get_document(str(doc_id))
@@ -188,8 +183,6 @@ def list_tags(
 ) -> None:
     """List all tags with statistics."""
     try:
-        # Ensure database schema exists
-        db.ensure_schema()
 
         # Get all tags
         all_tags = list_all_tags(sort_by=sort)
@@ -237,8 +230,6 @@ def rename(
 ) -> None:
     """Rename a tag globally."""
     try:
-        # Ensure database schema exists
-        db.ensure_schema()
 
         # Get current usage
         all_tags = list_all_tags()
@@ -281,8 +272,6 @@ def merge(
 ) -> None:
     """Merge multiple tags into one."""
     try:
-        # Ensure database schema exists
-        db.ensure_schema()
 
         # Get info about source tags
         all_tags = list_all_tags()
@@ -334,8 +323,6 @@ def batch(
 ) -> None:
     """Batch auto-tag multiple documents."""
     try:
-        # Ensure database schema exists
-        db.ensure_schema()
 
         tagger = AutoTagger()
 

--- a/emdx/commands/trash.py
+++ b/emdx/commands/trash.py
@@ -12,7 +12,6 @@ Consolidates trash, restore, and purge into a subcommand group:
 import typer
 from rich.table import Table
 
-from emdx.database import db
 from emdx.models.documents import (
     list_deleted_documents,
     purge_deleted_documents,
@@ -52,7 +51,6 @@ def list_cmd(
 def _list_trash(days: int | None = None, limit: int = 50) -> None:
     """Shared implementation for listing trash."""
     try:
-        db.ensure_schema()
 
         deleted_docs = list_deleted_documents(days=days, limit=limit)
 
@@ -102,7 +100,6 @@ def restore(
 ) -> None:
     """Restore soft-deleted document(s)."""
     try:
-        db.ensure_schema()
 
         if not identifiers and not all:
             console.print("[red]Error: Provide document ID(s) to restore or use --all[/red]")
@@ -160,7 +157,6 @@ def purge(
 ) -> None:
     """Permanently delete all items in trash."""
     try:
-        db.ensure_schema()
 
         if older_than:
             deleted_docs = list_deleted_documents()

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -274,6 +274,12 @@ def main(
     if safe_mode:
         os.environ["EMDX_SAFE_MODE"] = "1"
 
+    # Ensure database schema is up to date (idempotent, runs pending migrations)
+    if ctx.invoked_subcommand is not None:
+        from emdx.database import db
+
+        db.ensure_schema()
+
 
 # Known subcommands of `emdx tag` — used for shorthand routing
 _TAG_SUBCOMMANDS = {"add", "remove", "list", "rename", "merge", "batch", "--help", "-h", "help"}

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -1,7 +1,7 @@
 """Tests for browse commands."""
 
 from datetime import datetime
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
@@ -17,7 +17,6 @@ class TestBrowseCommands:
     @patch("emdx.commands.browse.list_documents")
     def test_list_command_empty_database(self, mock_list_docs, mock_db):
         """Test list command with empty database."""
-        mock_db.ensure_schema = Mock()
         mock_list_docs.return_value = []
 
         result = runner.invoke(app, ["list"])
@@ -30,7 +29,6 @@ class TestBrowseCommands:
     @patch("emdx.commands.browse.list_documents")
     def test_list_command_with_documents(self, mock_list_docs, mock_db):
         """Test list command with documents."""
-        mock_db.ensure_schema = Mock()
         mock_list_docs.return_value = [
             {
                 "id": 1,
@@ -51,7 +49,6 @@ class TestBrowseCommands:
     @patch("emdx.commands.browse.list_documents")
     def test_list_command_with_project_filter(self, mock_list_docs, mock_db):
         """Test list command with project filter."""
-        mock_db.ensure_schema = Mock()
         mock_list_docs.return_value = []
 
         result = runner.invoke(app, ["list", "--project", "test-project"])
@@ -66,7 +63,6 @@ class TestBrowseCommands:
     def test_list_command_json_format(self, mock_list_docs, mock_db):
         """Test list command with JSON format."""
         from datetime import datetime
-        mock_db.ensure_schema = Mock()
         mock_list_docs.return_value = [{"id": 1, "title": "Test", "project": "test", "created_at": datetime.now(), "access_count": 0}]  # noqa: E501
 
         result = runner.invoke(app, ["list", "--format", "json"])
@@ -84,7 +80,6 @@ class TestBrowseCommands:
     @patch("emdx.commands.browse.get_recent_documents")
     def test_recent_command(self, mock_get_recent_docs, mock_db):
         """Test recent command."""
-        mock_db.ensure_schema = Mock()
         mock_get_recent_docs.return_value = [
             {
                 "id": 1,
@@ -105,7 +100,6 @@ class TestBrowseCommands:
     @patch("emdx.commands.browse.get_stats")
     def test_stats_command(self, mock_get_stats, mock_db):
         """Test stats command."""
-        mock_db.ensure_schema = Mock()
         mock_get_stats.return_value = {
             "total_documents": 100,
             "total_projects": 10,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,7 +56,6 @@ class TestCLIBasics:
     @patch("emdx.commands.browse.list_documents")
     def test_list_command(self, mock_list_docs, mock_db):
         """Test list command."""
-        mock_db.ensure_schema = Mock()
         mock_list_docs.return_value = []
 
         result = runner.invoke(app, ["list"])
@@ -73,7 +72,6 @@ class TestCLIBasics:
     @patch("emdx.commands.browse.get_stats")
     def test_stats_command(self, mock_get_stats, mock_db):
         """Test stats command."""
-        mock_db.ensure_schema = Mock()
         mock_get_stats.return_value = {
             "total": 0,
             "by_project": {},

--- a/tests/test_commands_core.py
+++ b/tests/test_commands_core.py
@@ -3,7 +3,7 @@
 import json
 import re
 from datetime import datetime
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
@@ -173,7 +173,6 @@ class TestFindCommand:
     @patch("emdx.commands.core.db")
     def test_find_basic(self, mock_db, mock_search, mock_get_tags):
         """Basic search returns results."""
-        mock_db.ensure_schema = Mock()
         mock_search.return_value = [
             {
                 "id": 1,
@@ -193,7 +192,6 @@ class TestFindCommand:
     @patch("emdx.commands.core.db")
     def test_find_no_args(self, mock_db):
         """Find with no search terms and no tags should error."""
-        mock_db.ensure_schema = Mock()
         result = runner.invoke(app, ["find"])
         assert result.exit_code != 0
 
@@ -202,7 +200,6 @@ class TestFindCommand:
     @patch("emdx.commands.core.db")
     def test_find_no_results(self, mock_db, mock_search, mock_get_tags):
         """Search with no results shows appropriate message."""
-        mock_db.ensure_schema = Mock()
         mock_search.return_value = []
 
         # Use --mode keyword to force FTS path (which is what search_documents mock tests)
@@ -215,7 +212,6 @@ class TestFindCommand:
     @patch("emdx.commands.core.db")
     def test_find_ids_only(self, mock_db, mock_search, mock_get_tags):
         """--ids-only outputs just IDs."""
-        mock_db.ensure_schema = Mock()
         mock_search.return_value = [
             {
                 "id": 42,
@@ -237,7 +233,6 @@ class TestFindCommand:
     @patch("emdx.commands.core.db")
     def test_find_json_output(self, mock_db, mock_search, mock_get_tags):
         """--json outputs JSON array."""
-        mock_db.ensure_schema = Mock()
         mock_search.return_value = [
             {
                 "id": 1,
@@ -260,7 +255,6 @@ class TestFindCommand:
     @patch("emdx.commands.core.db")
     def test_find_by_tags(self, mock_db, mock_search_tags, mock_get_tags):
         """Find with --tags does tag-based search."""
-        mock_db.ensure_schema = Mock()
         mock_search_tags.return_value = [
             {
                 "id": 5,
@@ -288,7 +282,6 @@ class TestViewCommand:
     @patch("emdx.commands.core.db")
     def test_view_by_id(self, mock_db, mock_get_doc, mock_get_tags):
         """View a document by numeric ID."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {
             "id": 1,
             "title": "My Doc",
@@ -307,7 +300,6 @@ class TestViewCommand:
     @patch("emdx.commands.core.db")
     def test_view_not_found(self, mock_db, mock_get_doc):
         """View nonexistent document shows error."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = None
 
         result = runner.invoke(app, ["view", "999"])
@@ -319,7 +311,6 @@ class TestViewCommand:
     @patch("emdx.commands.core.db")
     def test_view_raw(self, mock_db, mock_get_doc, mock_get_tags):
         """View with --raw shows raw content."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {
             "id": 1,
             "title": "Raw Doc",
@@ -339,7 +330,6 @@ class TestViewCommand:
     @patch("emdx.commands.core.db")
     def test_view_no_header(self, mock_db, mock_get_doc, mock_get_tags):
         """View with --no-header hides header."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {
             "id": 1,
             "title": "No Header",
@@ -361,7 +351,6 @@ class TestViewCommand:
     @patch("emdx.commands.core.db")
     def test_view_json(self, mock_db, mock_get_doc, mock_get_tags):
         """View with --json outputs valid JSON."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {
             "id": 1,
             "title": "JSON Doc",
@@ -401,7 +390,6 @@ class TestEditCommand:
     @patch("emdx.commands.core.db")
     def test_edit_title_only(self, mock_db, mock_get_doc, mock_update):
         """Edit with --title updates title without opening editor."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {
             "id": 1,
             "title": "Old Title",
@@ -420,7 +408,6 @@ class TestEditCommand:
     @patch("emdx.commands.core.db")
     def test_edit_doc_not_found(self, mock_db, mock_get_doc):
         """Edit nonexistent document shows error."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = None
 
         result = runner.invoke(app, ["edit", "999"])
@@ -432,7 +419,6 @@ class TestEditCommand:
     @patch("emdx.commands.core.db")
     def test_edit_title_failure(self, mock_db, mock_get_doc, mock_update):
         """Edit that fails to update shows error."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {
             "id": 1,
             "title": "Title",
@@ -463,7 +449,6 @@ class TestDeleteCommand:
     @patch("emdx.commands.core.db")
     def test_delete_soft(self, mock_db, mock_get_doc, mock_delete):
         """Soft delete with --force skips confirmation."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {
             "id": 1,
             "title": "To Delete",
@@ -484,7 +469,6 @@ class TestDeleteCommand:
     @patch("emdx.commands.core.db")
     def test_delete_hard_force(self, mock_db, mock_get_doc, mock_delete):
         """Hard delete with --force --hard."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {
             "id": 1,
             "title": "Perm Delete",
@@ -503,7 +487,6 @@ class TestDeleteCommand:
     @patch("emdx.commands.core.db")
     def test_delete_not_found(self, mock_db, mock_get_doc):
         """Deleting a non-existent document shows error."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = None
 
         result = runner.invoke(app, ["delete", "999", "--force"])
@@ -515,7 +498,6 @@ class TestDeleteCommand:
     @patch("emdx.commands.core.db")
     def test_delete_dry_run(self, mock_db, mock_get_doc):
         """--dry-run shows what would be deleted without deleting."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {
             "id": 1,
             "title": "Dry Run Doc",
@@ -533,7 +515,6 @@ class TestDeleteCommand:
     @patch("emdx.commands.core.db")
     def test_delete_multiple(self, mock_db, mock_get_doc, mock_delete):
         """Delete multiple documents at once."""
-        mock_db.ensure_schema = Mock()
 
         def side_effect(identifier):
             docs = {
@@ -567,10 +548,8 @@ class TestTrashCommand:
     """Tests for the trash command."""
 
     @patch("emdx.commands.trash.list_deleted_documents")
-    @patch("emdx.commands.trash.db")
-    def test_trash_empty(self, mock_db, mock_list_deleted):
+    def test_trash_empty(self, mock_list_deleted):
         """Empty trash shows message."""
-        mock_db.ensure_schema = Mock()
         mock_list_deleted.return_value = []
 
         result = runner.invoke(main_app, ["trash"])
@@ -578,10 +557,8 @@ class TestTrashCommand:
         assert "No documents in trash" in _out(result)
 
     @patch("emdx.commands.trash.list_deleted_documents")
-    @patch("emdx.commands.trash.db")
-    def test_trash_with_items(self, mock_db, mock_list_deleted):
+    def test_trash_with_items(self, mock_list_deleted):
         """Trash with items shows table."""
-        mock_db.ensure_schema = Mock()
         mock_list_deleted.return_value = [
             {
                 "id": 1,
@@ -597,10 +574,8 @@ class TestTrashCommand:
         assert "Deleted Doc" in _out(result)
 
     @patch("emdx.commands.trash.list_deleted_documents")
-    @patch("emdx.commands.trash.db")
-    def test_trash_with_days_filter(self, mock_db, mock_list_deleted):
+    def test_trash_with_days_filter(self, mock_list_deleted):
         """Trash --days filters by age."""
-        mock_db.ensure_schema = Mock()
         mock_list_deleted.return_value = []
 
         result = runner.invoke(main_app, ["trash", "--days", "7"])
@@ -615,10 +590,8 @@ class TestRestoreCommand:
     """Tests for the trash restore command."""
 
     @patch("emdx.commands.trash.restore_document")
-    @patch("emdx.commands.trash.db")
-    def test_restore_by_id(self, mock_db, mock_restore):
+    def test_restore_by_id(self, mock_restore):
         """Restore a specific document."""
-        mock_db.ensure_schema = Mock()
         mock_restore.return_value = True
 
         result = runner.invoke(main_app, ["trash", "restore", "1"])
@@ -626,30 +599,24 @@ class TestRestoreCommand:
         assert "Restored" in _out(result)
 
     @patch("emdx.commands.trash.restore_document")
-    @patch("emdx.commands.trash.db")
-    def test_restore_not_found(self, mock_db, mock_restore):
+    def test_restore_not_found(self, mock_restore):
         """Restore a document not in trash."""
-        mock_db.ensure_schema = Mock()
         mock_restore.return_value = False
 
         result = runner.invoke(main_app, ["trash", "restore", "999"])
         assert result.exit_code == 0
         assert "Could not restore" in _out(result)
 
-    @patch("emdx.commands.trash.db")
-    def test_restore_no_args(self, mock_db):
+    def test_restore_no_args(self):
         """Restore with no ID and no --all should error."""
-        mock_db.ensure_schema = Mock()
 
         result = runner.invoke(main_app, ["trash", "restore"])
         assert result.exit_code != 0
 
     @patch("emdx.commands.trash.list_deleted_documents")
     @patch("emdx.commands.trash.restore_document")
-    @patch("emdx.commands.trash.db")
-    def test_restore_all(self, mock_db, mock_restore, mock_list_deleted):
+    def test_restore_all(self, mock_restore, mock_list_deleted):
         """Restore --all restores all deleted documents."""
-        mock_db.ensure_schema = Mock()
         mock_list_deleted.return_value = [
             {"id": 1, "title": "D1"},
             {"id": 2, "title": "D2"},
@@ -668,10 +635,8 @@ class TestPurgeCommand:
     """Tests for the trash purge command."""
 
     @patch("emdx.commands.trash.list_deleted_documents")
-    @patch("emdx.commands.trash.db")
-    def test_purge_empty_trash(self, mock_db, mock_list_deleted):
+    def test_purge_empty_trash(self, mock_list_deleted):
         """Purge with empty trash shows message."""
-        mock_db.ensure_schema = Mock()
         mock_list_deleted.return_value = []
 
         result = runner.invoke(main_app, ["trash", "purge"])
@@ -680,10 +645,8 @@ class TestPurgeCommand:
 
     @patch("emdx.commands.trash.purge_deleted_documents")
     @patch("emdx.commands.trash.list_deleted_documents")
-    @patch("emdx.commands.trash.db")
-    def test_purge_with_force(self, mock_db, mock_list_deleted, mock_purge):
+    def test_purge_with_force(self, mock_list_deleted, mock_purge):
         """Purge --force skips confirmation."""
-        mock_db.ensure_schema = Mock()
         mock_list_deleted.return_value = [{"id": 1, "title": "D", "deleted_at": datetime(2024, 1, 1)}]  # noqa: E501
         mock_purge.return_value = 1
 

--- a/tests/test_commands_groups.py
+++ b/tests/test_commands_groups.py
@@ -1,7 +1,7 @@
 """Tests for group management CLI commands."""
 
 import re
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
@@ -22,10 +22,8 @@ class TestGroupCreateCommand:
     """Tests for the group create command."""
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_create_basic(self, mock_db, mock_groups):
+    def test_create_basic(self, mock_groups):
         """Create a basic group."""
-        mock_db.ensure_schema = Mock()
         mock_groups.create_group.return_value = 1
 
         result = runner.invoke(app, ["create", "My Group"])
@@ -42,10 +40,8 @@ class TestGroupCreateCommand:
         )
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_create_with_options(self, mock_db, mock_groups):
+    def test_create_with_options(self, mock_groups):
         """Create a group with type, project, description."""
-        mock_db.ensure_schema = Mock()
         mock_groups.create_group.return_value = 2
 
         result = runner.invoke(app, [
@@ -66,10 +62,8 @@ class TestGroupCreateCommand:
         )
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_create_with_parent(self, mock_db, mock_groups):
+    def test_create_with_parent(self, mock_groups):
         """Create a nested group with --parent."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "Parent Group"}
         mock_groups.create_group.return_value = 3
 
@@ -80,10 +74,8 @@ class TestGroupCreateCommand:
         assert "Parent" in out
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_create_parent_not_found(self, mock_db, mock_groups):
+    def test_create_parent_not_found(self, mock_groups):
         """Create with non-existent parent shows error."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = None
 
         result = runner.invoke(app, ["create", "Orphan", "--parent", "999"])
@@ -104,10 +96,8 @@ class TestGroupAddCommand:
 
     @patch("emdx.commands.groups.get_document")
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_add_documents(self, mock_db, mock_groups, mock_get_doc):
+    def test_add_documents(self, mock_groups, mock_get_doc):
         """Add documents to a group."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "Group 1"}
         mock_groups.add_document_to_group.return_value = True
         mock_get_doc.return_value = {"id": 10, "title": "My Doc"}
@@ -120,10 +110,8 @@ class TestGroupAddCommand:
 
     @patch("emdx.commands.groups.get_document")
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_add_with_role(self, mock_db, mock_groups, mock_get_doc):
+    def test_add_with_role(self, mock_groups, mock_get_doc):
         """Add document with custom role."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
         mock_groups.add_document_to_group.return_value = True
         mock_get_doc.return_value = {"id": 5, "title": "Doc 5"}
@@ -133,10 +121,8 @@ class TestGroupAddCommand:
         mock_groups.add_document_to_group.assert_called_once_with(1, 5, role="primary")
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_add_group_not_found(self, mock_db, mock_groups):
+    def test_add_group_not_found(self, mock_groups):
         """Add to non-existent group shows error."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = None
 
         result = runner.invoke(app, ["add", "999", "1"])
@@ -145,10 +131,8 @@ class TestGroupAddCommand:
 
     @patch("emdx.commands.groups.get_document")
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_add_doc_not_found(self, mock_db, mock_groups, mock_get_doc):
+    def test_add_doc_not_found(self, mock_groups, mock_get_doc):
         """Add non-existent document reports not found."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
         mock_get_doc.return_value = None
 
@@ -158,10 +142,8 @@ class TestGroupAddCommand:
 
     @patch("emdx.commands.groups.get_document")
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_add_already_in_group(self, mock_db, mock_groups, mock_get_doc):
+    def test_add_already_in_group(self, mock_groups, mock_get_doc):
         """Add document already in group shows already-in message."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
         mock_groups.add_document_to_group.return_value = False  # already exists
         mock_get_doc.return_value = {"id": 5, "title": "D"}
@@ -178,10 +160,8 @@ class TestGroupRemoveCommand:
     """Tests for the group remove command."""
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_remove_document(self, mock_db, mock_groups):
+    def test_remove_document(self, mock_groups):
         """Remove a document from a group."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
         mock_groups.remove_document_from_group.return_value = True
 
@@ -190,10 +170,8 @@ class TestGroupRemoveCommand:
         assert "Removed 1 document" in _out(result)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_remove_not_in_group(self, mock_db, mock_groups):
+    def test_remove_not_in_group(self, mock_groups):
         """Remove document not in group shows not-in message."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
         mock_groups.remove_document_from_group.return_value = False
 
@@ -202,10 +180,8 @@ class TestGroupRemoveCommand:
         assert "Not in group" in _out(result)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_remove_group_not_found(self, mock_db, mock_groups):
+    def test_remove_group_not_found(self, mock_groups):
         """Remove from non-existent group shows error."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = None
 
         result = runner.invoke(app, ["remove", "999", "1"])
@@ -220,10 +196,8 @@ class TestGroupListCommand:
     """Tests for the group list command."""
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_list_empty(self, mock_db, mock_groups):
+    def test_list_empty(self, mock_groups):
         """List groups with no groups shows message."""
-        mock_db.ensure_schema = Mock()
         mock_groups.list_groups.return_value = []
 
         result = runner.invoke(app, ["list"])
@@ -231,10 +205,8 @@ class TestGroupListCommand:
         assert "No groups found" in _out(result)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_list_with_groups(self, mock_db, mock_groups):
+    def test_list_with_groups(self, mock_groups):
         """List groups shows table."""
-        mock_db.ensure_schema = Mock()
         mock_groups.list_groups.return_value = [
             {
                 "id": 1,
@@ -251,10 +223,8 @@ class TestGroupListCommand:
         assert "Group A" in _out(result)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_list_filter_by_type(self, mock_db, mock_groups):
+    def test_list_filter_by_type(self, mock_groups):
         """List with --type filter."""
-        mock_db.ensure_schema = Mock()
         mock_groups.list_groups.return_value = []
 
         runner.invoke(app, ["list", "--type", "initiative"])
@@ -267,10 +237,8 @@ class TestGroupListCommand:
         )
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_list_top_level_only(self, mock_db, mock_groups):
+    def test_list_top_level_only(self, mock_groups):
         """List with --parent -1 for top-level only."""
-        mock_db.ensure_schema = Mock()
         mock_groups.list_groups.return_value = []
 
         runner.invoke(app, ["list", "--parent", "-1"])
@@ -290,10 +258,8 @@ class TestGroupShowCommand:
     """Tests for the group show command."""
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_show_group(self, mock_db, mock_groups):
+    def test_show_group(self, mock_groups):
         """Show a group."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {
             "id": 1,
             "name": "My Group",
@@ -321,10 +287,8 @@ class TestGroupShowCommand:
         assert "primary" in out
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_show_not_found(self, mock_db, mock_groups):
+    def test_show_not_found(self, mock_groups):
         """Show non-existent group shows error."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = None
 
         result = runner.invoke(app, ["show", "999"])
@@ -332,10 +296,8 @@ class TestGroupShowCommand:
         assert "not found" in _out(result)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_show_empty_group(self, mock_db, mock_groups):
+    def test_show_empty_group(self, mock_groups):
         """Show group with no members."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {
             "id": 2,
             "name": "Empty Group",
@@ -364,10 +326,8 @@ class TestGroupDeleteCommand:
     """Tests for the group delete command."""
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_delete_with_force(self, mock_db, mock_groups):
+    def test_delete_with_force(self, mock_groups):
         """Delete a group with --force."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
         mock_groups.get_child_groups.return_value = []
         mock_groups.get_group_members.return_value = []
@@ -380,10 +340,8 @@ class TestGroupDeleteCommand:
         mock_groups.delete_group.assert_called_once_with(1, hard=False)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_delete_hard(self, mock_db, mock_groups):
+    def test_delete_hard(self, mock_groups):
         """Hard delete a group."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
         mock_groups.get_child_groups.return_value = []
         mock_groups.get_group_members.return_value = []
@@ -395,10 +353,8 @@ class TestGroupDeleteCommand:
         mock_groups.delete_group.assert_called_once_with(1, hard=True)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_delete_not_found(self, mock_db, mock_groups):
+    def test_delete_not_found(self, mock_groups):
         """Delete non-existent group shows error."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = None
 
         result = runner.invoke(app, ["delete", "999", "--force"])
@@ -406,10 +362,8 @@ class TestGroupDeleteCommand:
         assert "not found" in _out(result)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_delete_with_confirmation(self, mock_db, mock_groups):
+    def test_delete_with_confirmation(self, mock_groups):
         """Delete with confirmation prompt."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
         mock_groups.get_child_groups.return_value = []
         mock_groups.get_group_members.return_value = []
@@ -420,10 +374,8 @@ class TestGroupDeleteCommand:
         assert "Deleted" in _out(result)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_delete_cancelled(self, mock_db, mock_groups):
+    def test_delete_cancelled(self, mock_groups):
         """Delete cancelled by user."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
         mock_groups.get_child_groups.return_value = []
         mock_groups.get_group_members.return_value = []
@@ -432,10 +384,8 @@ class TestGroupDeleteCommand:
         assert "Cancelled" in _out(result)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_delete_failure(self, mock_db, mock_groups):
+    def test_delete_failure(self, mock_groups):
         """Delete that fails shows error."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
         mock_groups.get_child_groups.return_value = []
         mock_groups.get_group_members.return_value = []
@@ -454,10 +404,8 @@ class TestGroupEditCommand:
     """Tests for the group edit command."""
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_edit_name(self, mock_db, mock_groups):
+    def test_edit_name(self, mock_groups):
         """Edit group name."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "Old"}
         mock_groups.update_group.return_value = True
 
@@ -468,10 +416,8 @@ class TestGroupEditCommand:
         mock_groups.update_group.assert_called_once_with(1, name="New Name")
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_edit_multiple_fields(self, mock_db, mock_groups):
+    def test_edit_multiple_fields(self, mock_groups):
         """Edit multiple fields at once."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
         mock_groups.update_group.return_value = True
 
@@ -490,10 +436,8 @@ class TestGroupEditCommand:
         )
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_edit_no_changes(self, mock_db, mock_groups):
+    def test_edit_no_changes(self, mock_groups):
         """Edit with no changes shows message."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
 
         result = runner.invoke(app, ["edit", "1"])
@@ -501,10 +445,8 @@ class TestGroupEditCommand:
         assert "No changes" in _out(result)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_edit_not_found(self, mock_db, mock_groups):
+    def test_edit_not_found(self, mock_groups):
         """Edit non-existent group shows error."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = None
 
         result = runner.invoke(app, ["edit", "999", "--name", "X"])
@@ -512,10 +454,8 @@ class TestGroupEditCommand:
         assert "not found" in _out(result)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_edit_remove_parent(self, mock_db, mock_groups):
+    def test_edit_remove_parent(self, mock_groups):
         """Edit with --parent 0 removes parent."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 2, "name": "Child"}
         mock_groups.update_group.return_value = True
 
@@ -524,10 +464,8 @@ class TestGroupEditCommand:
         mock_groups.update_group.assert_called_once_with(2, parent_group_id=None)
 
     @patch("emdx.commands.groups.groups")
-    @patch("emdx.commands.groups.db")
-    def test_edit_failure(self, mock_db, mock_groups):
+    def test_edit_failure(self, mock_groups):
         """Edit that fails shows error."""
-        mock_db.ensure_schema = Mock()
         mock_groups.get_group.return_value = {"id": 1, "name": "G"}
         mock_groups.update_group.return_value = False
 

--- a/tests/test_commands_prime.py
+++ b/tests/test_commands_prime.py
@@ -58,8 +58,6 @@ def _make_epic(
     }
 
 
-# Patch ensure_schema globally for all CLI tests since we mock the data queries
-_SCHEMA_PATCH = "emdx.commands.prime.db.ensure_schema"
 
 
 # ---------------------------------------------------------------------------
@@ -117,12 +115,11 @@ class TestFormatEpicLine:
 class TestPrimeDefault:
     """Test default output (no flags)."""
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
-    def test_shows_header_and_project(self, mock_project, mock_ip, mock_ready, mock_epics, _):
+    def test_shows_header_and_project(self, mock_project, mock_ip, mock_ready, mock_epics):
         mock_project.return_value = "myproject"
         mock_epics.return_value = []
         mock_ready.return_value = []
@@ -133,12 +130,11 @@ class TestPrimeDefault:
         assert "EMDX WORK CONTEXT" in result.stdout
         assert "Project: myproject" in result.stdout
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
-    def test_shows_usage_instructions(self, mock_project, mock_ip, mock_ready, mock_epics, _):
+    def test_shows_usage_instructions(self, mock_project, mock_ip, mock_ready, mock_epics):
         mock_project.return_value = None
         mock_epics.return_value = []
         mock_ready.return_value = []
@@ -154,12 +150,11 @@ class TestPrimeDefault:
         assert "emdx task active" in result.stdout
         assert "emdx task log" in result.stdout
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
-    def test_shows_ready_tasks(self, mock_project, mock_ip, mock_ready, mock_epics, _):
+    def test_shows_ready_tasks(self, mock_project, mock_ip, mock_ready, mock_epics):
         mock_project.return_value = None
         mock_epics.return_value = []
         mock_ready.return_value = [
@@ -176,12 +171,11 @@ class TestPrimeDefault:
         assert "DEBT-10" in result.stdout
         assert "Fix type safety" in result.stdout
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
-    def test_shows_doc_reference(self, mock_project, mock_ip, mock_ready, mock_epics, _):
+    def test_shows_doc_reference(self, mock_project, mock_ip, mock_ready, mock_epics):
         mock_project.return_value = None
         mock_epics.return_value = []
         mock_ready.return_value = [_make_task(id=1, title="Task", source_doc_id=42)]
@@ -190,12 +184,11 @@ class TestPrimeDefault:
         result = runner.invoke(app, [])
         assert "doc #42" in result.stdout
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
-    def test_shows_active_epics(self, mock_project, mock_ip, mock_ready, mock_epics, _):
+    def test_shows_active_epics(self, mock_project, mock_ip, mock_ready, mock_epics):
         mock_project.return_value = None
         mock_epics.return_value = [_make_epic(epic_key="SEC", title="Security Hardening")]
         mock_ready.return_value = []
@@ -207,12 +200,11 @@ class TestPrimeDefault:
         assert "Security Hardening" in result.stdout
         assert "2/5 done" in result.stdout
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
-    def test_shows_in_progress(self, mock_project, mock_ip, mock_ready, mock_epics, _):
+    def test_shows_in_progress(self, mock_project, mock_ip, mock_ready, mock_epics):
         mock_project.return_value = None
         mock_epics.return_value = []
         mock_ready.return_value = []
@@ -223,12 +215,11 @@ class TestPrimeDefault:
         assert "#3" in result.stdout
         assert "Work in progress" in result.stdout
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
-    def test_no_ready_tasks_message(self, mock_project, mock_ip, mock_ready, mock_epics, _):
+    def test_no_ready_tasks_message(self, mock_project, mock_ip, mock_ready, mock_epics):
         mock_project.return_value = None
         mock_epics.return_value = []
         mock_ready.return_value = []
@@ -241,11 +232,10 @@ class TestPrimeDefault:
 class TestPrimeQuiet:
     """Test --quiet flag."""
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
-    def test_quiet_omits_header_and_instructions(self, mock_project, mock_ip, mock_ready, _):
+    def test_quiet_omits_header_and_instructions(self, mock_project, mock_ip, mock_ready):
         mock_project.return_value = "proj"
         mock_ready.return_value = [_make_task(id=1, title="A task")]
         mock_ip.return_value = []
@@ -256,11 +246,10 @@ class TestPrimeQuiet:
         assert "Project:" not in result.stdout
         assert "EMDX COMMANDS:" not in result.stdout
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
-    def test_quiet_still_shows_tasks(self, mock_project, mock_ip, mock_ready, _):
+    def test_quiet_still_shows_tasks(self, mock_project, mock_ip, mock_ready):
         mock_project.return_value = None
         mock_ready.return_value = [_make_task(id=5, title="Quiet task")]
         mock_ip.return_value = []
@@ -273,14 +262,13 @@ class TestPrimeQuiet:
 class TestPrimeVerbose:
     """Test --verbose flag."""
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_recent_docs")
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
     def test_verbose_shows_recent_docs(
-        self, mock_project, mock_ip, mock_ready, mock_epics, mock_docs, _
+        self, mock_project, mock_ip, mock_ready, mock_epics, mock_docs
     ):
         mock_project.return_value = None
         mock_epics.return_value = []
@@ -294,14 +282,13 @@ class TestPrimeVerbose:
         assert "#100" in result.stdout
         assert "Design Doc" in result.stdout
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_recent_docs")
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
     def test_verbose_shows_task_descriptions(
-        self, mock_project, mock_ip, mock_ready, mock_epics, mock_docs, _
+        self, mock_project, mock_ip, mock_ready, mock_epics, mock_docs
     ):
         mock_project.return_value = None
         mock_epics.return_value = []
@@ -318,12 +305,11 @@ class TestPrimeVerbose:
 class TestPrimeJson:
     """Test --format json output."""
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
-    def test_json_output_structure(self, mock_project, mock_ip, mock_ready, mock_epics, _):
+    def test_json_output_structure(self, mock_project, mock_ip, mock_ready, mock_epics):
         mock_project.return_value = "myproject"
         mock_epics.return_value = [_make_epic()]
         mock_ready.return_value = [_make_task()]
@@ -339,14 +325,13 @@ class TestPrimeJson:
         assert len(data["active_epics"]) == 1
         assert len(data["ready_tasks"]) == 1
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_recent_docs")
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
     def test_json_verbose_includes_extras(
-        self, mock_project, mock_ip, mock_ready, mock_epics, mock_docs, _
+        self, mock_project, mock_ip, mock_ready, mock_epics, mock_docs
     ):
         mock_project.return_value = None
         mock_epics.return_value = []
@@ -359,13 +344,12 @@ class TestPrimeJson:
         assert "execution_methods" in data
         assert "recent_docs" in data
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
     def test_json_non_verbose_excludes_extras(
-        self, mock_project, mock_ip, mock_ready, mock_epics, _
+        self, mock_project, mock_ip, mock_ready, mock_epics
     ):
         mock_project.return_value = None
         mock_epics.return_value = []
@@ -542,14 +526,13 @@ class TestGetKeyDocs:
 class TestPrimeWithGitContext:
     """Test that git context appears in prime output."""
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_git_context")
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
     def test_text_output_shows_git_context(
-        self, mock_project, mock_ip, mock_ready, mock_epics, mock_git, _
+        self, mock_project, mock_ip, mock_ready, mock_epics, mock_git
     ):
         mock_project.return_value = "myproject"
         mock_epics.return_value = []
@@ -571,14 +554,13 @@ class TestPrimeWithGitContext:
         assert "Open PRs:" in result.stdout
         assert "#42 My PR (my-pr)" in result.stdout
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_git_context")
     @patch("emdx.commands.prime._get_active_epics")
     @patch("emdx.commands.prime._get_ready_tasks")
     @patch("emdx.commands.prime._get_in_progress_tasks")
     @patch("emdx.commands.prime.get_git_project")
     def test_json_output_includes_git_context(
-        self, mock_project, mock_ip, mock_ready, mock_epics, mock_git, _
+        self, mock_project, mock_ip, mock_ready, mock_epics, mock_git
     ):
         mock_project.return_value = None
         mock_epics.return_value = []
@@ -602,7 +584,6 @@ class TestPrimeWithGitContext:
 class TestPrimeWithKeyDocs:
     """Test that key docs appear in verbose mode."""
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_key_docs")
     @patch("emdx.commands.prime._get_recent_docs")
     @patch("emdx.commands.prime._get_git_context")
@@ -619,7 +600,6 @@ class TestPrimeWithKeyDocs:
         mock_git,
         mock_recent,
         mock_key_docs,
-        _,
     ):
         mock_project.return_value = None
         mock_epics.return_value = []
@@ -638,7 +618,6 @@ class TestPrimeWithKeyDocs:
         assert '#1 "Important Doc" — 100 views' in result.stdout
         assert '#2 "Another Doc" — 50 views' in result.stdout
 
-    @patch(_SCHEMA_PATCH)
     @patch("emdx.commands.prime._get_key_docs")
     @patch("emdx.commands.prime._get_recent_docs")
     @patch("emdx.commands.prime._get_git_context")
@@ -655,7 +634,6 @@ class TestPrimeWithKeyDocs:
         mock_git,
         mock_recent,
         mock_key_docs,
-        _,
     ):
         mock_project.return_value = None
         mock_epics.return_value = []

--- a/tests/test_commands_tags.py
+++ b/tests/test_commands_tags.py
@@ -2,7 +2,7 @@
 
 import re
 from datetime import datetime
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
@@ -25,10 +25,8 @@ class TestTagAddCommand:
     @patch("emdx.commands.tags.get_document_tags")
     @patch("emdx.commands.tags.add_tags_to_document")
     @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
-    def test_add_tags_explicit(self, mock_db, mock_get_doc, mock_add_tags, mock_get_tags):
+    def test_add_tags_explicit(self, mock_get_doc, mock_add_tags, mock_get_tags):
         """Add tags via explicit 'add' subcommand."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {"id": 1, "title": "Doc"}
         mock_add_tags.return_value = ["python", "testing"]
         mock_get_tags.return_value = ["python", "testing"]
@@ -70,10 +68,8 @@ class TestTagAddCommand:
 
     @patch("emdx.commands.tags.get_document_tags")
     @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
-    def test_tag_show_current(self, mock_db, mock_get_doc, mock_get_tags):
+    def test_tag_show_current(self, mock_get_doc, mock_get_tags):
         """Tag with no tag arguments shows current tags."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {"id": 1, "title": "Doc"}
         mock_get_tags.return_value = ["python"]
 
@@ -83,10 +79,8 @@ class TestTagAddCommand:
         assert "Tags for #1" in out
 
     @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
-    def test_tag_doc_not_found(self, mock_db, mock_get_doc):
+    def test_tag_doc_not_found(self, mock_get_doc):
         """Tag a nonexistent document shows error."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = None
 
         result = runner.invoke(app, ["add", "999", "test"])
@@ -96,10 +90,8 @@ class TestTagAddCommand:
     @patch("emdx.commands.tags.get_document_tags")
     @patch("emdx.commands.tags.add_tags_to_document")
     @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
-    def test_tag_already_exists(self, mock_db, mock_get_doc, mock_add_tags, mock_get_tags):
+    def test_tag_already_exists(self, mock_get_doc, mock_add_tags, mock_get_tags):
         """Adding a tag that already exists shows message."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {"id": 1, "title": "Doc"}
         mock_add_tags.return_value = []  # no new tags added
         mock_get_tags.return_value = ["python"]
@@ -118,10 +110,8 @@ class TestTagRemoveCommand:
     @patch("emdx.commands.tags.get_document_tags")
     @patch("emdx.commands.tags.remove_tags_from_document")
     @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
-    def test_remove(self, mock_db, mock_get_doc, mock_remove_tags, mock_get_tags):
+    def test_remove(self, mock_get_doc, mock_remove_tags, mock_get_tags):
         """Remove tags from a document."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {"id": 1, "title": "Doc"}
         mock_remove_tags.return_value = ["python"]
         mock_get_tags.return_value = []
@@ -133,10 +123,8 @@ class TestTagRemoveCommand:
     @patch("emdx.commands.tags.get_document_tags")
     @patch("emdx.commands.tags.remove_tags_from_document")
     @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
-    def test_remove_not_on_doc(self, mock_db, mock_get_doc, mock_remove_tags, mock_get_tags):
+    def test_remove_not_on_doc(self, mock_get_doc, mock_remove_tags, mock_get_tags):
         """Removing a tag that doesn't exist shows message."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = {"id": 1, "title": "Doc"}
         mock_remove_tags.return_value = []
         mock_get_tags.return_value = []
@@ -146,10 +134,8 @@ class TestTagRemoveCommand:
         assert "No tags removed" in _out(result)
 
     @patch("emdx.commands.tags.get_document")
-    @patch("emdx.commands.tags.db")
-    def test_remove_doc_not_found(self, mock_db, mock_get_doc):
+    def test_remove_doc_not_found(self, mock_get_doc):
         """Remove tags from a nonexistent document shows error."""
-        mock_db.ensure_schema = Mock()
         mock_get_doc.return_value = None
 
         result = runner.invoke(app, ["remove", "999", "tag"])
@@ -164,10 +150,8 @@ class TestTagListCommand:
     """Tests for the tag list command."""
 
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
-    def test_tags_list(self, mock_db, mock_list_all):
+    def test_tags_list(self, mock_list_all):
         """List all tags."""
-        mock_db.ensure_schema = Mock()
         mock_list_all.return_value = [
             {
                 "name": "python",
@@ -190,10 +174,8 @@ class TestTagListCommand:
         assert "testing" in out
 
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
-    def test_tags_list_empty(self, mock_db, mock_list_all):
+    def test_tags_list_empty(self, mock_list_all):
         """No tags shows message."""
-        mock_db.ensure_schema = Mock()
         mock_list_all.return_value = []
 
         result = runner.invoke(app, ["list"])
@@ -201,10 +183,8 @@ class TestTagListCommand:
         assert "No tags found" in _out(result)
 
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
-    def test_tags_sort_option(self, mock_db, mock_list_all):
+    def test_tags_sort_option(self, mock_list_all):
         """Tags with --sort option."""
-        mock_db.ensure_schema = Mock()
         mock_list_all.return_value = []
 
         runner.invoke(app, ["list", "--sort", "name"])
@@ -219,10 +199,8 @@ class TestTagRenameCommand:
 
     @patch("emdx.commands.tags.rename_tag")
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
-    def test_rename_with_force(self, mock_db, mock_list_all, mock_rename):
+    def test_rename_with_force(self, mock_list_all, mock_rename):
         """Rename a tag with --force."""
-        mock_db.ensure_schema = Mock()
         mock_list_all.return_value = [
             {"name": "old-tag", "count": 3, "created_at": None, "last_used": None},
         ]
@@ -234,10 +212,8 @@ class TestTagRenameCommand:
         mock_rename.assert_called_once_with("old-tag", "new-tag")
 
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
-    def test_rename_not_found(self, mock_db, mock_list_all):
+    def test_rename_not_found(self, mock_list_all):
         """Rename a tag that doesn't exist shows error."""
-        mock_db.ensure_schema = Mock()
         mock_list_all.return_value = []
 
         result = runner.invoke(app, ["rename", "nope", "new", "--force"])
@@ -246,10 +222,8 @@ class TestTagRenameCommand:
 
     @patch("emdx.commands.tags.rename_tag")
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
-    def test_rename_failure(self, mock_db, mock_list_all, mock_rename):
+    def test_rename_failure(self, mock_list_all, mock_rename):
         """Rename that fails (e.g. target already exists) shows error."""
-        mock_db.ensure_schema = Mock()
         mock_list_all.return_value = [
             {"name": "old", "count": 1, "created_at": None, "last_used": None},
         ]
@@ -268,10 +242,8 @@ class TestTagMergeCommand:
 
     @patch("emdx.commands.tags.merge_tags")
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
-    def test_merge_tags_with_force(self, mock_db, mock_list_all, mock_merge):
+    def test_merge_tags_with_force(self, mock_list_all, mock_merge):
         """Merge tags with --force."""
-        mock_db.ensure_schema = Mock()
         mock_list_all.return_value = [
             {"name": "tag1", "count": 3, "created_at": None, "last_used": None},
             {"name": "tag2", "count": 5, "created_at": None, "last_used": None},
@@ -285,10 +257,8 @@ class TestTagMergeCommand:
         assert "Merged" in _out(result)
 
     @patch("emdx.commands.tags.list_all_tags")
-    @patch("emdx.commands.tags.db")
-    def test_merge_tags_no_valid_sources(self, mock_db, mock_list_all):
+    def test_merge_tags_no_valid_sources(self, mock_list_all):
         """Merge with no valid source tags shows error."""
-        mock_db.ensure_schema = Mock()
         mock_list_all.return_value = []
 
         result = runner.invoke(app, [

--- a/tests/test_commands_trash.py
+++ b/tests/test_commands_trash.py
@@ -19,25 +19,22 @@ def _out(result) -> str:
 class TestTrashList:
     """Tests for trash list command."""
 
-    @patch("emdx.commands.trash.db")
     @patch("emdx.commands.trash.list_deleted_documents")
-    def test_list_empty_trash(self, mock_list, mock_db):
+    def test_list_empty_trash(self, mock_list):
         mock_list.return_value = []
         result = runner.invoke(app)
         assert result.exit_code == 0
         assert "No documents in trash" in _out(result)
 
-    @patch("emdx.commands.trash.db")
     @patch("emdx.commands.trash.list_deleted_documents")
-    def test_list_empty_trash_with_days(self, mock_list, mock_db):
+    def test_list_empty_trash_with_days(self, mock_list):
         mock_list.return_value = []
         result = runner.invoke(app, ["list", "--days", "7"])
         assert result.exit_code == 0
         assert "No documents deleted in the last 7 days" in _out(result)
 
-    @patch("emdx.commands.trash.db")
     @patch("emdx.commands.trash.list_deleted_documents")
-    def test_list_shows_documents(self, mock_list, mock_db):
+    def test_list_shows_documents(self, mock_list):
         mock_list.return_value = [
             {
                 "id": 42,
@@ -54,9 +51,8 @@ class TestTrashList:
         assert "Test Document" in out
         assert "test-project" in out
 
-    @patch("emdx.commands.trash.db")
     @patch("emdx.commands.trash.list_deleted_documents")
-    def test_list_truncates_long_titles(self, mock_list, mock_db):
+    def test_list_truncates_long_titles(self, mock_list):
         mock_list.return_value = [
             {
                 "id": 1,
@@ -72,9 +68,8 @@ class TestTrashList:
         # Title gets truncated — either by our code ("...") or Rich table ("…")
         assert "..." in out or "…" in out
 
-    @patch("emdx.commands.trash.db")
     @patch("emdx.commands.trash.list_deleted_documents")
-    def test_callback_invokes_list(self, mock_list, mock_db):
+    def test_callback_invokes_list(self, mock_list):
         """Invoking `trash` without subcommand runs list."""
         mock_list.return_value = []
         result = runner.invoke(app)
@@ -85,33 +80,29 @@ class TestTrashList:
 class TestTrashRestore:
     """Tests for trash restore command."""
 
-    @patch("emdx.commands.trash.db")
-    def test_restore_no_args_exits(self, mock_db):
+    def test_restore_no_args_exits(self):
         result = runner.invoke(app, ["restore"])
         assert result.exit_code == 1
         assert "Provide document ID" in _out(result)
 
-    @patch("emdx.commands.trash.db")
     @patch("emdx.commands.trash.restore_document")
-    def test_restore_single_doc(self, mock_restore, mock_db):
+    def test_restore_single_doc(self, mock_restore):
         mock_restore.return_value = True
         result = runner.invoke(app, ["restore", "42"])
         assert result.exit_code == 0
         assert "Restored 1 document" in _out(result)
         mock_restore.assert_called_once_with("42")
 
-    @patch("emdx.commands.trash.db")
     @patch("emdx.commands.trash.restore_document")
-    def test_restore_not_found(self, mock_restore, mock_db):
+    def test_restore_not_found(self, mock_restore):
         mock_restore.return_value = False
         result = runner.invoke(app, ["restore", "999"])
         assert result.exit_code == 0
         assert "Could not restore" in _out(result)
         assert "999" in _out(result)
 
-    @patch("emdx.commands.trash.db")
     @patch("emdx.commands.trash.restore_document")
-    def test_restore_multiple_docs(self, mock_restore, mock_db):
+    def test_restore_multiple_docs(self, mock_restore):
         mock_restore.side_effect = [True, False, True]
         result = runner.invoke(app, ["restore", "1", "2", "3"])
         assert result.exit_code == 0
@@ -119,9 +110,8 @@ class TestTrashRestore:
         assert "Restored 2 document" in out
         assert "Could not restore 1 document" in out
 
-    @patch("emdx.commands.trash.db")
     @patch("emdx.commands.trash.list_deleted_documents")
-    def test_restore_all_empty(self, mock_list, mock_db):
+    def test_restore_all_empty(self, mock_list):
         mock_list.return_value = []
         result = runner.invoke(app, ["restore", "--all"])
         assert result.exit_code == 0
@@ -131,27 +121,24 @@ class TestTrashRestore:
 class TestTrashPurge:
     """Tests for trash purge command."""
 
-    @patch("emdx.commands.trash.db")
     @patch("emdx.commands.trash.list_deleted_documents")
-    def test_purge_empty_trash(self, mock_list, mock_db):
+    def test_purge_empty_trash(self, mock_list):
         mock_list.return_value = []
         result = runner.invoke(app, ["purge"])
         assert result.exit_code == 0
         assert "No documents in trash to purge" in _out(result)
 
-    @patch("emdx.commands.trash.db")
     @patch("emdx.commands.trash.list_deleted_documents")
     @patch("emdx.commands.trash.purge_deleted_documents")
-    def test_purge_with_force(self, mock_purge, mock_list, mock_db):
+    def test_purge_with_force(self, mock_purge, mock_list):
         mock_list.return_value = [{"id": 1, "deleted_at": datetime(2026, 1, 1)}]
         mock_purge.return_value = 1
         result = runner.invoke(app, ["purge", "--force"])
         assert result.exit_code == 0
         assert "Permanently deleted 1 document" in _out(result)
 
-    @patch("emdx.commands.trash.db")
     @patch("emdx.commands.trash.list_deleted_documents")
-    def test_purge_cancelled(self, mock_list, mock_db):
+    def test_purge_cancelled(self, mock_list):
         mock_list.return_value = [{"id": 1, "deleted_at": datetime(2026, 1, 1)}]
         result = runner.invoke(app, ["purge"], input="n\n")
         assert result.exit_code == 0

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -171,7 +171,6 @@ class TestDistillCommand:
         """Distill without topic or tags shows error."""
         from emdx.commands.distill import app
 
-        mock_db.ensure_schema = MagicMock()
 
         result = runner.invoke(app, [])
         assert result.exit_code != 0
@@ -184,7 +183,6 @@ class TestDistillCommand:
         """Distill with topic searches and synthesizes."""
         from emdx.commands.distill import app
 
-        mock_db.ensure_schema = MagicMock()
         mock_get_docs.return_value = [
             {"id": 1, "title": "Auth Doc", "content": "Auth content"},
         ]
@@ -211,7 +209,6 @@ class TestDistillCommand:
         """Distill with --tags searches by tags."""
         from emdx.commands.distill import app
 
-        mock_db.ensure_schema = MagicMock()
         mock_get_docs.return_value = [
             {"id": 5, "title": "Security Doc", "content": "Security info"},
         ]
@@ -238,7 +235,6 @@ class TestDistillCommand:
         """Distill --for option sets audience."""
         from emdx.commands.distill import app
 
-        mock_db.ensure_schema = MagicMock()
         mock_get_docs.return_value = [{"id": 1, "title": "T", "content": "C"}]
 
         mock_service = MagicMock()
@@ -267,7 +263,6 @@ class TestDistillCommand:
         """Distill --quiet outputs only content."""
         from emdx.commands.distill import app
 
-        mock_db.ensure_schema = MagicMock()
         mock_get_docs.return_value = [{"id": 1, "title": "T", "content": "C"}]
 
         mock_service = MagicMock()
@@ -295,7 +290,6 @@ class TestDistillCommand:
         """Distill with no matching documents shows message."""
         from emdx.commands.distill import app
 
-        mock_db.ensure_schema = MagicMock()
         mock_get_docs.return_value = []
 
         result = runner.invoke(app, ["nonexistent-topic-xyz"])
@@ -307,7 +301,6 @@ class TestDistillCommand:
         """Distill with invalid --for shows error."""
         from emdx.commands.distill import app
 
-        mock_db.ensure_schema = MagicMock()
 
         result = runner.invoke(app, ["--for", "invalid", "topic"])
         assert result.exit_code != 0
@@ -324,7 +317,6 @@ class TestDistillCommand:
         """Distill --save saves the output to KB."""
         from emdx.commands.distill import app
 
-        mock_db.ensure_schema = MagicMock()
         mock_get_docs.return_value = [{"id": 1, "title": "T", "content": "C"}]
 
         mock_service = MagicMock()


### PR DESCRIPTION
## Summary

- Move `db.ensure_schema()` from 23+ scattered calls in individual command files to a single call in the main app callback
- Simplify `_helpers.py`: remove `ensure_schema` decorator and dead code, keep `combined_decorator` (error handling only) and `require_document`
- Remove `db` import from `groups.py` and `review.py` (no longer needed)
- Update tests: remove unnecessary `mock_db.ensure_schema` setup and `_helpers.db` patches

**Net: -242 lines** across 18 files. Source command files have minimal, surgical changes (just removing `db.ensure_schema()` calls). No formatting changes to files that weren't otherwise modified.

## Test plan

- [x] All 1189 tests pass
- [x] ruff lint clean
- [x] Verified `ensure_schema` runs once in app callback before any subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)