### PR TITLE
fix: Demote hybrid search fallback warnings to debug level

### DIFF
--- a/emdx/services/hybrid_search.py
+++ b/emdx/services/hybrid_search.py
@@ -193,7 +193,7 @@ class HybridSearchService:
         try:
             matches = self.embedding_service.search(query, limit=limit, threshold=0.3)
         except Exception as e:
-            logger.warning(f"Semantic search failed: {e}")
+            logger.debug(f"Semantic search unavailable: {e}")
             return []
 
         # Filter by project if specified
@@ -227,10 +227,12 @@ class HybridSearchService:
 
         try:
             matches = self.embedding_service.search_chunks(
-                query, limit=limit * 2, threshold=0.3  # Get more, then dedupe
+                query,
+                limit=limit * 2,
+                threshold=0.3,  # Get more, then dedupe
             )
         except Exception as e:
-            logger.warning(f"Chunk search failed: {e}")
+            logger.debug(f"Chunk search unavailable: {e}")
             return []
 
         # Filter by project
@@ -254,9 +256,7 @@ class HybridSearchService:
 
             # Build snippet from chunk
             chunk_preview = (
-                match.chunk_text[:200] + "..."
-                if len(match.chunk_text) > 200
-                else match.chunk_text
+                match.chunk_text[:200] + "..." if len(match.chunk_text) > 200 else match.chunk_text
             )
 
             results.append(


### PR DESCRIPTION
## Summary

- Demote `logger.warning` to `logger.debug` for chunk search and semantic search failures in hybrid search
- When `emdx[ai]` is not installed, `emdx find` was printing a noisy numpy error on every search even though it falls back to keyword-only just fine

## Test plan

- [x] `emdx find "query"` no longer prints `Chunk search failed: numpy is required...`
- [x] ruff/mypy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)