### PR TITLE
docs: Remove emoji alias references from documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ EMDX is a knowledge base that AI agents populate and humans curate. Python 3.11+
 - `ui/` - TUI components (Textual widgets)
 - `services/` - Business logic (log streaming, file watching, etc.)
 - `models/` - Data models and operations
-- `utils/` - Shared utilities (git, emoji aliases, Claude integration)
+- `utils/` - Shared utilities (git, tags, Claude integration)
 
 **Detailed docs:** [docs/](docs/) | [Architecture](docs/architecture.md) | [CLI Reference](docs/cli-api.md) | [Development Setup](docs/development-setup.md)
 
@@ -166,7 +166,7 @@ emdx delegate --each "fd -e py src/" --do "Review {{item}}"
 
 ### Document Tags vs Task Organization
 
-**Documents** use tags (emoji aliases) for classification:
+**Documents** use plain text tags for classification:
 
 | Content Type | Tags |
 |--------------|------|

--- a/README.md
+++ b/README.md
@@ -67,20 +67,20 @@ emdx recent                         # See what you worked on recently
 
 ### Tag and organize
 
-Tags use plain text that maps to emoji under the hood:
+Tags are plain text strings for flexible classification:
 
 ```bash
 emdx tag 42 gameplan active         # Add tags
 emdx find --tags "gameplan,active"  # Search by tags
 ```
 
-| You type | Means | Use for |
-|----------|-------|---------|
-| `gameplan` | 🎯 | Plans and strategy |
-| `analysis` | 🔍 | Research and investigation |
-| `active` | 🚀 | Currently working on |
-| `done` | ✅ | Completed |
-| `blocked` | 🚧 | Stuck or waiting |
+| Tag | Use for |
+|-----|---------|
+| `gameplan` | Plans and strategy |
+| `analysis` | Research and investigation |
+| `active` | Currently working on |
+| `done` | Completed |
+| `blocked` | Stuck or waiting |
 
 ## Delegate work to Claude agents
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,7 +101,7 @@ emdx/
 └── utils/                  # Shared utilities
     ├── git.py             # git operations (worktrees, branches)
     ├── git_ops.py         # additional git utilities
-    ├── emoji_aliases.py   # tag alias system
+    ├── emoji_aliases.py   # tag utilities
     ├── claude_wrapper.py  # Claude Code integration
     ├── chunk_splitter.py  # document chunking
     ├── output.py          # shared console output
@@ -168,7 +168,7 @@ EMDX has a multi-modal TUI accessible via `emdx gui`:
 
 ### **Key Design Decisions**
 - **SQLite with FTS5** - Fast full-text search with simple deployment
-- **Emoji tags** - Space-efficient visual organization
+- **Plain text tags** - Simple, readable tag organization
 - **JSON metadata** - Flexible document attributes
 - **Versioned migrations** - Safe schema evolution
 

--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -23,7 +23,7 @@ emdx save document.md --title "Custom Title"
 # Save from stdin
 echo "Content here" | emdx save --title "My Note"
 
-# Save with tags using text aliases
+# Save with tags
 echo "Gameplan content" | emdx save --title "Auth Gameplan" --tags "gameplan,active"
 
 # Save from command output
@@ -38,7 +38,7 @@ emdx save notes.md --public --copy
 
 **Options:**
 - `--title, -t TEXT` - Custom title (auto-detected from filename if not provided)
-- `--tags TEXT` - Comma-separated tags using text aliases
+- `--tags TEXT` - Comma-separated tags
 - `--project, -p TEXT` - Override project detection
 - `--group, -g INTEGER` - Add document to group
 - `--group-role TEXT` - Role in group (primary, exploration, synthesis, variant, member)
@@ -61,7 +61,7 @@ Search documents with hybrid (default when index exists), keyword, or semantic s
 emdx find "docker compose"
 emdx find "kubernetes deployment"
 
