### PR TITLE
refactor: Remove --each/--do dynamic discovery from delegate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,12 +143,9 @@ emdx delegate --branch -b develop "add feature X"
 
 # All flags compose together
 emdx delegate --doc 42 --pr "fix the bug"
-
-# Dynamic discovery
-emdx delegate --each "fd -e py src/" --do "Review {{item}}"
 ```
 
-**All options:** `--tags`, `--title`, `-j` (max parallel), `--model`, `-q` (quiet), `--base-branch`/`-b`, `--branch`, `--pr`, `--draft`/`--no-draft`, `--worktree`/`-w`, `--each`/`--do`, `--epic`/`-e`, `--cat`/`-c`, `--cleanup`
+**All options:** `--tags`, `--title`, `-j` (max parallel), `--model`, `-q` (quiet), `--base-branch`/`-b`, `--branch`, `--pr`, `--draft`/`--no-draft`, `--worktree`/`-w`, `--epic`/`-e`, `--cat`/`-c`, `--cleanup`
 
 ### Quick Reference
 
@@ -157,7 +154,6 @@ emdx delegate --each "fd -e py src/" --do "Review {{item}}"
 | Research/analysis | `emdx delegate "task"` |
 | Parallel research | `emdx delegate "t1" "t2" "t3"` |
 | Combined summary | `emdx delegate --synthesize "t1" "t2"` |
-| Discover + process | `emdx delegate --each "cmd" --do "Review {{item}}"` |
 | Doc as input | `emdx delegate --doc 42 "implement this"` |
 | Code changes with PR | `emdx delegate --pr "fix the bug"` |
 | Push branch, no PR | `emdx delegate --branch "add feature"` |

--- a/README.md
+++ b/README.md
@@ -100,19 +100,6 @@ emdx delegate -j 3 "t1" "t2" "t3" "t4" "t5"
 emdx delegate --synthesize "analyze auth" "analyze api" "analyze db"
 ```
 
-### Dynamic discovery
-
-Find items at runtime, then process each one:
-
-```bash
-# Review every Python file in src/
-emdx delegate --each "fd -e py src/" --do "Review {{item}} for issues"
-
-# Review all open PRs
-emdx delegate --each "gh pr list --json number -q '.[].number'" \
-  --do "Review PR #{{item}}"
-```
-
 ### Code changes with PRs
 
 Agents can make changes in isolated git worktrees and open PRs:
@@ -231,7 +218,6 @@ emdx briefing              # Activity summary
 | Run an AI task | `emdx delegate "task"` |
 | Run tasks in parallel | `emdx delegate "t1" "t2" "t3"` |
 | Create a PR from a task | `emdx delegate --pr "fix the bug"` |
-| Process items dynamically | `emdx delegate --each "cmd" --do "task {{item}}"` |
 | Search by meaning | `emdx find "concept" --mode semantic` |
 | Ask your KB a question | `emdx ai context "question" \| claude` |
 | Deduplicate the KB | `emdx compact --dry-run` |

--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -846,21 +846,6 @@ emdx delegate --worktree --pr "fix X"
 
 ```
 
-### Dynamic Discovery
-
-Discover items at runtime via a shell command, then process each in parallel:
-
-```bash
-# Review all Python files
-emdx delegate --each "fd -e py src/" --do "Review {{item}} for security issues"
-
-# Process all feature branches
-emdx delegate --each "git branch -r | grep feature" --do "Review branch {{item}}"
-
-# Combine with explicit tasks
-emdx delegate --each "fd -e py src/" --do "Check {{item}}" "Also review the README"
-```
-
 ### Options Reference
 
 | Option | Short | Description |
@@ -877,13 +862,9 @@ emdx delegate --each "fd -e py src/" --do "Check {{item}}" "Also review the READ
 | `--draft` / `--no-draft` | | Create PR as draft (default: `--no-draft`) |
 | `--worktree` | `-w` | Run in isolated git worktree |
 | `--base-branch` | `-b` | Base branch for worktree (default: main) |
-| `--each` | | Shell command to discover items (one per line) |
-| `--do` | | Template for each discovered item (use `{{item}}`) |
 | `--epic` | `-e` | Epic task ID to add tasks to |
 | `--cat` | `-c` | Category key for auto-numbered tasks |
 | `--cleanup` | | Remove stale delegate worktrees (>1 hour old) |
-
-**Note:** `--each` requires `--do`.
 
 ### Output Format
 

--- a/emdx/commands/prime.py
+++ b/emdx/commands/prime.py
@@ -478,7 +478,6 @@ def _get_execution_methods_json() -> list[ExecutionMethod]:
             when="All one-shot AI execution (single, parallel, PR, worktree)",
             key_flags=[
                 "--doc",
-                "--each/--do",
                 "--pr",
                 "--worktree",
                 "--synthesize",


### PR DESCRIPTION
## Summary
- Remove the `--each`/`--do` dynamic discovery feature from `emdx delegate` — this feature is no longer used
- Remove CLI options, discovery command allowlist/validation/execution code (`SAFE_DISCOVERY_COMMANDS`, `_validate_discovery_command`, `_run_discovery`)
- Remove 8 related tests (`TestRunDiscovery` class + 2 integration tests)
- Remove all documentation references from CLAUDE.md, README.md, docs/cli-api.md, and prime.py

## Test plan
- [x] `poetry run ruff check .` — All checks passed
- [x] `poetry run pytest tests/ -x -q` — 1174 passed, 9 skipped
- [x] All 83 delegate tests pass
- [x] All 35 prime tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)