### PR TITLE
chore: Release v0.18.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ emdx delegate --branch -b develop "add feature X"
 emdx delegate --doc 42 --pr "fix the bug"
 ```
 
-**All options:** `--tags`, `--title`, `-j` (max parallel), `--model`, `-q` (quiet), `--base-branch`/`-b`, `--branch`, `--pr`, `--draft`/`--no-draft`, `--worktree`/`-w`, `--epic`/`-e`, `--cat`/`-c`, `--cleanup`
+**All options:** `--tags`, `--title`, `-j` (max parallel), `--model`, `--sonnet`, `--opus`, `-q` (quiet), `--base-branch`/`-b`, `--branch`, `--pr`, `--draft`/`--no-draft`, `--worktree`/`-w`, `--epic`/`-e`, `--cat`/`-c`, `--cleanup`
 
 ### Quick Reference
 
@@ -297,7 +297,6 @@ If a delegate appears stuck (no output beyond worktree creation):
 4. Kill: `kill <PID>` then clean up worktree: `git worktree remove <path> --force`
 
 ### Common Causes of Hanging
-- Very large `--doc` content embedded in CLI arguments
 - Shared virtualenv editable install pointing to deleted worktree (fix: `poetry lock && poetry install`)
 
 ## Release Process

--- a/emdx/__init__.py
+++ b/emdx/__init__.py
@@ -6,7 +6,7 @@ import hashlib
 import time
 from pathlib import Path
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"
 
 
 # Generate a unique build identifier based on current timestamp and file modification times

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "emdx"
-version = "0.17.0"
+version = "0.18.0"
 description = "Send agents. Save everything. Track what's next."
 authors = ["Alex Rockwell <arockwell@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump version to 0.18.0
- Write changelog covering 15 features and 12 fixes since v0.17.0
- Update `docs/cli-api.md` for new commands: `emdx explore`, `emdx ai link/links/unlink`, `--auto-link`, `--sonnet`/`--opus`, `task cat/epic delete`, and the `save --file` breaking change
- Fix stale `emdx save file.md` examples in docs and CLAUDE.md
- Update epic/cat section headers from `emdx epic`/`emdx cat` to `emdx task epic`/`emdx task cat`

## Highlights
- **Auto-linking** — self-organizing knowledge graph on save (#577, #725)
- **Reciprocal Rank Fusion** — better hybrid search scoring (#578, #724)
- **`emdx explore`** — KB topic discovery with clustering (#716)
- **`emdx save` breaking change** — positional arg is always content, use `--file` for files (#714, #721)

## After merge
```bash
git tag v0.18.0 && git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)