### PR TITLE
feat: Phase 2 auto-wikify — default auto-link + project scoping

### DIFF
--- a/docs/auto-wikify.md
+++ b/docs/auto-wikify.md
@@ -163,17 +163,17 @@ emdx prime --json          # already includes links in doc metadata
 
 ## Implementation Plan
 
-### Phase 1: Title-Match Wikification
-- Add `wikify` command to CLI (`commands/wikify.py`)
-- Implement `services/wikify_service.py` with `title_match_wikify(doc_id)`
-- Wire into save command (after document creation, like existing auto-link)
-- Add `--dry-run` flag
-- Tests for edge cases (short titles, self-links, word boundaries)
+### Phase 1: Title-Match Wikification ✅
+- ~~Add `wikify` command to CLI~~ → `emdx maintain wikify`
+- ~~Implement `services/wikify_service.py`~~ with `title_match_wikify(doc_id)`
+- ~~Wire into save command~~ (runs automatically on every save)
+- ~~Add `--dry-run` flag~~
+- ~~Tests for edge cases~~ (31 tests: short titles, self-links, word boundaries, etc.)
 
-### Phase 2: Enhanced Semantic (improve existing)
-- Make `--auto-link` default on save
-- Add project scoping to `auto_link_document()`
-- Surface links in `emdx show` output
+### Phase 2: Enhanced Semantic (improve existing) ✅
+- ~~Make `--auto-link` default on save~~ (`--auto-link/--no-auto-link`, default on)
+- ~~Add project scoping~~ (`--cross-project` flag, default: same project only)
+- Surface links in `emdx show` output (already exists via `--links`)
 
 ### Phase 3: Entity Extraction (future)
 - Add `document_entities` table via migration


### PR DESCRIPTION
## Summary

- **Auto-link on by default**: `emdx save` now runs semantic auto-linking automatically when an embedding index exists. Use `--no-auto-link` to suppress. Silently skips if AI extras aren't installed (no more warning noise).
- **Project scoping**: `find_similar()` and `auto_link_document()` accept a `project` parameter. By default, matches are scoped to the same project. Use `--cross-project` on `emdx save` or `emdx maintain link` to match globally.
- **Design doc updated**: Phase 1 and Phase 2 marked complete in `docs/auto-wikify.md`

## Test plan

- [x] `poetry run pytest tests/test_wikify_service.py tests/test_document_links.py -x -q` — 50 tests pass
- [x] `poetry run ruff check` + `mypy` — zero errors
- [x] `emdx save --help` shows `--auto-link/--no-auto-link` (default: auto-link) and `--cross-project`
- [x] `emdx maintain link --help` shows `--cross-project` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)