### PR TITLE
feat: add --sonnet/--opus shortcut flags and model tagging to delegate

### DIFF
--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -37,7 +37,7 @@ from pathlib import Path
 
 import typer
 
-from ..config.cli_config import resolve_model_for_tag
+from ..config.cli_config import get_model_display_name, resolve_model_version
 from ..config.constants import DELEGATE_EXECUTION_TIMEOUT
 from ..database.documents import get_document, save_document
 from ..services.unified_executor import ExecutionConfig, UnifiedExecutor
@@ -471,10 +471,15 @@ def _run_single(
     """Run a single task via UnifiedExecutor. Returns SingleResult."""
     doc_title = title or f"Delegate: {prompt[:60]}"
 
-    # Resolve model and add tag with alias + version (e.g. model:opus/claude-opus-4-6)
-    model_tag = f"model:{resolve_model_for_tag(model)}"
-    if model_tag not in tags:
-        tags = [*tags, model_tag]
+    # Add model tags: model:opus for filtering, model-ver:claude-opus-4-6 for version
+    alias_tag = f"model:{get_model_display_name(model)}"
+    ver_tag = f"model-ver:{resolve_model_version(model)}"
+    new_tags = list(tags)
+    if alias_tag not in new_tags:
+        new_tags.append(alias_tag)
+    if ver_tag not in new_tags:
+        new_tags.append(ver_tag)
+    tags = new_tags
 
     # Create task before execution
     task_id = _safe_create_task(

--- a/emdx/config/cli_config.py
+++ b/emdx/config/cli_config.py
@@ -174,11 +174,11 @@ def get_model_display_name(model: str | None, cli_tool: CliTool | None = None) -
     return model
 
 
-def resolve_model_for_tag(model: str | None, cli_tool: CliTool | None = None) -> str:
-    """Resolve a model spec into a tag value with alias and full version.
+def resolve_model_version(model: str | None, cli_tool: CliTool | None = None) -> str:
+    """Resolve a model spec to its full version ID.
 
-    Returns "alias/full-model-id" when an alias exists (e.g. "opus/claude-opus-4-6"),
-    or just the full model id when no alias maps to it.
+    Handles aliases, full names, and None (default). Always returns the
+    concrete model identifier (e.g. "claude-opus-4-6").
 
     Args:
         model: Model name, alias, or None (uses default).
@@ -191,12 +191,7 @@ def resolve_model_for_tag(model: str | None, cli_tool: CliTool | None = None) ->
     if model is None:
         model = config.default_model
 
-    display = get_model_display_name(model, cli_tool)
-    full = resolve_model_alias(model, cli_tool) if model in MODEL_ALIASES else model
-
-    if display != full:
-        return f"{display}/{full}"
-    return full
+    return resolve_model_alias(model, cli_tool) if model in MODEL_ALIASES else model
 
 
 def get_available_models(cli_tool: CliTool) -> list[str]:


### PR DESCRIPTION
Add convenience flags --sonnet and --opus as shortcuts for --model sonnet
and --model opus. Documents created by delegate now automatically get a
model:<name> tag (e.g. model:opus, model:sonnet) recording which model
produced them.

Also adds get_model_display_name() helper to cli_config.py for resolving
full model names back to short aliases.

https://claude.ai/code/session_018iCEzXyjGcY6FNwG6meBPT