### PR TITLE
feat: task browser TUI improvements (Issue #952)

### DIFF
--- a/emdx/ui/keybindings/context.py
+++ b/emdx/ui/keybindings/context.py
@@ -15,6 +15,7 @@ class Context(Enum):
     Hierarchy:
         GLOBAL
         ├── ACTIVITY_*
+        ├── TASK_*
         ├── DOCUMENT_*
         │   └── VIM_* (when editing)
         ├── AGENT_*
@@ -38,6 +39,9 @@ class Context(Enum):
     # Agent browser contexts
     AGENT_NORMAL = "agent:normal"
     AGENT_FORM = "agent:form"
+
+    # Task browser contexts
+    TASK_NORMAL = "task:normal"
 
     # Log browser contexts
     LOG_NORMAL = "log:normal"
@@ -93,6 +97,8 @@ class Context(Enum):
             # Agent contexts
             cls.AGENT_NORMAL: [cls.GLOBAL],
             cls.AGENT_FORM: [cls.AGENT_NORMAL, cls.GLOBAL],
+            # Task contexts
+            cls.TASK_NORMAL: [cls.GLOBAL],
             # Log contexts
             cls.LOG_NORMAL: [cls.GLOBAL],
             cls.LOG_SEARCH: [cls.LOG_NORMAL, cls.GLOBAL],
@@ -183,5 +189,8 @@ class Context(Enum):
             "DeleteConfirmationDialog": cls.MODAL_DELETE,
             # Activity browser
             "ActivityBrowser": cls.ACTIVITY_NORMAL,
+            # Task browser
+            "TaskBrowser": cls.TASK_NORMAL,
+            "TaskView": cls.TASK_NORMAL,
         }
         return mapping.get(widget_class_name, cls.GLOBAL)

--- a/emdx/ui/task_browser.py
+++ b/emdx/ui/task_browser.py
@@ -7,16 +7,24 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
+from .modals import HelpMixin
 from .task_view import TaskView
 
 logger = logging.getLogger(__name__)
 
 
-class TaskBrowser(Widget):
+class TaskBrowser(HelpMixin, Widget):
     """Browser wrapper for TaskView."""
 
+    HELP_TITLE = "Task Browser"
+    HELP_CATEGORIES = {
+        "mark_done": "Actions",
+        "mark_active": "Actions",
+        "mark_blocked": "Actions",
+    }
+
     BINDINGS = [
-        ("?", "show_help", "Help"),
+        ("question_mark", "show_help", "Help"),
     ]
 
     DEFAULT_CSS = """
@@ -45,13 +53,59 @@ class TaskBrowser(Widget):
         yield self.task_view
         yield Static(
             "[dim]1[/dim] Activity │ [bold]2[/bold] Tasks │ [dim]3[/dim] Q&A │ "
-            "[dim]j/k[/dim] nav │ [dim]r[/dim] refresh │ [dim]?[/dim] help",
+            "[dim]j/k[/dim] nav │ [dim]d[/dim] done │ [dim]a[/dim] active │ "
+            "[dim]Tab[/dim] panes │ [dim]r[/dim] refresh │ [dim]?[/dim] help",
             id="task-help-bar",
         )
 
-    def action_show_help(self) -> None:
-        """Show help."""
-        pass
+    def get_help_bindings(self) -> list[tuple[str, str, str]]:
+        """Combine TaskBrowser + TaskView bindings for help display."""
+        # Gather bindings from TaskView as well
+        task_view_bindings = []
+        if self.task_view:
+            raw = getattr(self.task_view, "BINDINGS", [])
+            categories = {**self._DEFAULT_CATEGORIES, **self.HELP_CATEGORIES}
+            for binding in raw:
+                if hasattr(binding, "key"):
+                    key, action, desc = binding.key, binding.action, binding.description
+                    show = getattr(binding, "show", True)
+                else:
+                    key, action, desc = binding[:3]
+                    show = True
+                if not show or action in ("close", "cancel"):
+                    continue
+                display_key = self._KEY_DISPLAY.get(key, key)
+                category = categories.get(action, "Other")
+                task_view_bindings.append((category, display_key, desc))
+
+        # Get our own bindings via the mixin
+        own_bindings = super().get_help_bindings()
+
+        # Merge, dedup by key
+        seen_keys: set[str] = set()
+        merged = []
+        for b in task_view_bindings + own_bindings:
+            if b[1] not in seen_keys:
+                seen_keys.add(b[1])
+                merged.append(b)
+
+        # Sort
+        category_order = [
+            "Navigation",
+            "Actions",
+            "View",
+            "Other",
+            "General",
+        ]
+
+        def sort_key(item: tuple[str, str, str]) -> tuple[int, str]:
+            try:
+                return (category_order.index(item[0]), item[1])
+            except ValueError:
+                return (len(category_order), item[1])
+
+        merged.sort(key=sort_key)
+        return merged
 
     def update_status(self, text: str) -> None:
         """Update status — for compatibility with browser container."""


### PR DESCRIPTION
## Summary

- **DataTable replaces OptionList**: Stable cursor across refreshes and status changes — no more jarring list rebuilds
- **Quick status actions**: `d`=done, `a`=active, `b`=blocked — change task status without leaving the TUI. Cursor stays in place instead of chasing the task into its new status group
- **`?` help overlay**: TaskBrowser inherits HelpMixin, merges bindings from both TaskBrowser and TaskView into a categorized help modal
- **Tab/Shift+Tab pane focus**: Toggle between task list and detail pane (Tab twice returns you). Detail pane scrollable with arrow keys when focused
- **Richer list items**: Columns for priority indicator (`!!!`/`!!`), color-coded status icon, epic badge (cyan, e.g. `TUI-5`), title, compact age (`3d`, `2h`). Strips `KEY-N:` prefix from titles to avoid duplication with epic badge
- **TASK_NORMAL keybinding context**: Registered in `context.py` with parent hierarchy and widget class mapping

## Test plan

- [x] `poetry run pytest tests/test_task_browser.py -x -q` — 35 tests pass
- [x] `poetry run ruff check .` — zero errors
- [x] `poetry run mypy emdx/ui/task_view.py emdx/ui/task_browser.py emdx/ui/keybindings/context.py` — clean
- [ ] Manual: `emdx gui` → screen 2 → verify richer rows, `d`/`a`/`b` status changes, `?` help, Tab pane toggle
- [ ] Manual: verify cursor stays put when marking tasks done

🤖 Generated with [Claude Code](https://claude.com/claude-code)