### PR TITLE
refactor: Add ExecutionResultDict TypedDict (Issue #ARCH-2b)

### DIFF
--- a/emdx/services/types.py
+++ b/emdx/services/types.py
@@ -124,6 +124,27 @@ class BatchAutoTagResult(TypedDict):
     documents: list[DocumentTagResult]
 
 
+# ── Unified Executor types ───────────────────────────────────────────
+
+
+class ExecutionResultDict(TypedDict):
+    """Serialized form of ExecutionResult from to_dict()."""
+
+    success: bool
+    execution_id: int
+    log_file: str
+    output_doc_id: int | None
+    output_content: str | None
+    tokens_used: int
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    execution_time_ms: int
+    error_message: str | None
+    exit_code: int | None
+    cli_tool: str
+
+
 # ── Document Merger types ─────────────────────────────────────────────
 
 

--- a/emdx/services/unified_executor.py
+++ b/emdx/services/unified_executor.py
@@ -21,6 +21,7 @@ from ..config.constants import EMDX_LOG_DIR
 from ..models.executions import create_execution, update_execution_status
 from ..utils.environment import get_subprocess_env
 from .cli_executor import get_cli_executor
+from .types import ExecutionResultDict
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +190,7 @@ class ExecutionResult:
     exit_code: int | None = None
     cli_tool: str = "claude"  # Which CLI was used
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> ExecutionResultDict:
         return {
             "success": self.success,
             "execution_id": self.execution_id,


### PR DESCRIPTION
## Summary
- Add `ExecutionResultDict` TypedDict to `emdx/services/types.py` in a new "Unified Executor types" section
- Update `ExecutionResult.to_dict()` return type from `dict[str, Any]` to `ExecutionResultDict`
- Import `ExecutionResultDict` in `unified_executor.py`

## Test plan
- [x] `ruff check .` passes
- [x] `mypy emdx/services/types.py emdx/services/unified_executor.py` passes
- [x] `pytest tests/test_unified_executor.py` — all 18 tests pass
- [x] Pre-commit hooks (ruff lint, ruff format, mypy) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)