### PR TITLE
fix: Remove duplicate ExecutionResultDict TypedDict

### DIFF
--- a/emdx/services/types.py
+++ b/emdx/services/types.py
@@ -155,24 +155,3 @@ class DocumentMetadata(TypedDict):
     content: str
     project: str | None
     access_count: int
-
-
-# ── Unified Executor types ──────────────────────────────────────────
-
-
-class ExecutionResultDict(TypedDict):
-    """Typed dict for ExecutionResult.to_dict() return value."""
-
-    success: bool
-    execution_id: int
-    log_file: str
-    output_doc_id: int | None
-    output_content: str | None
-    tokens_used: int
-    input_tokens: int
-    output_tokens: int
-    cost_usd: float
-    execution_time_ms: int
-    error_message: str | None
-    exit_code: int | None
-    cli_tool: str


### PR DESCRIPTION
## Summary

- Remove duplicate `ExecutionResultDict` TypedDict from `emdx/services/types.py`
- Both #697 and #698 added the same TypedDict, causing mypy (`no-redef`) and ruff failures on main

## Test plan

- [x] `ruff check` passes
- [x] `mypy` passes (no more `no-redef` error)
- [x] 18/18 `test_unified_executor.py` tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)