### PR TITLE
docs: README rewrite options — pick your favorite

### DIFF
--- a/README-v1-compound.md
+++ b/README-v1-compound.md
@@ -1,0 +1,190 @@
+# emdx
+
+[![Version](https://img.shields.io/badge/version-0.19.0-blue.svg)](https://github.com/arockwell/emdx/releases)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
+
+**AI sessions forget. emdx compounds.**
+
+Every Claude session starts from zero — your research, decisions, and context vanish when the window closes. emdx is a local knowledge base that makes AI sessions cumulative. Save findings, dispatch parallel agents, track tasks, and start the next session exactly where you left off.
+
+## See it in action
+
+Three sessions. Each one picks up where the last left off.
+
+**Session 1 — Research and save**
+
+```bash
+# Claude investigates an auth bug and saves what it finds
+$ emdx save "Token refresh fails when clock skew > 30s..." --title "Auth Bug Analysis"
+✅ Saved as #42: Auth Bug Analysis
+
+# Fire off parallel agents for deeper analysis
+$ emdx delegate "audit auth for race conditions" \
+                "review error handling patterns" \
+                "check input validation coverage"
+📋 Saved as #43, #44, #45
+```
+
+**Session 2 — Pick up context, delegate deeper**
+
+```bash
+# New session. Claude checks what exists.
+$ emdx prime
+📋 Ready tasks: 0  |  Recent: #45, #44, #43, #42
+
+# Reads the audit results, creates tasks
+$ emdx task add "Fix token refresh race condition" --cat FIX
+$ emdx task add "Add clock skew tolerance" --cat FEAT
+$ emdx task dep add 2 1   # FEAT depends on FIX
+
+# Chains previous results into a PR
+$ emdx delegate --doc 43 --pr "fix the token refresh race condition"
+🔀 PR #87: fix the token refresh race condition
+```
+
+**Session 3 — Ship and summarize**
+
+```bash
+# Everything from sessions 1 and 2 is waiting
+$ emdx prime
+📋 Ready tasks: 1  |  In-progress: 0  |  Recent: PR #87 merged
+
+$ emdx task done FIX-1
+$ emdx task ready          # FEAT-2 is now unblocked
+$ emdx briefing --save     # AI summary of what happened
+```
+
+Each session builds on the last. Research compounds. Context never dies.
+
+## Install
+
+```bash
+uv tool install emdx    # or: pip install emdx
+emdx --help
+```
+
+## Save
+
+Files, notes, piped command output — anything you save becomes searchable.
+
+```bash
+$ emdx save --file meeting-notes.md
+✅ Saved as #12: meeting-notes
+
+$ emdx save "the auth bug is in token refresh" --title "Auth Bug"
+✅ Saved as #13: Auth Bug
+
+$ docker logs api --since 1h | emdx save --title "API errors"
+✅ Saved as #14: API errors
+
+$ emdx tag 13 bugfix security
+$ emdx find "auth"
+$ emdx find --tags "security"
+```
+
+## Find
+
+Keyword search, semantic search, or ask a question directly.
+
+```bash
+$ emdx find "auth"                                    # keyword (FTS5)
+$ emdx find "how does rate limiting work?" --mode semantic  # conceptual
+$ emdx find --ask "What did we decide about the API redesign?"  # RAG Q&A
+$ emdx find --context "auth" | claude                 # pipe context to Claude
+$ emdx find --recent 10                               # recently accessed
+```
+
+## Delegate
+
+Parallel agents that save results back to your knowledge base.
+
+```bash
+# Single task
+$ emdx delegate "audit auth for vulnerabilities"
+📋 Saved as #43: Delegate: audit auth...
+
+# Parallel (up to 10)
+$ emdx delegate "check auth" "review tests" "scan for XSS"
+
+# Synthesize parallel results into one doc
+$ emdx delegate --synthesize "analyze auth" "analyze api" "analyze db"
+📋 Saved as #60: Synthesis: analyze auth, analyze api, analyze db
+
+# Feed previous results into new tasks
+$ emdx delegate --doc 60 "write an action plan based on this analysis"
+
+# Code changes — isolated worktree, auto-PR
+$ emdx delegate --pr "fix the auth bug"
+🔀 PR #88: fix the auth bug
+
+# Doc context + PR
+$ emdx delegate --doc 43 --pr "implement fixes from this audit"
+```
+
+## Track
+
+Tasks with categories, epics, and dependencies.
+
+```bash
+$ emdx task add "Fix token refresh" --cat FIX
+$ emdx task add "Add rate limiting" --cat FEAT --epic 42
+$ emdx task dep add 2 1                # task 2 depends on task 1
+$ emdx task chain 1 2 3 4              # wire up: 1→2→3→4
+$ emdx task ready                      # show unblocked tasks
+$ emdx task active FIX-1               # prefixed IDs work everywhere
+$ emdx task done FIX-1
+```
+
+## Explore and maintain
+
+Your knowledge base gets smarter the more you use it.
+
+```bash
+$ emdx explore                         # topic map of your KB
+$ emdx explore --gaps                  # coverage gaps and stale areas
+$ emdx briefing                        # what happened in the last 24h
+$ emdx briefing --save                 # AI summary, persisted to KB
+$ emdx maintain compact --dry-run      # find near-duplicate docs
+$ emdx maintain link --all             # auto-link related documents
+$ emdx maintain index                  # build semantic search index
+```
+
+## Session workflow
+
+```bash
+$ emdx prime              # start here — full context from last session
+$ emdx task ready          # what's unblocked
+# ... do work ...
+$ emdx briefing --save     # end here — summarize what happened
+```
+
+## Quick reference
+
+| I want to... | Command |
+|---|---|
+| Save a file | `emdx save --file doc.md` |
+| Save a note | `emdx save "text" --title "Title"` |
+| Find by keyword | `emdx find "query"` |
+| Find by meaning | `emdx find "concept" --mode semantic` |
+| Ask a question | `emdx find --ask "question"` |
+| Pipe context to Claude | `emdx find --context "topic" \| claude` |
+| Run an agent | `emdx delegate "task"` |
+| Run agents in parallel | `emdx delegate "t1" "t2" "t3"` |
+| Agent makes a PR | `emdx delegate --pr "fix the bug"` |
+| Add a task | `emdx task add "title" --cat FEAT` |
+| See ready tasks | `emdx task ready` |
+| Task dependencies | `emdx task dep add 2 1` |
+| What happened today | `emdx briefing` |
+| Topic map | `emdx explore` |
+| TUI browser | `emdx gui` |
+
+## Documentation
+
+- [CLI Reference](docs/cli-api.md) — Complete command documentation
+- [Architecture](docs/architecture.md) — System design
+- [Development Setup](docs/development-setup.md) — Contributing guide
+
+## License
+
+MIT License — see LICENSE file.

--- a/README-v2-replaces.md
+++ b/README-v2-replaces.md
@@ -1,0 +1,164 @@
+# emdx
+
+[![Version](https://img.shields.io/badge/version-0.19.0-blue.svg)](https://github.com/arockwell/emdx/releases)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
+
+**One CLI replaces four tool categories.**
+
+| You used to need | emdx |
+|---|---|
+| **Notes app** (Notion, Obsidian) | `emdx save`, `emdx find`, `emdx tag` |
+| **Task tracker** (Linear, GitHub Issues) | `emdx task`, `emdx task dep`, `emdx task epic` |
+| **RAG pipeline** (LangChain, custom scripts) | `emdx find --mode semantic`, `emdx find --ask` |
+| **Agent orchestrator** (CrewAI, AutoGen) | `emdx delegate`, `emdx delegate --pr` |
+
+The difference: these four tools share a single knowledge base. Save a research note → it becomes searchable context → an agent picks it up → its output creates a task → the task drives a PR. One data store, local SQLite, nothing vanishes.
+
+## See it in action
+
+```bash
+# Notes app — save anything, find it instantly
+$ emdx save "Token refresh fails when clock skew > 30s..." --title "Auth Bug"
+✅ Saved as #42: Auth Bug
+$ emdx tag 42 bugfix security
+$ emdx find "auth"
+
+# Agent orchestrator — parallel agents, results auto-saved
+$ emdx delegate "audit auth" "review error handling" "check validation"
+📋 Saved as #43, #44, #45
+
+# RAG pipeline — semantic search and Q&A, zero config
+$ emdx find "how does token refresh work?" --mode semantic
+$ emdx find --ask "What vulnerabilities did the auth audit find?"
+
+# Task tracker — epics, categories, dependencies
+$ emdx task add "Fix token refresh race condition" --cat FIX
+$ emdx task add "Add clock skew tolerance" --cat FEAT
+$ emdx task dep add FEAT-2 FIX-1       # FEAT depends on FIX
+$ emdx task ready                       # show what's unblocked
+
+# The loop closes — chain agent output into a PR
+$ emdx delegate --doc 43 --pr "fix the issues from this audit"
+🔀 PR #87: fix the issues from this audit
+```
+
+Every session compounds on the last. `emdx prime` loads full context — ready tasks, recent research, in-progress work. No re-explaining, no starting from scratch.
+
+## Install
+
+```bash
+uv tool install emdx    # or: pip install emdx
+emdx --help
+```
+
+## Save
+
+```bash
+$ emdx save --file meeting-notes.md
+✅ Saved as #12: meeting-notes
+
+$ emdx save "quick note about the API" --title "API Note"
+✅ Saved as #13: API Note
+
+$ docker logs api --since 1h | emdx save --title "API errors"
+✅ Saved as #14: API errors
+
+$ emdx tag 13 analysis active
+```
+
+## Find
+
+```bash
+$ emdx find "auth"                                         # keyword (FTS5)
+$ emdx find "how does rate limiting work?" --mode semantic  # conceptual
+$ emdx find --ask "What did we decide about the redesign?" # RAG Q&A
+$ emdx find --context "auth" | claude                      # pipe to Claude
+$ emdx find --tags "security,active"                       # filter by tags
+$ emdx find --recent 10                                    # recently accessed
+```
+
+## Delegate
+
+```bash
+# Single task — results print AND persist
+$ emdx delegate "audit auth for vulnerabilities"
+📋 Saved as #43: Delegate: audit auth...
+
+# Parallel (up to 10)
+$ emdx delegate "check auth" "review tests" "scan for XSS"
+
+# Synthesize into one doc
+$ emdx delegate --synthesize "analyze auth" "analyze api" "analyze db"
+
+# Feed previous results in
+$ emdx delegate --doc 43 "write an action plan from this audit"
+
+# Code changes — isolated worktree, auto-PR
+$ emdx delegate --pr "fix the auth bug"
+🔀 PR #88: fix the auth bug
+```
+
+## Track
+
+```bash
+$ emdx task add "Fix token refresh" --cat FIX
+$ emdx task add "Add rate limiting" --cat FEAT --epic 42
+$ emdx task dep add 2 1                # task 2 depends on task 1
+$ emdx task chain 1 2 3 4              # sequential pipeline: 1→2→3→4
+$ emdx task ready                      # show unblocked tasks
+$ emdx task active FIX-1               # prefixed IDs work everywhere
+$ emdx task done FIX-1
+$ emdx task epic list
+```
+
+## Explore and maintain
+
+```bash
+$ emdx explore                         # topic map of your KB
+$ emdx explore --gaps                  # coverage gaps and stale areas
+$ emdx briefing                        # activity in the last 24h
+$ emdx briefing --save                 # AI-synthesized session summary
+$ emdx maintain compact --dry-run      # find near-duplicate docs
+$ emdx maintain link --all             # auto-link related documents
+$ emdx maintain index                  # build semantic search index
+```
+
+## Session workflow
+
+```bash
+$ emdx prime              # start — full context from last session
+$ emdx task ready          # what's unblocked
+# ... do work ...
+$ emdx briefing --save     # end — summarize what happened
+```
+
+## Quick reference
+
+| I want to... | Command |
+|---|---|
+| Save a file | `emdx save --file doc.md` |
+| Save a note | `emdx save "text" --title "Title"` |
+| Find by keyword | `emdx find "query"` |
+| Find by meaning | `emdx find "concept" --mode semantic` |
+| Ask a question | `emdx find --ask "question"` |
+| Pipe context to Claude | `emdx find --context "topic" \| claude` |
+| Run an agent | `emdx delegate "task"` |
+| Run agents in parallel | `emdx delegate "t1" "t2" "t3"` |
+| Agent makes a PR | `emdx delegate --pr "fix the bug"` |
+| Add a task | `emdx task add "title" --cat FEAT` |
+| Task dependencies | `emdx task dep add 2 1` |
+| See ready tasks | `emdx task ready` |
+| What happened today | `emdx briefing` |
+| Topic map | `emdx explore` |
+| TUI browser | `emdx gui` |
+
+## Documentation
+
+- [CLI Reference](docs/cli-api.md) — Complete command documentation
+- [Architecture](docs/architecture.md) — System design
+- [Development Setup](docs/development-setup.md) — Contributing guide
+
+## License
+
+MIT License — see LICENSE file.

--- a/README-v3-bold.md
+++ b/README-v3-bold.md
@@ -1,0 +1,151 @@
+# emdx
+
+[![Version](https://img.shields.io/badge/version-0.19.0-blue.svg)](https://github.com/arockwell/emdx/releases)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
+
+**Claude sessions are stateless. Your work shouldn't be.**
+
+You spend an hour with Claude mapping a gnarly auth bug — call chains, root causes, three related issues. Session ends. Tomorrow you open a new chat. "Can you look at the auth module?" It reads the same files. Asks the same questions. Your hour is gone.
+
+emdx fixes this. Save findings, fire off parallel agents, track what's left. Everything lives in local SQLite. Next session, run `emdx prime` — Claude sees yesterday's work and picks up where it left off. Half the PRs in this repo were opened by emdx agents.
+
+```bash
+# Save research — it persists across sessions
+$ emdx save "Token refresh fails when clock skew > 30s..." --title "Auth Bug Analysis"
+✅ Saved as #42: Auth Bug Analysis
+
+# Fire off 3 agents in parallel — results auto-save to the KB
+$ emdx delegate "audit auth for vulnerabilities" \
+                "review error handling patterns" \
+                "check input validation coverage"
+📋 Saved as #43, #44, #45
+
+# Track what needs doing
+$ emdx task add "Fix token refresh race condition" --cat FIX
+$ emdx task add "Add clock skew tolerance" --cat FEAT
+$ emdx task dep add FEAT-2 FIX-1
+
+# Next session: everything is waiting
+$ emdx prime
+📋 Ready tasks: 2  |  Recent: #45, #44, #43, #42
+
+# Chain agent output into a PR
+$ emdx delegate --doc 43 --pr "fix the token refresh race condition"
+🔀 PR #87: fix the token refresh race condition
+
+# End of day: AI-generated summary of what happened
+$ emdx briefing --save
+```
+
+Every session compounds. Context never dies.
+
+## Install
+
+```bash
+uv tool install emdx    # or: pip install emdx
+emdx --help
+```
+
+## What it replaces
+
+| Tool category | emdx equivalent |
+|---|---|
+| **Notes** (Notion, Obsidian) | `save`, `find`, `tag` |
+| **Tasks** (Linear, GitHub Issues) | `task add`, `task ready`, `task dep`, `task epic` |
+| **RAG** (LangChain, custom) | `find --mode semantic`, `find --ask` |
+| **Agent orchestrator** (CrewAI, AutoGen) | `delegate`, `delegate --pr` |
+
+One knowledge base. Data flows between all four without import/export.
+
+## Save
+
+```bash
+$ emdx save --file meeting-notes.md
+$ emdx save "quick note" --title "Note"
+$ docker logs api --since 1h | emdx save --title "API errors"
+$ emdx tag 12 analysis active
+```
+
+## Find
+
+```bash
+$ emdx find "auth"                                         # keyword
+$ emdx find "how does rate limiting work?" --mode semantic  # conceptual
+$ emdx find --ask "What did we decide about the redesign?" # RAG Q&A
+$ emdx find --context "auth" | claude                      # pipe to Claude
+$ emdx find --tags "security"                              # by tag
+$ emdx find --recent 10                                    # recently accessed
+```
+
+## Delegate
+
+```bash
+$ emdx delegate "audit auth for vulnerabilities"           # single task
+$ emdx delegate "t1" "t2" "t3"                             # parallel (up to 10)
+$ emdx delegate --synthesize "analyze auth" "analyze api"  # combined summary
+$ emdx delegate --doc 43 "action plan from this audit"     # feed previous results
+$ emdx delegate --pr "fix the auth bug"                    # isolated worktree → PR
+$ emdx delegate --doc 43 --pr "implement this audit"       # doc context + PR
+```
+
+## Track
+
+```bash
+$ emdx task add "Fix token refresh" --cat FIX
+$ emdx task add "Add rate limiting" --cat FEAT --epic 42
+$ emdx task dep add 2 1                # task 2 depends on task 1
+$ emdx task chain 1 2 3 4              # sequential: 1→2→3→4
+$ emdx task ready                      # what's unblocked
+$ emdx task done FIX-1                 # prefixed IDs work everywhere
+```
+
+## Explore
+
+```bash
+$ emdx explore                         # topic map of your KB
+$ emdx explore --gaps                  # coverage gaps and stale areas
+$ emdx briefing                        # what happened in the last 24h
+$ emdx briefing --save                 # AI summary, persisted to KB
+$ emdx maintain compact --dry-run      # find near-duplicate docs
+$ emdx maintain link --all             # auto-link related documents
+```
+
+## The loop
+
+```bash
+$ emdx prime              # start — context from last session
+$ emdx task ready          # what's unblocked
+# ... do work ...
+$ emdx briefing --save     # end — summarize what happened
+```
+
+## Quick reference
+
+| I want to... | Command |
+|---|---|
+| Save a file | `emdx save --file doc.md` |
+| Save a note | `emdx save "text" --title "Title"` |
+| Find by keyword | `emdx find "query"` |
+| Find by meaning | `emdx find "concept" --mode semantic` |
+| Ask a question | `emdx find --ask "question"` |
+| Pipe context to Claude | `emdx find --context "topic" \| claude` |
+| Run an agent | `emdx delegate "task"` |
+| Parallel agents | `emdx delegate "t1" "t2" "t3"` |
+| Agent makes a PR | `emdx delegate --pr "fix the bug"` |
+| Add a task | `emdx task add "title" --cat FEAT` |
+| Task dependencies | `emdx task dep add 2 1` |
+| See ready tasks | `emdx task ready` |
+| What happened today | `emdx briefing` |
+| Topic map | `emdx explore` |
+| TUI browser | `emdx gui` |
+
+## Documentation
+
+- [CLI Reference](docs/cli-api.md) — Complete command documentation
+- [Architecture](docs/architecture.md) — System design
+- [Development Setup](docs/development-setup.md) — Contributing guide
+
+## License
+
+MIT License — see LICENSE file.


### PR DESCRIPTION
## 3 README rewrites to choose from

Each file is a complete, standalone README. Review them side by side and pick the one that tells the best story (or cherry-pick pieces from each).

### README-v1-compound.md — "Compound Loop"
- **Tagline:** *"AI sessions forget. emdx compounds."*
- 3-session progression showing context accumulating across sessions
- Tone: Clear, structured, methodical

### README-v2-replaces.md — "What It Replaces"
- **Tagline:** *"One CLI replaces four tool categories."*
- Positioning table (Notes + Tasks + RAG + Agent Orchestrator → emdx)
- Tone: Pragmatic, positions against known tools

### README-v3-bold.md — "Bold/Visceral"
- **Tagline:** *"Claude sessions are stateless. Your work shouldn't be."*
- Pain narrative → single code block → "Half the PRs in this repo were opened by emdx agents"
- Tone: Confident, confrontational, leads with the problem

### What's the same in all three
- Updated feature sections: Save, Find, Delegate, Track, Explore
- New features covered: task dependencies, prefixed IDs, briefing, explore, semantic search
- Fixed dead docs link (ai-system.md was deleted)
- Quick reference table with all current commands

### Next step
Pick one (or mix & match), then we replace `README.md` and delete the `-v*` files.