### PR TITLE
feat: Add `emdx task cat delete` and `emdx task epic delete` commands

### DIFF
--- a/emdx/commands/categories.py
+++ b/emdx/commands/categories.py
@@ -71,6 +71,34 @@ def list_cmd() -> None:
 
 
 @app.command()
+def delete(
+    key: str = typer.Argument(..., help="Category key to delete (e.g. SEC)"),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Delete even if open/active tasks exist"
+    ),
+) -> None:
+    """Delete a category and unlink associated tasks.
+
+    Tasks are NOT deleted — their epic_key/epic_seq are cleared.
+    Refuses to delete if open/active tasks exist unless --force is used.
+
+    Examples:
+        emdx task cat delete OLDCAT
+        emdx task cat delete OLDCAT --force
+    """
+    try:
+        result = categories.delete_category(key, force=force)
+        console.print(f"[green]Deleted category {key.upper()}[/green]")
+        if result["tasks_cleared"]:
+            console.print(f"[yellow]Unlinked {result['tasks_cleared']} task(s)[/yellow]")
+        if result["epics_cleared"]:
+            console.print(f"[yellow]Unlinked {result['epics_cleared']} epic(s)[/yellow]")
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1) from None
+
+
+@app.command()
 def adopt(
     key: str = typer.Argument(..., help="Category key to adopt tasks for"),
     name: str | None = typer.Option(None, "--name", "-n", help="Set category name"),

--- a/emdx/commands/epics.py
+++ b/emdx/commands/epics.py
@@ -111,6 +111,32 @@ def view(
 
 
 @app.command()
+def delete(
+    epic_id: int = typer.Argument(..., help="Epic task ID to delete"),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Delete even if open/active child tasks exist"
+    ),
+) -> None:
+    """Delete an epic and unlink its child tasks.
+
+    Child tasks are NOT deleted — their parent_task_id is cleared.
+    Refuses to delete if open/active children exist unless --force is used.
+
+    Examples:
+        emdx task epic delete 510
+        emdx task epic delete 510 --force
+    """
+    try:
+        result = tasks.delete_epic(epic_id, force=force)
+        console.print(f"[green]Deleted epic #{epic_id}[/green]")
+        if result["children_unlinked"]:
+            console.print(f"[yellow]Unlinked {result['children_unlinked']} child task(s)[/yellow]")
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1) from None
+
+
+@app.command()
 def done(
     epic_id: int = typer.Argument(..., help="Epic task ID"),
 ) -> None:


### PR DESCRIPTION
Add delete commands for categories and epics to allow cleanup of
completed organizational elements. Both commands refuse to delete
when open/active tasks exist unless --force is used. Tasks are
unlinked (not deleted) when their parent category or epic is removed.

Closes #719

https://claude.ai/code/session_01AiouCVFZi7PiwJUTjiyf1h