### PR TITLE
docs: Rework README around Save/Delegate/Track + bundle all deps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ emdx task cat list                     # See available categories
 emdx tag add 42 gameplan active
 emdx tag list
 
-# AI search (requires emdx[ai] extra)
+# AI search
 # Note: emdx find now supports semantic search natively via --mode semantic
 emdx ai search "concept"
 emdx ai context "question" | claude

--- a/README.md
+++ b/README.md
@@ -43,11 +43,6 @@ uv tool install emdx    # or: pip install emdx
 emdx --help
 ```
 
-```bash
-uv tool install 'emdx[ai]'     # Add semantic search, embeddings, Q&A
-uv tool install 'emdx[all]'    # Everything
-```
-
 ## Save
 
 Files, notes, piped command output — anything you save becomes searchable. Tag things so you can find them by topic later.
@@ -131,7 +126,7 @@ $ emdx task epic list
 
 ## AI features
 
-With `emdx[ai]` installed, search by meaning instead of just keywords:
+Search by meaning instead of just keywords:
 
 ```bash
 # "rate limiting" finds docs about throttling, backoff, quotas...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "emdx"
 version = "0.17.0"
-description = "A knowledge base that AI agents can read, write, and search — and so can you"
+description = "Send agents. Save everything. Track what's next."
 authors = ["Alex Rockwell <arockwell@gmail.com>"]
 readme = "README.md"
 license = "MIT"
@@ -31,23 +31,13 @@ rich = "^14.3.0"
 textual = "^8.0.0"
 psutil = "^7.0.0"
 pyyaml = ">=6.0"
-
-# Optional heavy dependencies (declared but not installed by default)
-scikit-learn = {version = "^1.6.0", optional = true}
-datasketch = {version = "^1.6.0", optional = true}
-sentence-transformers = {version = "^5.2.2", optional = true}
-numpy = {version = "^2.4.2", optional = true}
-google-api-python-client = {version = "^2.100.0", optional = true}
-google-auth-httplib2 = {version = "^0.3.0", optional = true}
-google-auth-oauthlib = {version = "^1.2.0", optional = true}
-
-[tool.poetry.extras]
-ai = ["sentence-transformers", "scikit-learn", "numpy"]
-similarity = ["scikit-learn", "datasketch", "numpy"]
-google = ["google-api-python-client", "google-auth-httplib2", "google-auth-oauthlib"]
-all = ["sentence-transformers", "scikit-learn", "numpy",
-       "datasketch", "google-api-python-client", "google-auth-httplib2",
-       "google-auth-oauthlib"]
+scikit-learn = "^1.6.0"
+datasketch = "^1.6.0"
+sentence-transformers = "^5.2.2"
+numpy = "^2.4.2"
+google-api-python-client = "^2.100.0"
+google-auth-httplib2 = "^0.3.0"
+google-auth-oauthlib = "^1.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.0"


### PR DESCRIPTION
## Summary
- New tagline: **"Send agents. Save everything. Track what's next."**
- Tighter intro paragraph — problem statement + value prop in two sentences
- Sections renamed to **Save** / **Delegate** / **Track** to mirror the tagline
- New **Track** section with task, epic, and category examples (was completely missing)
- Fix `emdx save` examples for `--file` flag after #721
- Fold thin Claude Code integration section into More features
- Update quick reference table with task commands and split save file/note
- Bundle all deps as required — no more `[ai]`/`[all]`/`[similarity]` extras

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] `poetry lock && poetry install` pulls in all deps without extras
- [ ] `poetry run pytest tests/ -x -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)