-# Tag-based search using text aliases
+# Tag-based search
 emdx find --tags "gameplan,active"      # Active gameplans
 emdx find --tags "bug,urgent"           # Urgent bugs
 emdx find --tags "feature,done"         # Completed features
@@ -95,7 +95,7 @@ emdx find "database" --snippets
 ```
 
 **Options:**
-- `--tags, -t TEXT` - Search by tags (using text aliases)
+- `--tags, -t TEXT` - Search by tags
 - `--any-tags` - Match ANY tag instead of ALL tags
 - `--no-tags TEXT` - Exclude documents with specified tags (comma-separated)
 - `--project, -p TEXT` - Limit search to specific project
@@ -159,10 +159,10 @@ emdx delete 42 43 44
 ## 🏷️ **Tag Management**
 
 ### **emdx tag add**
-Add tags to a document using intuitive text aliases.
+Add tags to a document.
 
 ```bash
-# Add tags using text aliases (much easier than emojis!)
+# Add tags
 emdx tag add 42 gameplan active urgent
 
 # Add tags with auto-tagging
@@ -198,8 +198,8 @@ emdx tag list --sort name
 Rename tags globally across all documents.
 
 ```bash
-# Convert old word tags to emoji system
-emdx tag rename "old-word-tag" "gameplan" --force
+# Rename a tag across all documents
+emdx tag rename "old-tag" "gameplan" --force
 
 # Standardize tag names
 emdx tag rename "todo" "active" --force
@@ -516,7 +516,7 @@ Recipes are reusable emdx documents tagged with `recipe` that contain instructio
 List all recipes.
 
 ```bash
-# List all recipes (documents tagged 📋)
+# List all recipes (documents tagged "recipe")
 emdx recipe list
 ```
 
@@ -737,7 +737,7 @@ Command 'delegate' is disabled in safe mode. Set EMDX_SAFE_MODE=0 to enable.
 # Save a quick thought
 echo "Remember to update documentation" | emdx save --title "Todo: Docs"
 
-# Save with context tags
+# Save with tags
 echo "Bug in auth system" | emdx save --title "Auth Bug" --tags "bug,urgent"
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,7 +40,7 @@ tests/
 ├── test_document_merger.py           # Document merging
 ├── test_documents.py                 # Document CRUD operations
 ├── test_duplicate_detector.py        # Duplicate detection
-├── test_emoji_aliases.py             # Emoji alias system
+├── test_emoji_aliases.py             # Tag utilities
 ├── test_epics.py                     # Epic management tests
 ├── test_execution_monitor.py         # Execution monitoring
 ├── test_execution_system.py          # Execution tracking
@@ -76,7 +76,7 @@ tests/
 ### **Core Functionality Tests**
 - **CLI Commands** (`test_core.py`, `test_cli.py`, `test_commands_core.py`) - save, find, view, edit, delete
 - **Database Operations** (`test_database.py`, `test_sqlite_database.py`, `test_documents.py`) - CRUD, search, migrations
-- **Tag System** (`test_tags.py`, `test_models_tags.py`, `test_commands_tags.py`, `test_emoji_aliases.py`) - emoji tags, aliases, management
+- **Tag System** (`test_tags.py`, `test_models_tags.py`, `test_commands_tags.py`, `test_emoji_aliases.py`) - plain text tags, management
 - **Groups** (`test_groups.py`, `test_commands_groups.py`) - document group management
 - **Tasks** (`test_task_commands.py`, `test_epics.py`, `test_categories.py`) - task queue, epics, categories
 


### PR DESCRIPTION
## Summary
- Removed all references to emoji auto-conversion / text-to-emoji alias system from documentation
- Updated tag descriptions to reflect plain text storage across CLAUDE.md, README.md, docs/architecture.md, docs/cli-api.md, and docs/testing.md
- No code changes — documentation only

## Test plan
- [x] `ruff check .` passes
- [ ] Review that no emoji alias references remain in documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)