### PR TITLE
feat: expose task dependency CLI commands

### DIFF
--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -49,6 +49,9 @@ def add(
     description: str | None = typer.Option(None, "-D", "--description", help="Task description"),
     epic: int | None = typer.Option(None, "-e", "--epic", help="Add to epic (task ID)"),
     cat: str | None = typer.Option(None, "-c", "--cat", help="Category key (e.g. SEC)"),
+    after: list[int] | None = typer.Option(
+        None, "--after", help="Task IDs this depends on (repeatable)"
+    ),
 ) -> None:
     """Add a task to the work queue.
 
@@ -58,6 +61,7 @@ def add(
         emdx task add "Refactor tests" -D "Split into unit and integration"
         emdx task add "Test task" --epic 510
         emdx task add "Another task" --cat SEC
+        emdx task add "Deploy" --after 10 --after 11
     """
     parent_task_id = None
     epic_key = cat.upper() if cat else None
@@ -72,18 +76,24 @@ def add(
         if not epic_key and parent_task.get("epic_key"):
             epic_key = parent_task["epic_key"]
 
+    depends_on = after if after else None
+
     task_id = tasks.create_task(
         title,
         description=description or "",
         source_doc_id=doc,
         parent_task_id=parent_task_id,
         epic_key=epic_key,
+        depends_on=depends_on,
     )
     msg = f"[green]✅ Task #{task_id}:[/green] {title}"
     if doc:
         msg += f" [dim](doc #{doc})[/dim]"
     if epic_key:
         msg += f" [dim]({epic_key})[/dim]"
+    if depends_on:
+        dep_ids = " ".join(f"#{d}" for d in depends_on)
+        msg += f" [dim](after {dep_ids})[/dim]"
     console.print(msg)
 
 
@@ -458,3 +468,185 @@ def delete(
 
     tasks.delete_task(task_id)
     console.print(f"[green]✅ Deleted #{task_id}[/green]")
+
+
+# --- Task dependency subcommands ---
+
+dep_app = typer.Typer(help="Manage task dependencies")
+app.add_typer(dep_app, name="dep")
+
+
+@dep_app.command("add")
+def dep_add(
+    task_id: int = typer.Argument(..., help="Task that needs the dependency done first"),
+    depends_on: int = typer.Argument(..., help="Task that must be completed first"),
+) -> None:
+    """Add a dependency between tasks.
+
+    TASK_ID will be blocked until DEPENDS_ON is done.
+
+    Examples:
+        emdx task dep add 5 3    # task 5 depends on task 3
+    """
+    for tid in (task_id, depends_on):
+        if not tasks.get_task(tid):
+            console.print(f"[red]Task #{tid} not found[/red]")
+            raise typer.Exit(1)
+
+    ok = tasks.add_dependency(task_id, depends_on)
+    if ok:
+        console.print(f"[green]✅ #{task_id} now depends on #{depends_on}[/green]")
+    else:
+        console.print("[red]Cannot add: dependency already exists or would create a cycle[/red]")
+        raise typer.Exit(1)
+
+
+@dep_app.command("rm")
+def dep_rm(
+    task_id: int = typer.Argument(..., help="Task to remove dependency from"),
+    depends_on: int = typer.Argument(..., help="Dependency to remove"),
+) -> None:
+    """Remove a dependency between tasks.
+
+    Examples:
+        emdx task dep rm 5 3    # task 5 no longer depends on task 3
+    """
+    ok = tasks.remove_dependency(task_id, depends_on)
+    if ok:
+        console.print(f"[green]✅ Removed: #{task_id} no longer depends on #{depends_on}[/green]")
+    else:
+        console.print("[yellow]No such dependency[/yellow]")
+
+
+@dep_app.command("list")
+def dep_list(
+    task_id: int = typer.Argument(..., help="Task ID"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """Show dependencies for a task.
+
+    Lists what this task depends on (blockers) and what depends on it (blocked by this).
+
+    Examples:
+        emdx task dep list 5
+    """
+    task = tasks.get_task(task_id)
+    if not task:
+        console.print(f"[red]Task #{task_id} not found[/red]")
+        raise typer.Exit(1)
+
+    deps = tasks.get_dependencies(task_id)
+    dependents = tasks.get_dependents(task_id)
+
+    if json_output:
+
+        def _dep_summary(d: TaskDict) -> dict[str, str | int]:
+            return {"id": d["id"], "title": d["title"], "status": d["status"]}
+
+        print_json(
+            {
+                "task_id": task_id,
+                "depends_on": [_dep_summary(d) for d in deps],
+                "blocks": [_dep_summary(d) for d in dependents],
+            }
+        )
+        return
+
+    if not deps and not dependents:
+        console.print(f"[yellow]#{task_id} has no dependencies[/yellow]")
+        return
+
+    if deps:
+        console.print(f"[bold]#{task_id} depends on:[/bold]")
+        for d in deps:
+            icon = ICONS.get(d["status"], "?")
+            console.print(f"  {icon} #{d['id']} {d['title']}")
+
+    if dependents:
+        console.print(f"[bold]#{task_id} blocks:[/bold]")
+        for d in dependents:
+            icon = ICONS.get(d["status"], "?")
+            console.print(f"  {icon} #{d['id']} {d['title']}")
+
+
+@app.command()
+def chain(
+    task_id: int = typer.Argument(..., help="Task ID to trace"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """Show the full dependency chain for a task.
+
+    Traces upward through blockers and downward through dependents
+    to show the complete dependency graph rooted at this task.
+
+    Examples:
+        emdx task chain 5
+    """
+    task = tasks.get_task(task_id)
+    if not task:
+        console.print(f"[red]Task #{task_id} not found[/red]")
+        raise typer.Exit(1)
+
+    # Walk upward: everything this task is waiting on (transitively)
+    upstream = _walk_deps(task_id, direction="up")
+    # Walk downward: everything waiting on this task (transitively)
+    downstream = _walk_deps(task_id, direction="down")
+
+    if json_output:
+
+        def _task_summary(t: TaskDict) -> dict[str, str | int]:
+            return {"id": t["id"], "title": t["title"], "status": t["status"]}
+
+        print_json(
+            {
+                "task": _task_summary(task),
+                "upstream": [_task_summary(t) for t in upstream],
+                "downstream": [_task_summary(t) for t in downstream],
+            }
+        )
+        return
+
+    icon = ICONS.get(task["status"], "?")
+    console.print(f"\n[bold]Chain for #{task_id}: {task['title']}[/bold]")
+
+    if upstream:
+        console.print("\n[bold]Upstream (must finish first):[/bold]")
+        for t in upstream:
+            t_icon = ICONS.get(t["status"], "?")
+            console.print(f"  {t_icon} #{t['id']} {t['title']}")
+
+    console.print(f"\n  [bold cyan]{icon} #{task_id} {task['title']}[/bold cyan]  ← you are here")
+
+    if downstream:
+        console.print("\n[bold]Downstream (waiting on this):[/bold]")
+        for t in downstream:
+            t_icon = ICONS.get(t["status"], "?")
+            console.print(f"  {t_icon} #{t['id']} {t['title']}")
+
+    if not upstream and not downstream:
+        console.print("\n[yellow]No dependencies in either direction[/yellow]")
+
+
+def _walk_deps(task_id: int, direction: str) -> list[TaskDict]:
+    """BFS walk of dependency graph. Returns tasks in traversal order."""
+    visited: set[int] = set()
+    queue = [task_id]
+    result: list[TaskDict] = []
+
+    while queue:
+        current = queue.pop(0)
+        if current in visited:
+            continue
+        visited.add(current)
+
+        if direction == "up":
+            neighbors = tasks.get_dependencies(current)
+        else:
+            neighbors = tasks.get_dependents(current)
+
+        for n in neighbors:
+            if n["id"] not in visited:
+                result.append(n)
+                queue.append(n["id"])
+
+    return result

--- a/emdx/models/tasks.py
+++ b/emdx/models/tasks.py
@@ -403,6 +403,17 @@ def add_dependency(task_id: int, depends_on: int) -> bool:
             return False
 
 
+def remove_dependency(task_id: int, depends_on: int) -> bool:
+    """Remove a dependency. Returns True if it existed."""
+    with db.get_connection() as conn:
+        cursor = conn.execute(
+            "DELETE FROM task_deps WHERE task_id = ? AND depends_on = ?",
+            (task_id, depends_on),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
 def _would_cycle(task_id: int, new_dep: int) -> bool:
     """Check if adding dep would create cycle (DFS)."""
     visited, stack = set(), [new_dep]

--- a/tests/test_task_commands.py
+++ b/tests/test_task_commands.py
@@ -32,6 +32,7 @@ class TestTaskAdd:
             source_doc_id=None,
             parent_task_id=None,
             epic_key=None,
+            depends_on=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
@@ -49,6 +50,7 @@ class TestTaskAdd:
             source_doc_id=42,
             parent_task_id=None,
             epic_key=None,
+            depends_on=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
@@ -65,6 +67,7 @@ class TestTaskAdd:
             source_doc_id=99,
             parent_task_id=None,
             epic_key=None,
+            depends_on=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
@@ -83,6 +86,7 @@ class TestTaskAdd:
             source_doc_id=None,
             parent_task_id=None,
             epic_key=None,
+            depends_on=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
@@ -96,14 +100,13 @@ class TestTaskAdd:
             source_doc_id=None,
             parent_task_id=None,
             epic_key=None,
+            depends_on=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
     def test_add_task_with_all_options(self, mock_tasks):
         mock_tasks.create_task.return_value = 6
-        result = runner.invoke(
-            app, ["add", "Full task", "-d", "10", "-D", "Full description"]
-        )
+        result = runner.invoke(app, ["add", "Full task", "-d", "10", "-D", "Full description"])
         assert result.exit_code == 0
         out = _out(result)
         assert "Task #6" in out
@@ -114,6 +117,7 @@ class TestTaskAdd:
             source_doc_id=10,
             parent_task_id=None,
             epic_key=None,
+            depends_on=None,
         )
 
     def test_add_task_requires_title(self):
@@ -217,12 +221,21 @@ class TestTaskList:
     @patch("emdx.commands.tasks.tasks")
     def test_list_shows_tasks(self, mock_tasks):
         mock_tasks.list_tasks.return_value = [
-            {"id": 1, "title": "Open task", "status": "open",
-             "epic_key": None, "epic_seq": None},
-            {"id": 2, "title": "Active task", "status": "active",
-             "epic_key": None, "epic_seq": None},
-            {"id": 3, "title": "Blocked task", "status": "blocked",
-             "epic_key": None, "epic_seq": None},
+            {"id": 1, "title": "Open task", "status": "open", "epic_key": None, "epic_seq": None},
+            {
+                "id": 2,
+                "title": "Active task",
+                "status": "active",
+                "epic_key": None,
+                "epic_seq": None,
+            },
+            {
+                "id": 3,
+                "title": "Blocked task",
+                "status": "blocked",
+                "epic_key": None,
+                "epic_seq": None,
+            },
         ]
         mock_tasks.get_dependencies.return_value = []
         result = runner.invoke(app, ["list"])
@@ -236,8 +249,7 @@ class TestTaskList:
     @patch("emdx.commands.tasks.tasks")
     def test_list_shows_status_text(self, mock_tasks):
         mock_tasks.list_tasks.return_value = [
-            {"id": 1, "title": "Task", "status": "active",
-             "epic_key": None, "epic_seq": None},
+            {"id": 1, "title": "Task", "status": "active", "epic_key": None, "epic_seq": None},
         ]
         result = runner.invoke(app, ["list"])
         out = _out(result)
@@ -246,8 +258,13 @@ class TestTaskList:
     @patch("emdx.commands.tasks.tasks")
     def test_list_shows_epic_label_and_strips_prefix(self, mock_tasks):
         mock_tasks.list_tasks.return_value = [
-            {"id": 1, "title": "SEC-1: Harden auth", "status": "open",
-             "epic_key": "SEC", "epic_seq": 1},
+            {
+                "id": 1,
+                "title": "SEC-1: Harden auth",
+                "status": "open",
+                "epic_key": "SEC",
+                "epic_seq": 1,
+            },
         ]
         result = runner.invoke(app, ["list"])
         out = _out(result)
@@ -261,8 +278,11 @@ class TestTaskList:
         result = runner.invoke(app, ["list"])
         assert result.exit_code == 0
         mock_tasks.list_tasks.assert_called_once_with(
-            status=["open", "active", "blocked"], limit=20, exclude_delegate=True,
-            epic_key=None, parent_task_id=None,
+            status=["open", "active", "blocked"],
+            limit=20,
+            exclude_delegate=True,
+            epic_key=None,
+            parent_task_id=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
@@ -271,8 +291,11 @@ class TestTaskList:
         result = runner.invoke(app, ["list", "--done"])
         assert result.exit_code == 0
         mock_tasks.list_tasks.assert_called_once_with(
-            status=None, limit=20, exclude_delegate=True,
-            epic_key=None, parent_task_id=None,
+            status=None,
+            limit=20,
+            exclude_delegate=True,
+            epic_key=None,
+            parent_task_id=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
@@ -281,8 +304,11 @@ class TestTaskList:
         result = runner.invoke(app, ["list", "--all"])
         assert result.exit_code == 0
         mock_tasks.list_tasks.assert_called_once_with(
-            status=["open", "active", "blocked"], limit=20, exclude_delegate=False,
-            epic_key=None, parent_task_id=None,
+            status=["open", "active", "blocked"],
+            limit=20,
+            exclude_delegate=False,
+            epic_key=None,
+            parent_task_id=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
@@ -291,8 +317,11 @@ class TestTaskList:
         result = runner.invoke(app, ["list", "-a"])
         assert result.exit_code == 0
         mock_tasks.list_tasks.assert_called_once_with(
-            status=["open", "active", "blocked"], limit=20, exclude_delegate=False,
-            epic_key=None, parent_task_id=None,
+            status=["open", "active", "blocked"],
+            limit=20,
+            exclude_delegate=False,
+            epic_key=None,
+            parent_task_id=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
@@ -301,8 +330,11 @@ class TestTaskList:
         result = runner.invoke(app, ["list", "--status", "open"])
         assert result.exit_code == 0
         mock_tasks.list_tasks.assert_called_once_with(
-            status=["open"], limit=20, exclude_delegate=True,
-            epic_key=None, parent_task_id=None,
+            status=["open"],
+            limit=20,
+            exclude_delegate=True,
+            epic_key=None,
+            parent_task_id=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
@@ -311,8 +343,11 @@ class TestTaskList:
         result = runner.invoke(app, ["list", "-s", "open,active"])
         assert result.exit_code == 0
         mock_tasks.list_tasks.assert_called_once_with(
-            status=["open", "active"], limit=20, exclude_delegate=True,
-            epic_key=None, parent_task_id=None,
+            status=["open", "active"],
+            limit=20,
+            exclude_delegate=True,
+            epic_key=None,
+            parent_task_id=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
@@ -321,8 +356,11 @@ class TestTaskList:
         result = runner.invoke(app, ["list", "--limit", "5"])
         assert result.exit_code == 0
         mock_tasks.list_tasks.assert_called_once_with(
-            status=["open", "active", "blocked"], limit=5, exclude_delegate=True,
-            epic_key=None, parent_task_id=None,
+            status=["open", "active", "blocked"],
+            limit=5,
+            exclude_delegate=True,
+            epic_key=None,
+            parent_task_id=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
@@ -331,21 +369,20 @@ class TestTaskList:
         result = runner.invoke(app, ["list", "-n", "10"])
         assert result.exit_code == 0
         mock_tasks.list_tasks.assert_called_once_with(
-            status=["open", "active", "blocked"], limit=10, exclude_delegate=True,
-            epic_key=None, parent_task_id=None,
+            status=["open", "active", "blocked"],
+            limit=10,
+            exclude_delegate=True,
+            epic_key=None,
+            parent_task_id=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
     def test_list_displays_status_as_text(self, mock_tasks):
         mock_tasks.list_tasks.return_value = [
-            {"id": 1, "title": "Open", "status": "open",
-             "epic_key": None, "epic_seq": None},
-            {"id": 2, "title": "Active", "status": "active",
-             "epic_key": None, "epic_seq": None},
-            {"id": 3, "title": "Done", "status": "done",
-             "epic_key": None, "epic_seq": None},
-            {"id": 4, "title": "Failed", "status": "failed",
-             "epic_key": None, "epic_seq": None},
+            {"id": 1, "title": "Open", "status": "open", "epic_key": None, "epic_seq": None},
+            {"id": 2, "title": "Active", "status": "active", "epic_key": None, "epic_seq": None},
+            {"id": 3, "title": "Done", "status": "done", "epic_key": None, "epic_seq": None},
+            {"id": 4, "title": "Failed", "status": "failed", "epic_key": None, "epic_seq": None},
         ]
         result = runner.invoke(app, ["list"])
         assert result.exit_code == 0
@@ -357,13 +394,9 @@ class TestTaskList:
 
     @patch("emdx.commands.tasks.tasks")
     def test_list_does_not_truncate_title(self, mock_tasks):
-        long_title = (
-            "This is a very long task title that exceeds fifty"
-            " characters by quite a bit"
-        )
+        long_title = "This is a very long task title that exceeds fifty characters by quite a bit"
         mock_tasks.list_tasks.return_value = [
-            {"id": 1, "title": long_title, "status": "open",
-             "epic_key": None, "epic_seq": None},
+            {"id": 1, "title": long_title, "status": "open", "epic_key": None, "epic_seq": None},
         ]
         result = runner.invoke(app, ["list"])
         out = _out(result)
@@ -429,10 +462,16 @@ class TestTaskView:
     @patch("emdx.commands.tasks.tasks")
     def test_view_shows_basic_info(self, mock_tasks):
         mock_tasks.get_task.return_value = {
-            "id": 42, "title": "Fix auth bug", "status": "open",
+            "id": 42,
+            "title": "Fix auth bug",
+            "status": "open",
             "description": "The auth middleware has a race condition",
-            "epic_key": None, "epic_seq": None, "parent_task_id": None,
-            "source_doc_id": None, "priority": 3, "created_at": "2026-01-15",
+            "epic_key": None,
+            "epic_seq": None,
+            "parent_task_id": None,
+            "source_doc_id": None,
+            "priority": 3,
+            "created_at": "2026-01-15",
         }
         mock_tasks.get_dependencies.return_value = []
         mock_tasks.get_dependents.return_value = []
@@ -450,10 +489,17 @@ class TestTaskView:
     @patch("emdx.commands.tasks.tasks")
     def test_view_shows_epic_label(self, mock_tasks, mock_get_doc):
         mock_tasks.get_task.return_value = {
-            "id": 10, "title": "SEC-1: Harden auth", "status": "active",
-            "description": "", "epic_key": "SEC", "epic_seq": 1,
-            "parent_task_id": 500, "source_doc_id": 99, "output_doc_id": None,
-            "priority": 1, "created_at": "2026-01-15",
+            "id": 10,
+            "title": "SEC-1: Harden auth",
+            "status": "active",
+            "description": "",
+            "epic_key": "SEC",
+            "epic_seq": 1,
+            "parent_task_id": 500,
+            "source_doc_id": 99,
+            "output_doc_id": None,
+            "priority": 1,
+            "created_at": "2026-01-15",
         }
         mock_tasks.get_dependencies.return_value = []
         mock_tasks.get_dependents.return_value = []
@@ -473,9 +519,15 @@ class TestTaskView:
     @patch("emdx.commands.tasks.tasks")
     def test_view_shows_dependencies(self, mock_tasks):
         mock_tasks.get_task.return_value = {
-            "id": 5, "title": "Task with deps", "status": "blocked",
-            "description": "", "epic_key": None, "epic_seq": None,
-            "parent_task_id": None, "source_doc_id": None, "priority": 3,
+            "id": 5,
+            "title": "Task with deps",
+            "status": "blocked",
+            "description": "",
+            "epic_key": None,
+            "epic_seq": None,
+            "parent_task_id": None,
+            "source_doc_id": None,
+            "priority": 3,
             "created_at": "2026-01-15",
         }
         mock_tasks.get_dependencies.return_value = [
@@ -498,9 +550,15 @@ class TestTaskView:
     @patch("emdx.commands.tasks.tasks")
     def test_view_shows_work_log(self, mock_tasks):
         mock_tasks.get_task.return_value = {
-            "id": 7, "title": "Some task", "status": "active",
-            "description": "", "epic_key": None, "epic_seq": None,
-            "parent_task_id": None, "source_doc_id": None, "priority": 3,
+            "id": 7,
+            "title": "Some task",
+            "status": "active",
+            "description": "",
+            "epic_key": None,
+            "epic_seq": None,
+            "parent_task_id": None,
+            "source_doc_id": None,
+            "priority": 3,
             "created_at": "2026-01-15",
         }
         mock_tasks.get_dependencies.return_value = []
@@ -700,3 +758,229 @@ class TestTaskBlocked:
     def test_blocked_requires_task_id(self):
         result = runner.invoke(app, ["blocked"])
         assert result.exit_code != 0
+
+
+class TestTaskAddWithAfter:
+    """Tests for --after flag on task add."""
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_add_with_single_after(self, mock_tasks):
+        mock_tasks.create_task.return_value = 10
+        result = runner.invoke(app, ["add", "Deploy", "--after", "5"])
+        assert result.exit_code == 0
+        out = _out(result)
+        assert "Task #10" in out
+        assert "after #5" in out
+        mock_tasks.create_task.assert_called_once_with(
+            "Deploy",
+            description="",
+            source_doc_id=None,
+            parent_task_id=None,
+            epic_key=None,
+            depends_on=[5],
+        )
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_add_with_multiple_after(self, mock_tasks):
+        mock_tasks.create_task.return_value = 20
+        result = runner.invoke(app, ["add", "Release", "--after", "10", "--after", "11"])
+        assert result.exit_code == 0
+        out = _out(result)
+        assert "Task #20" in out
+        assert "#10" in out
+        assert "#11" in out
+        mock_tasks.create_task.assert_called_once_with(
+            "Release",
+            description="",
+            source_doc_id=None,
+            parent_task_id=None,
+            epic_key=None,
+            depends_on=[10, 11],
+        )
+
+
+class TestTaskDepAdd:
+    """Tests for task dep add command."""
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_dep_add_success(self, mock_tasks):
+        mock_tasks.get_task.return_value = {"id": 5, "title": "Task"}
+        mock_tasks.add_dependency.return_value = True
+        result = runner.invoke(app, ["dep", "add", "5", "3"])
+        assert result.exit_code == 0
+        out = _out(result)
+        assert "#5" in out
+        assert "#3" in out
+        mock_tasks.add_dependency.assert_called_once_with(5, 3)
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_dep_add_cycle(self, mock_tasks):
+        mock_tasks.get_task.return_value = {"id": 1, "title": "Task"}
+        mock_tasks.add_dependency.return_value = False
+        result = runner.invoke(app, ["dep", "add", "5", "3"])
+        assert result.exit_code == 1
+        assert "cycle" in _out(result).lower() or "Cannot add" in _out(result)
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_dep_add_task_not_found(self, mock_tasks):
+        mock_tasks.get_task.return_value = None
+        result = runner.invoke(app, ["dep", "add", "999", "1"])
+        assert result.exit_code == 1
+        assert "not found" in _out(result)
+
+    def test_dep_add_requires_both_args(self):
+        result = runner.invoke(app, ["dep", "add", "5"])
+        assert result.exit_code != 0
+
+
+class TestTaskDepRm:
+    """Tests for task dep rm command."""
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_dep_rm_success(self, mock_tasks):
+        mock_tasks.remove_dependency.return_value = True
+        result = runner.invoke(app, ["dep", "rm", "5", "3"])
+        assert result.exit_code == 0
+        out = _out(result)
+        assert "#5" in out
+        assert "#3" in out
+        mock_tasks.remove_dependency.assert_called_once_with(5, 3)
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_dep_rm_not_found(self, mock_tasks):
+        mock_tasks.remove_dependency.return_value = False
+        result = runner.invoke(app, ["dep", "rm", "5", "3"])
+        assert result.exit_code == 0
+        assert "No such dependency" in _out(result)
+
+
+class TestTaskDepList:
+    """Tests for task dep list command."""
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_dep_list_shows_both_directions(self, mock_tasks):
+        mock_tasks.get_task.return_value = {"id": 5, "title": "Middle task"}
+        mock_tasks.get_dependencies.return_value = [
+            {"id": 3, "title": "Blocker", "status": "active"},
+        ]
+        mock_tasks.get_dependents.return_value = [
+            {"id": 8, "title": "Downstream", "status": "open"},
+        ]
+        result = runner.invoke(app, ["dep", "list", "5"])
+        assert result.exit_code == 0
+        out = _out(result)
+        assert "#5 depends on:" in out
+        assert "#3" in out
+        assert "Blocker" in out
+        assert "#5 blocks:" in out
+        assert "#8" in out
+        assert "Downstream" in out
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_dep_list_no_deps(self, mock_tasks):
+        mock_tasks.get_task.return_value = {"id": 1, "title": "Solo task"}
+        mock_tasks.get_dependencies.return_value = []
+        mock_tasks.get_dependents.return_value = []
+        result = runner.invoke(app, ["dep", "list", "1"])
+        assert result.exit_code == 0
+        assert "no dependencies" in _out(result)
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_dep_list_not_found(self, mock_tasks):
+        mock_tasks.get_task.return_value = None
+        result = runner.invoke(app, ["dep", "list", "999"])
+        assert result.exit_code == 1
+        assert "not found" in _out(result)
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_dep_list_json(self, mock_tasks):
+        mock_tasks.get_task.return_value = {"id": 5, "title": "Task"}
+        mock_tasks.get_dependencies.return_value = [
+            {"id": 3, "title": "Dep", "status": "done"},
+        ]
+        mock_tasks.get_dependents.return_value = []
+        result = runner.invoke(app, ["dep", "list", "5", "--json"])
+        assert result.exit_code == 0
+        import json
+
+        data = json.loads(result.stdout)
+        assert data["task_id"] == 5
+        assert len(data["depends_on"]) == 1
+        assert data["depends_on"][0]["id"] == 3
+        assert data["blocks"] == []
+
+
+class TestTaskChain:
+    """Tests for task chain command."""
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_chain_shows_upstream_and_downstream(self, mock_tasks):
+        mock_tasks.get_task.return_value = {
+            "id": 5,
+            "title": "Middle task",
+            "status": "open",
+        }
+        # Walk up: task 5 depends on 3
+        mock_tasks.get_dependencies.side_effect = lambda tid: (
+            [{"id": 3, "title": "First", "status": "done"}] if tid == 5 else []
+        )
+        # Walk down: task 8 depends on 5
+        mock_tasks.get_dependents.side_effect = lambda tid: (
+            [{"id": 8, "title": "Last", "status": "open"}] if tid == 5 else []
+        )
+        result = runner.invoke(app, ["chain", "5"])
+        assert result.exit_code == 0
+        out = _out(result)
+        assert "Chain for #5" in out
+        assert "Upstream" in out
+        assert "#3" in out
+        assert "First" in out
+        assert "you are here" in out
+        assert "Downstream" in out
+        assert "#8" in out
+        assert "Last" in out
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_chain_no_deps(self, mock_tasks):
+        mock_tasks.get_task.return_value = {
+            "id": 1,
+            "title": "Solo task",
+            "status": "open",
+        }
+        mock_tasks.get_dependencies.return_value = []
+        mock_tasks.get_dependents.return_value = []
+        result = runner.invoke(app, ["chain", "1"])
+        assert result.exit_code == 0
+        out = _out(result)
+        assert "No dependencies in either direction" in out
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_chain_not_found(self, mock_tasks):
+        mock_tasks.get_task.return_value = None
+        result = runner.invoke(app, ["chain", "999"])
+        assert result.exit_code == 1
+        assert "not found" in _out(result)
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_chain_json(self, mock_tasks):
+        mock_tasks.get_task.return_value = {
+            "id": 5,
+            "title": "Middle",
+            "status": "open",
+        }
+        mock_tasks.get_dependencies.side_effect = lambda tid: (
+            [{"id": 3, "title": "Up", "status": "done"}] if tid == 5 else []
+        )
+        mock_tasks.get_dependents.side_effect = lambda tid: (
+            [{"id": 8, "title": "Down", "status": "open"}] if tid == 5 else []
+        )
+        result = runner.invoke(app, ["chain", "5", "--json"])
+        assert result.exit_code == 0
+        import json
+
+        data = json.loads(result.stdout)
+        assert data["task"]["id"] == 5
+        assert len(data["upstream"]) == 1
+        assert data["upstream"][0]["id"] == 3
+        assert len(data["downstream"]) == 1
+        assert data["downstream"][0]["id"] == 8


### PR DESCRIPTION
Wire up the existing task dependency model layer to the CLI:
- `--after` flag on `task add` for setting deps at creation time
- `task dep add/rm/list` subcommands for managing dependencies
- `task chain` command for viewing full transitive dependency graph
- `remove_dependency()` model function for unlinking deps

https://claude.ai/code/session_01Vu7dQGNr4kDw7tiTHDbtaC