### PR TITLE
fix: auto-confirm destructive commands when stdin is not a TTY

### DIFF
--- a/emdx/commands/compact.py
+++ b/emdx/commands/compact.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.table import Table
 
 from ..database import db
+from ..utils.output import is_non_interactive
 
 console = Console()
 app = typer.Typer(help="Compact documents by AI-powered synthesis")
@@ -395,7 +396,7 @@ def compact(
         )
 
         # Confirm
-        if not yes and not dry_run:
+        if not yes and not dry_run and not is_non_interactive():
             if not typer.confirm("Proceed with synthesis?"):
                 console.print("[yellow]Cancelled[/yellow]")
                 raise typer.Exit(0)
@@ -476,7 +477,7 @@ def compact(
             f"  Estimated cost: ~${total_cost:.4f}"
         )
 
-        if not yes:
+        if not yes and not is_non_interactive():
             if not typer.confirm("Proceed with synthesis?"):
                 console.print("[yellow]Cancelled[/yellow]")
                 raise typer.Exit(0)

--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -35,7 +35,7 @@ from emdx.models.tags import (
 )
 from emdx.services.auto_tagger import AutoTagger
 from emdx.ui.formatting import format_tags
-from emdx.utils.output import console
+from emdx.utils.output import console, is_non_interactive
 from emdx.utils.text_formatting import truncate_title
 
 app = typer.Typer(help="Core CRUD operations for documents")
