### PR TITLE
feat: context-aware prime output for delegate vs human sessions

### DIFF
--- a/.claude/hooks/prime.sh
+++ b/.claude/hooks/prime.sh
@@ -5,6 +5,7 @@
 # Stdout is added to Claude's context.
 #
 # Env vars (set by delegate launcher):
+#   EMDX_AUTO_SAVE - Enable auto-save ("1" for delegate sessions)
 #   EMDX_DOC_ID    - Include specific document as context
 #   EMDX_TASK_ID   - Mark task as active on session start
 set -euo pipefail
@@ -12,17 +13,30 @@ set -euo pipefail
 # Consume stdin (required by hook protocol)
 cat > /dev/null
 
-# Prime with current work context (quiet = just ready tasks)
-emdx prime --quiet 2>/dev/null || true
+if [[ "${EMDX_AUTO_SAVE:-}" == "1" ]]; then
+    # DELEGATE context — minimal priming
+    echo "● emdx delegate — Focus on your assigned task only."
+    echo "Output is auto-saved to the knowledge base when you finish."
+    echo "Do NOT check ready tasks or pick up other work."
+    if [[ -n "${EMDX_DOC_ID:-}" ]]; then
+        echo "Document context (doc #${EMDX_DOC_ID}) follows below."
+        echo ""
+        echo "=== Document Context (doc #${EMDX_DOC_ID}) ==="
+        emdx view "$EMDX_DOC_ID" 2>/dev/null || true
+    fi
+else
+    # HUMAN context — full orientation
+    emdx prime 2>/dev/null || true
 
-# If delegate set a doc context, include it
-if [[ -n "${EMDX_DOC_ID:-}" ]]; then
-    echo ""
-    echo "=== Document Context (doc #${EMDX_DOC_ID}) ==="
-    emdx view "$EMDX_DOC_ID" 2>/dev/null || true
+    # If a doc context was set, include it
+    if [[ -n "${EMDX_DOC_ID:-}" ]]; then
+        echo ""
+        echo "=== Document Context (doc #${EMDX_DOC_ID}) ==="
+        emdx view "$EMDX_DOC_ID" 2>/dev/null || true
+    fi
 fi
 
-# If delegate set a task, mark it active
+# Task activation (both contexts)
 if [[ -n "${EMDX_TASK_ID:-}" ]]; then
     emdx task active "$EMDX_TASK_ID" 2>/dev/null || true
 fi


### PR DESCRIPTION
## Summary
- **Delegate sessions** (`EMDX_AUTO_SAVE=1`) get 3-line minimal prime: "Focus on your assigned task only. Do NOT check ready tasks."
- **Human sessions** get full prime (epics, ready tasks, git context) — minus the command cheatsheet and `RULES:` line (redundant with CLAUDE.md)
- Removes `====` chrome and `_get_usage_instructions()` from prime.py
- Adds `_get_current_branch()` for a compact `● emdx — project (branch)` header

## Why
Delegates spawned with `emdx delegate "fix the login bug"` were seeing 20 READY TASKS and instructions to "Check ready tasks" — actively causing them to wander from their assigned task.

## Test plan
- [x] `poetry run pytest tests/test_commands_prime.py -x -q` — 35 tests pass
- [x] `emdx prime` — shows clean header with project + branch, no command cheatsheet
- [x] `EMDX_AUTO_SAVE=1 prime.sh` — shows 3-line delegate message only
- [x] `EMDX_AUTO_SAVE=1 EMDX_DOC_ID=N prime.sh` — shows delegate message + doc context

🤖 Generated with [Claude Code](https://claude.com/claude-code)