### PR TITLE
refactor: Add ExecutionResultDict TypedDict (Issue #ARCH-2b)

### DIFF
--- a/emdx/services/types.py
+++ b/emdx/services/types.py
@@ -134,3 +134,24 @@ class DocumentMetadata(TypedDict):
     content: str
     project: str | None
     access_count: int
+
+
+# ── Unified Executor types ──────────────────────────────────────────
+
+
+class ExecutionResultDict(TypedDict):
+    """Typed dict for ExecutionResult.to_dict() return value."""
+
+    success: bool
+    execution_id: int
+    log_file: str
+    output_doc_id: int | None
+    output_content: str | None
+    tokens_used: int
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    execution_time_ms: int
+    error_message: str | None
+    exit_code: int | None
+    cli_tool: str

--- a/emdx/services/unified_executor.py
+++ b/emdx/services/unified_executor.py
@@ -21,6 +21,7 @@ from ..config.constants import EMDX_LOG_DIR
 from ..models.executions import create_execution, update_execution_status
 from ..utils.environment import get_subprocess_env
 from .cli_executor import get_cli_executor
+from .types import ExecutionResultDict
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +190,7 @@ class ExecutionResult:
     exit_code: int | None = None
     cli_tool: str = "claude"  # Which CLI was used
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> ExecutionResultDict:
         return {
             "success": self.success,
             "execution_id": self.execution_id,


### PR DESCRIPTION
## Summary
- Add `ExecutionResultDict` TypedDict to `emdx/services/types.py` with all 13 fields matching `ExecutionResult.to_dict()` return shape
- Update `ExecutionResult.to_dict()` return type from `dict[str, Any]` to `ExecutionResultDict` in `emdx/services/unified_executor.py`
- Redone from stale PR #687 on current main

## Test plan
- [x] `ruff check` passes with zero errors
- [x] `mypy` passes on both changed files
- [x] Full pytest suite passes (1189 passed, 9 skipped)
- [x] Pre-commit hooks pass (ruff lint, ruff format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)