### PR TITLE
test: Add pilot-based tests for TaskBrowser/TaskView TUI

### DIFF
--- a/emdx/services/types.py
+++ b/emdx/services/types.py
@@ -155,24 +155,3 @@ class DocumentMetadata(TypedDict):
     content: str
     project: str | None
     access_count: int
-
-
-# ── Unified Executor types ──────────────────────────────────────────
-
-
-class ExecutionResultDict(TypedDict):
-    """Typed dict for ExecutionResult.to_dict() return value."""
-
-    success: bool
-    execution_id: int
-    log_file: str
-    output_doc_id: int | None
-    output_content: str | None
-    tokens_used: int
-    input_tokens: int
-    output_tokens: int
-    cost_usd: float
-    execution_time_ms: int
-    error_message: str | None
-    exit_code: int | None
-    cli_tool: str


### PR DESCRIPTION
## Summary

- Adds `tests/test_task_browser.py` — first pilot-based test file for the TUI, covering the Tasks screen
- 36 tests across 7 categories: rendering, keyboard navigation, detail pane content, mouse interaction, screen switching, edge cases, and pure helper functions
- Establishes reusable patterns (factories, fixtures, assertion helpers) for testing other TUI screens with Textual's Pilot API
- Adds "Textual Pilot Testing Patterns" section to CLAUDE.md
- Fixes duplicate `ExecutionResultDict` class in `emdx/services/types.py` (pre-existing on main)

Supersedes #699

## Test plan

- [x] `poetry run pytest tests/test_task_browser.py -v` — 36/36 pass (~7s) on Textual 8.0
- [x] `poetry run ruff check tests/test_task_browser.py` — clean
- [x] `poetry run mypy tests/test_task_browser.py` — clean
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)