@@ -1481,8 +1481,8 @@ def delete(
             console.print("\n[dim]This is a dry run. No documents were deleted.[/dim]")
             return
 
-        # Confirmation
-        if not force:
+        # Confirmation (skip when stdin is not a TTY to avoid hanging agents)
+        if not force and not is_non_interactive():
             if hard:
                 console.print(
                     f"\n[red bold]⚠️  WARNING: This will PERMANENTLY delete "

--- a/emdx/commands/executions.py
+++ b/emdx/commands/executions.py
@@ -19,7 +19,7 @@ from ..models.executions import (
     get_running_executions,
     update_execution_status,
 )
-from ..utils.output import console
+from ..utils.output import console, is_non_interactive
 from ..utils.text_formatting import truncate_description
 
 logger = logging.getLogger(__name__)
@@ -355,11 +355,12 @@ def kill_all_executions() -> None:
     for exec in executions:
         console.print(f"  [cyan]{exec.id}[/cyan] - {exec.doc_title}")
 
-    # Ask for confirmation
-    confirm = typer.confirm("Are you sure you want to kill all running executions?")
-    if not confirm:
-        console.print("[yellow]Cancelled.[/yellow]")
-        return
+    # Ask for confirmation (skip when stdin is not a TTY)
+    if not is_non_interactive():
+        confirm = typer.confirm("Are you sure you want to kill all running executions?")
+        if not confirm:
+            console.print("[yellow]Cancelled.[/yellow]")
+            return
 
     # Kill all running executions
     for execution in executions:
@@ -455,9 +456,7 @@ def execution_health() -> None:
     # Show recommendations if there are unhealthy executions
     if metrics["unhealthy_running"] > 0:
         console.print("\n[yellow]⚠ Found unhealthy executions![/yellow]")
-        console.print(
-            "Run [cyan]emdx maintain cleanup --executions --execute[/cyan] to clean up"
-        )
+        console.print("Run [cyan]emdx maintain cleanup --executions --execute[/cyan] to clean up")
 
 
 @app.command(name="monitor")

--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -12,7 +12,7 @@ from emdx.commands.categories import app as categories_app
 from emdx.commands.epics import app as epics_app
 from emdx.models import tasks
 from emdx.models.types import TaskDict
-from emdx.utils.output import console, print_json
+from emdx.utils.output import console, is_non_interactive, print_json
 
 app = typer.Typer(help="Agent work queue")
 app.add_typer(epics_app, name="epic", help="Manage task epics")
@@ -493,7 +493,7 @@ def delete(
         console.print(f"[red]Task #{task_id} not found[/red]")
         raise typer.Exit(1)
 
-    if not force:
+    if not force and not is_non_interactive():
         console.print(f"Delete task #{task_id}: {task['title']}?")
         confirm = typer.confirm("Are you sure?")
         if not confirm:

--- a/emdx/utils/output.py
+++ b/emdx/utils/output.py
@@ -1,6 +1,7 @@
 """Shared console output utilities."""
 
 import json
+import sys
 from typing import Any
 
 from rich.console import Console
@@ -8,6 +9,14 @@ from rich.console import Console
 # Shared console instance for all CLI output
 # Uses force_terminal=True to ensure color output even when not connected to a terminal
 console = Console(force_terminal=True, color_system="auto")
+
+
+def is_non_interactive() -> bool:
+    """Return True when stdin is not a TTY (e.g. running inside Claude Code).
+
+    Used to auto-confirm destructive prompts that would otherwise hang agents.
+    """
+    return not sys.stdin.isatty()
 
 
 def print_json(data: Any) -> None:

--- a/tests/test_commands_core.py
+++ b/tests/test_commands_core.py
@@ -119,7 +119,9 @@ class TestSaveCommand:
     @patch("emdx.commands.core.apply_tags")
     @patch("emdx.commands.core.create_document")
     @patch("emdx.commands.core.detect_project")
-    def test_save_with_title_and_project(self, mock_detect, mock_create, mock_tags, mock_display, tmp_path):  # noqa: E501
+    def test_save_with_title_and_project(
+        self, mock_detect, mock_create, mock_tags, mock_display, tmp_path
+    ):  # noqa: E501
         """Save with explicit --title and --project."""
         f = tmp_path / "note.md"
         f.write_text("content")
@@ -128,11 +130,18 @@ class TestSaveCommand:
         mock_create.return_value = 1
         mock_tags.return_value = []
 
-        result = runner.invoke(app, [
-            "save", "--file", str(f),
-            "--title", "Custom Title",
-            "--project", "my-project",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "save",
+                "--file",
+                str(f),
+                "--title",
+                "Custom Title",
+                "--project",
+                "my-project",
+            ],
+        )
         assert result.exit_code == 0
         args = mock_create.call_args
         assert args[0][0] == "Custom Title"
@@ -150,9 +159,16 @@ class TestSaveCommand:
         mock_create.return_value = 5
         mock_tags.return_value = ["python", "testing"]
 
-        result = runner.invoke(app, [
-            "save", "--file", str(f), "--tags", "python,testing",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "save",
+                "--file",
+                str(f),
+                "--tags",
+                "python,testing",
+            ],
+        )
         assert result.exit_code == 0
         mock_tags.assert_called_once_with(5, "python,testing")
 
@@ -170,7 +186,6 @@ class TestFindCommand:
 
     @patch("emdx.commands.core.get_tags_for_documents")
     @patch("emdx.commands.core.search_documents")
-
     def test_find_basic(self, mock_search, mock_get_tags):
         """Basic search returns results."""
         mock_search.return_value = [
@@ -189,7 +204,6 @@ class TestFindCommand:
         assert result.exit_code == 0
         assert "Found Doc" in _out(result)
 
-
     def test_find_no_args(self):
         """Find with no search terms and no tags should error."""
         result = runner.invoke(app, ["find"])
@@ -197,7 +211,6 @@ class TestFindCommand:
 
     @patch("emdx.commands.core.get_tags_for_documents")
     @patch("emdx.commands.core.search_documents")
-
     def test_find_no_results(self, mock_search, mock_get_tags):
         """Search with no results shows appropriate message."""
         mock_search.return_value = []
@@ -209,7 +222,6 @@ class TestFindCommand:
 
     @patch("emdx.commands.core.get_tags_for_documents")
     @patch("emdx.commands.core.search_documents")
-
     def test_find_ids_only(self, mock_search, mock_get_tags):
         """--ids-only outputs just IDs."""
         mock_search.return_value = [
@@ -230,7 +242,6 @@ class TestFindCommand:
 
     @patch("emdx.commands.core.get_tags_for_documents")
     @patch("emdx.commands.core.search_documents")
-
     def test_find_json_output(self, mock_search, mock_get_tags):
         """--json outputs JSON array."""
         mock_search.return_value = [
@@ -252,7 +263,6 @@ class TestFindCommand:
 
     @patch("emdx.commands.core.get_tags_for_documents")
     @patch("emdx.commands.core.search_by_tags")
-
     def test_find_by_tags(self, mock_search_tags, mock_get_tags):
         """Find with --tags does tag-based search."""
         mock_search_tags.return_value = [
@@ -279,7 +289,6 @@ class TestViewCommand:
 
     @patch("emdx.commands.core.get_document_tags")
     @patch("emdx.commands.core.get_document")
-
     def test_view_by_id(self, mock_get_doc, mock_get_tags):
         """View a document by numeric ID."""
         mock_get_doc.return_value = {
@@ -297,7 +306,6 @@ class TestViewCommand:
         assert "My Doc" in _out(result)
 
     @patch("emdx.commands.core.get_document")
-
     def test_view_not_found(self, mock_get_doc):
         """View nonexistent document shows error."""
         mock_get_doc.return_value = None
@@ -308,7 +316,6 @@ class TestViewCommand:
 
     @patch("emdx.commands.core.get_document_tags")
     @patch("emdx.commands.core.get_document")
-
     def test_view_raw(self, mock_get_doc, mock_get_tags):
         """View with --raw shows raw content."""
         mock_get_doc.return_value = {
@@ -327,7 +334,6 @@ class TestViewCommand:
 
     @patch("emdx.commands.core.get_document_tags")
     @patch("emdx.commands.core.get_document")
-
     def test_view_no_header(self, mock_get_doc, mock_get_tags):
         """View with --no-header hides header."""
         mock_get_doc.return_value = {
@@ -348,7 +354,6 @@ class TestViewCommand:
 
     @patch("emdx.commands.core.get_document_tags")
     @patch("emdx.commands.core.get_document")
-
     def test_view_json(self, mock_get_doc, mock_get_tags):
         """View with --json outputs valid JSON."""
         mock_get_doc.return_value = {
@@ -387,7 +392,6 @@ class TestEditCommand:
 
     @patch("emdx.commands.core.update_document")
     @patch("emdx.commands.core.get_document")
-
     def test_edit_title_only(self, mock_get_doc, mock_update):
         """Edit with --title updates title without opening editor."""
         mock_get_doc.return_value = {
@@ -405,7 +409,6 @@ class TestEditCommand:
         mock_update.assert_called_once_with(1, "New Title", "content")
 
     @patch("emdx.commands.core.get_document")
-
     def test_edit_doc_not_found(self, mock_get_doc):
         """Edit nonexistent document shows error."""
         mock_get_doc.return_value = None
@@ -416,7 +419,6 @@ class TestEditCommand:
 
     @patch("emdx.commands.core.update_document")
     @patch("emdx.commands.core.get_document")
-
     def test_edit_title_failure(self, mock_get_doc, mock_update):
         """Edit that fails to update shows error."""
         mock_get_doc.return_value = {
@@ -446,7 +448,6 @@ class TestDeleteCommand:
 
     @patch("emdx.commands.core.delete_document")
     @patch("emdx.commands.core.get_document")
-
     def test_delete_soft(self, mock_get_doc, mock_delete):
         """Soft delete with --force skips confirmation."""
         mock_get_doc.return_value = {
@@ -466,7 +467,6 @@ class TestDeleteCommand:
 
     @patch("emdx.commands.core.delete_document")
     @patch("emdx.commands.core.get_document")
-
     def test_delete_hard_force(self, mock_get_doc, mock_delete):
         """Hard delete with --force --hard."""
         mock_get_doc.return_value = {
@@ -484,7 +484,6 @@ class TestDeleteCommand:
         mock_delete.assert_called_once_with("1", hard_delete=True)
 
     @patch("emdx.commands.core.get_document")
-
     def test_delete_not_found(self, mock_get_doc):
         """Deleting a non-existent document shows error."""
         mock_get_doc.return_value = None
@@ -495,7 +494,6 @@ class TestDeleteCommand:
         assert "not found" in out.lower() or "No valid" in out
 
     @patch("emdx.commands.core.get_document")
-
     def test_delete_dry_run(self, mock_get_doc):
         """--dry-run shows what would be deleted without deleting."""
         mock_get_doc.return_value = {
@@ -512,14 +510,25 @@ class TestDeleteCommand:
 
     @patch("emdx.commands.core.delete_document")
     @patch("emdx.commands.core.get_document")
-
     def test_delete_multiple(self, mock_get_doc, mock_delete):
         """Delete multiple documents at once."""
 
         def side_effect(identifier):
             docs = {
-                "1": {"id": 1, "title": "Doc 1", "project": None, "created_at": datetime(2024, 1, 1), "access_count": 0},  # noqa: E501
-                "2": {"id": 2, "title": "Doc 2", "project": None, "created_at": datetime(2024, 1, 2), "access_count": 0},  # noqa: E501
+                "1": {
+                    "id": 1,
+                    "title": "Doc 1",
+                    "project": None,
+                    "created_at": datetime(2024, 1, 1),
+                    "access_count": 0,
+                },  # noqa: E501
+                "2": {
+                    "id": 2,
+                    "title": "Doc 2",
+                    "project": None,
+                    "created_at": datetime(2024, 1, 2),
+                    "access_count": 0,
+                },  # noqa: E501
             }
             return docs.get(identifier)
 
@@ -534,6 +543,47 @@ class TestDeleteCommand:
         """Delete with no ID should fail."""
         result = runner.invoke(app, ["delete"])
         assert result.exit_code != 0
+
+    @patch("emdx.commands.core.delete_document")
+    @patch("emdx.commands.core.get_document")
+    @patch("emdx.commands.core.is_non_interactive", return_value=True)
+    def test_delete_auto_confirms_when_non_tty(self, mock_isatty, mock_get_doc, mock_delete):
+        """Delete skips confirmation when stdin is not a TTY (agent mode)."""
+        mock_get_doc.return_value = {
+            "id": 1,
+            "title": "Agent Delete",
+            "project": "p",
+            "created_at": datetime(2024, 1, 1),
+            "access_count": 0,
+        }
+        mock_delete.return_value = True
+
+        # No --force flag, but should still proceed without prompting
+        result = runner.invoke(app, ["delete", "1"])
+        out = _out(result)
+        assert result.exit_code == 0
+        assert "Moved" in out or "trash" in out
+        mock_delete.assert_called_once_with("1", hard_delete=False)
+
+    @patch("emdx.commands.core.delete_document")
+    @patch("emdx.commands.core.get_document")
+    @patch("emdx.commands.core.is_non_interactive", return_value=True)
+    def test_delete_hard_auto_confirms_when_non_tty(self, mock_isatty, mock_get_doc, mock_delete):
+        """Hard delete skips confirmation when stdin is not a TTY (agent mode)."""
+        mock_get_doc.return_value = {
+            "id": 1,
+            "title": "Agent Hard Delete",
+            "project": None,
+            "created_at": datetime(2024, 1, 1),
+            "access_count": 0,
+        }
+        mock_delete.return_value = True
+
+        # No --force flag, --hard, should still proceed without prompting
+        result = runner.invoke(app, ["delete", "1", "--hard"])
+        assert result.exit_code == 0
+        assert "Permanently deleted" in _out(result)
+        mock_delete.assert_called_once_with("1", hard_delete=True)
 
 
 # ---------------------------------------------------------------------------
@@ -623,7 +673,8 @@ class TestRestoreCommand:
         ]
         mock_restore.return_value = True
 
-        result = runner.invoke(main_app, ["trash", "restore", "--all"], input="y\n")
+        with patch("emdx.commands.trash.is_non_interactive", return_value=False):
+            result = runner.invoke(main_app, ["trash", "restore", "--all"], input="y\n")
         assert result.exit_code == 0
         assert "Restored 2" in _out(result)
 
@@ -647,11 +698,11 @@ class TestPurgeCommand:
     @patch("emdx.commands.trash.list_deleted_documents")
     def test_purge_with_force(self, mock_list_deleted, mock_purge):
         """Purge --force skips confirmation."""
-        mock_list_deleted.return_value = [{"id": 1, "title": "D", "deleted_at": datetime(2024, 1, 1)}]  # noqa: E501
+        mock_list_deleted.return_value = [
+            {"id": 1, "title": "D", "deleted_at": datetime(2024, 1, 1)}
+        ]  # noqa: E501
         mock_purge.return_value = 1
 
         result = runner.invoke(main_app, ["trash", "purge", "--force"])
         assert result.exit_code == 0
         assert "Permanently deleted" in _out(result)
-
-

--- a/tests/test_commands_trash.py
+++ b/tests/test_commands_trash.py
@@ -138,7 +138,8 @@ class TestTrashPurge:
         assert "Permanently deleted 1 document" in _out(result)
 
     @patch("emdx.commands.trash.list_deleted_documents")
-    def test_purge_cancelled(self, mock_list):
+    @patch("emdx.commands.trash.is_non_interactive", return_value=False)
+    def test_purge_cancelled(self, mock_interactive, mock_list):
         mock_list.return_value = [{"id": 1, "deleted_at": datetime(2026, 1, 1)}]
         result = runner.invoke(app, ["purge"], input="n\n")
         assert result.exit_code == 0

--- a/tests/test_task_commands.py
+++ b/tests/test_task_commands.py
@@ -441,8 +441,9 @@ class TestTaskDelete:
         assert result.exit_code == 1
         assert "not found" in _out(result)
 
+    @patch("emdx.commands.tasks.is_non_interactive", return_value=False)
     @patch("emdx.commands.tasks.tasks")
-    def test_delete_with_confirmation(self, mock_tasks):
+    def test_delete_with_confirmation(self, mock_tasks, mock_interactive):
         mock_tasks.resolve_task_id.return_value = 3
         mock_tasks.get_task.return_value = {"id": 3, "title": "Confirm delete"}
         mock_tasks.delete_task.return_value = True
@@ -451,8 +452,9 @@ class TestTaskDelete:
         out = _out(result)
         assert "Deleted #3" in out
 
+    @patch("emdx.commands.tasks.is_non_interactive", return_value=False)
     @patch("emdx.commands.tasks.tasks")
-    def test_delete_cancelled(self, mock_tasks):
+    def test_delete_cancelled(self, mock_tasks, mock_interactive):
         mock_tasks.resolve_task_id.return_value = 4
         mock_tasks.get_task.return_value = {"id": 4, "title": "Cancel delete"}
         result = runner.invoke(app, ["delete", "4"], input="n\n")


### PR DESCRIPTION
## Summary
- Add `is_interactive()` utility that checks `sys.stdin.isatty()` 
- Guard all `typer.confirm()` calls across 8 command files — when not a TTY, skip confirmation and proceed
- Prevents Claude Code agents from hanging on interactive prompts during `emdx delete`, `emdx task delete`, `emdx purge`, etc.

## Files changed
| File | Change |
|------|--------|
| `emdx/utils/output.py` | Add `is_interactive()` helper |
| `emdx/commands/core.py` | Guard delete confirmation |
| `emdx/commands/trash.py` | Guard restore --all and purge |
| `emdx/commands/tasks.py` | Guard task delete |
| `emdx/commands/executions.py` | Guard kill_all |
| `emdx/commands/tags.py` | Guard rename, merge, batch |
| `emdx/commands/maintain.py` | Guard wizard + index clear |
| `emdx/commands/compact.py` | Guard synthesis |
| `emdx/commands/ask.py` | Guard clear-index |

## Test plan
- [x] 1289 tests pass, 0 failures
- [x] 2 new tests for non-TTY auto-confirm behavior
- [x] 3 existing tests fixed for new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)