### PR TITLE
feat: wire task actions and remove dead streaming code from Activity screen (Issue #6709)

### DIFF
--- a/emdx/ui/activity/activity_items.py
+++ b/emdx/ui/activity/activity_items.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from emdx.models.types import TaskDict
 from emdx.ui.types import AgentExecutionDict
 
 if TYPE_CHECKING:

--- a/emdx/ui/activity/activity_view.py
+++ b/emdx/ui/activity/activity_view.py
@@ -6,7 +6,6 @@ No hierarchy, no groups — just a scannable list sorted by time.
 
 import logging
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from typing import Any
 
 from textual.app import ComposeResult
@@ -28,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 try:
     from emdx.services import document_service as doc_db
-    from emdx.services.log_stream import LogStream, LogStreamSubscriber
 
     HAS_DOCS = True
 except ImportError:
@@ -92,19 +90,6 @@ def format_time_ago(dt: datetime) -> str:
 ActivityItem = ActivityItemBase
 
 
-class AgentLogSubscriber(LogStreamSubscriber):
-    """Forwards log content to the activity view."""
-
-    def __init__(self, view: "ActivityView"):
-        self.view = view
-
-    def on_log_content(self, new_content: str) -> None:
-        self.view._handle_log_content(new_content)
-
-    def on_log_error(self, error: Exception) -> None:
-        logger.error(f"Log stream error: {error}")
-
-
 class ActivityView(HelpMixin, Widget):
     """Activity View - Mission Control for EMDX."""
 
@@ -126,6 +111,9 @@ class ActivityView(HelpMixin, Widget):
         ("r", "refresh", "Refresh"),
         ("i", "create_gist", "New Gist"),
         ("x", "dismiss_execution", "Kill/Dismiss"),
+        ("d", "mark_done", "Mark Done"),
+        ("a", "mark_active", "Mark Active"),
+        ("b", "mark_blocked", "Mark Blocked"),
         ("tab", "focus_next", "Next Pane"),
         ("shift+tab", "focus_prev", "Prev Pane"),
         ("question_mark", "show_help", "Help"),
@@ -216,11 +204,6 @@ class ActivityView(HelpMixin, Widget):
         display: none;
     }
 
-    #preview-log {
-        height: 1fr;
-        display: none;
-    }
-
     .notification {
         height: 1;
         background: $success;
@@ -245,9 +228,6 @@ class ActivityView(HelpMixin, Widget):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.activity_items: list[ActivityItem] = []
-        self.log_stream: LogStream | None = None
-        self.log_subscriber = AgentLogSubscriber(self)
-        self.streaming_item_id: int | None = None
         self._fullscreen = False
         self._last_preview_key: tuple[str, int, str] | None = None
         self._preview_raw_content: str = ""
@@ -306,12 +286,6 @@ class ActivityView(HelpMixin, Widget):
                     id="preview-copy",
                     highlight=True,
                     auto_scroll=False,
-                )
-                yield RichLog(
-                    id="preview-log",
-                    highlight=True,
-                    markup=True,
-                    wrap=True,
                 )
 
     async def on_mount(self) -> None:
@@ -471,7 +445,6 @@ class ActivityView(HelpMixin, Widget):
         try:
             preview = self.query_one("#preview-content", RichLog)
             preview_scroll = self.query_one("#preview-scroll", ScrollableContainer)
-            preview_log = self.query_one("#preview-log", RichLog)
             header = self.query_one("#preview-header", Static)
         except Exception as e:
             logger.debug(f"Preview widgets not ready: {e}")
@@ -479,7 +452,6 @@ class ActivityView(HelpMixin, Widget):
 
         def show_markdown() -> None:
             copy_log = self.query_one("#preview-copy", Log)
-            preview_log.display = False
             if self._copy_mode:
                 preview_scroll.display = False
                 copy_log.display = True
@@ -503,14 +475,6 @@ class ActivityView(HelpMixin, Widget):
             return
 
         self._last_preview_key = current_key
-
-        # Stop any existing stream
-        self._stop_stream()
-
-        # For running agent executions, show live log
-        if item.status == "running" and item.item_type == "agent_execution":
-            await self._show_live_log(item)
-            return
 
         # For documents, show content
         if item.doc_id and HAS_DOCS:
@@ -542,8 +506,8 @@ class ActivityView(HelpMixin, Widget):
             except Exception as e:
                 logger.error(f"Error loading document: {e}")
 
-        # For agent executions without doc_id
-        if item.item_type == "agent_execution":
+        # For agent executions without doc_id, or tasks
+        if item.item_type in ("agent_execution", "task"):
             content, header_text = await item.get_preview_content(doc_db)
             if content:
                 self._render_markdown_preview(content)
@@ -626,95 +590,6 @@ class ActivityView(HelpMixin, Widget):
 
         except Exception as e:
             logger.error(f"Error showing document context: {e}")
-
-    async def _show_live_log(self, item: ActivityItem) -> None:
-        """Show live log for running agent execution."""
-        try:
-            preview_scroll = self.query_one("#preview-scroll", ScrollableContainer)
-            preview_log = self.query_one("#preview-log", RichLog)
-            header = self.query_one("#preview-header", Static)
-        except Exception as e:
-            logger.debug(f"Preview widgets not ready for live log: {e}")
-            return
-
-        preview_scroll.display = False
-        try:
-            self.query_one("#preview-copy", Log).display = False
-        except Exception:
-            pass
-        preview_log.display = True
-        preview_log.clear()
-
-        header.update(f"[green]● LIVE[/green] {item.title}")
-
-        try:
-            log_path = None
-
-            if item.item_type == "agent_execution":
-                log_file = getattr(item, "log_file", None)
-                if log_file:
-                    log_path = Path(log_file)
-
-            if not log_path:
-                preview_log.write("[yellow]⏳ Waiting for log...[/yellow]")
-                preview_log.write(f"[dim]item_type={item.item_type}[/dim]")
-                return
-
-            if not log_path.exists():
-                preview_log.write(f"[yellow]⏳ Log file pending: {log_path}[/yellow]")
-                return
-
-            preview_log.write(f"[green]● Streaming from: {log_path.name}[/green]")
-            self.log_stream = LogStream(log_path)
-            self.streaming_item_id = item.item_id
-
-            initial = self.log_stream.get_initial_content()
-            if initial:
-                from emdx.ui.live_log_writer import LiveLogWriter
-
-                LiveLogWriter(preview_log, auto_scroll=True)
-                from emdx.utils.stream_json_parser import (
-                    parse_and_format_live_logs,
-                )
-
-                formatted = parse_and_format_live_logs(initial)
-                formatted = [ln for ln in formatted if "__RAW_RESULT_JSON__:" not in ln]
-                for line in formatted[-50:]:
-                    preview_log.write(line)
-                preview_log.scroll_end(animate=False)
-
-            self.log_stream.subscribe(self.log_subscriber)
-
-        except Exception as e:
-            logger.error(f"Error setting up live log: {e}", exc_info=True)
-            preview_log.write(f"[red]Error: {e}[/red]")
-
-    def _handle_log_content(self, content: str) -> None:
-        """Handle new log content from stream."""
-        content = "\n".join(
-            ln for ln in content.split("\n") if not ln.startswith("__RAW_RESULT_JSON__:")
-        )
-        if not content.strip():
-            return
-
-        def update_ui() -> None:
-            try:
-                from emdx.ui.live_log_writer import LiveLogWriter
-
-                preview_log = self.query_one("#preview-log", RichLog)
-                writer = LiveLogWriter(preview_log, auto_scroll=True)
-                writer.write(content)
-            except Exception as e:
-                logger.error(f"Error handling log content: {e}")
-
-        self.app.call_from_thread(update_ui)
-
-    def _stop_stream(self) -> None:
-        """Stop any active log stream."""
-        if self.log_stream:
-            self.log_stream.unsubscribe(self.log_subscriber)
-            self.log_stream = None
-        self.streaming_item_id = None
 
     def _hide_notification(self) -> None:
         """Hide the notification bar."""
@@ -829,10 +704,6 @@ class ActivityView(HelpMixin, Widget):
         """Handle double-click on table row — open fullscreen."""
         self.action_fullscreen()
 
-    def on_unmount(self) -> None:
-        """Cleanup on unmount."""
-        self._stop_stream()
-
     # Gist/quick document creation
 
     async def action_create_gist(self) -> None:
@@ -885,7 +756,7 @@ class ActivityView(HelpMixin, Widget):
             return
 
         if item.item_type != "agent_execution":
-            self._show_notification("Can only dismiss executions", is_error=True)
+            # x is a no-op for tasks and documents
             return
 
         if item.status != "running":
@@ -919,6 +790,43 @@ class ActivityView(HelpMixin, Widget):
         except Exception as e:
             logger.error(f"Error dismissing execution: {e}")
             self._show_notification(f"Error: {e}", is_error=True)
+
+    # Task status actions
+
+    async def _set_task_status(self, new_status: str) -> None:
+        """Change status of the selected task and refresh."""
+        item = self._get_selected_item()
+        if item is None:
+            self._show_notification("No item selected", is_error=True)
+            return
+
+        if item.item_type != "task":
+            return
+
+        if item.status == new_status:
+            return
+
+        try:
+            from emdx.models.tasks import update_task
+
+            update_task(item.item_id, status=new_status)
+            self._show_notification(f"Task #{item.item_id} → {new_status}")
+            await self._refresh_data()
+        except Exception as e:
+            logger.error(f"Failed to update task: {e}")
+            self._show_notification(f"Error: {e}", is_error=True)
+
+    async def action_mark_done(self) -> None:
+        """Mark selected task as done."""
+        await self._set_task_status("done")
+
+    async def action_mark_active(self) -> None:
+        """Mark selected task as active."""
+        await self._set_task_status("active")
+
+    async def action_mark_blocked(self) -> None:
+        """Mark selected task as blocked."""
+        await self._set_task_status("blocked")
 
     def _show_notification(self, message: str, is_error: bool = False) -> None:
         """Show a notification message."""

--- a/tests/test_activity_view.py
+++ b/tests/test_activity_view.py
@@ -1,0 +1,473 @@
+"""Tests for ActivityView — task action keybindings and streaming removal.
+
+Phase 2 of the Unified Dashboard Data Model:
+- Part A: Task action keybindings (d/a/b/x) in ActivityView
+- Part B: Verify dead live-streaming code was removed
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import RichLog, Static
+
+from emdx.ui.activity.activity_items import (
+    AgentExecutionItem,
+    DocumentItem,
+    TaskItem,
+)
+from emdx.ui.activity.activity_view import ActivityView
+
+# ---------------------------------------------------------------------------
+# Factories
+# ---------------------------------------------------------------------------
+
+
+def make_task_item(
+    item_id: int = 1,
+    title: str = "Test task",
+    status: str = "open",
+    priority: int = 5,
+    epic_key: str | None = None,
+    description: str | None = None,
+) -> TaskItem:
+    """Create a TaskItem for testing."""
+    task_dict: dict[str, Any] = {
+        "id": item_id,
+        "title": title,
+        "status": status,
+        "priority": priority,
+        "epic_key": epic_key,
+        "description": description,
+        "error": None,
+        "epic_seq": None,
+        "created_at": "2025-01-01T12:00:00",
+        "updated_at": None,
+        "completed_at": None,
+        "tags": None,
+        "execution_id": None,
+        "output_doc_id": None,
+        "gameplan_id": None,
+        "project": None,
+        "current_step": None,
+        "prompt": None,
+        "type": "manual",
+        "source_doc_id": None,
+        "parent_task_id": None,
+        "seq": None,
+        "retry_of": None,
+    }
+    return TaskItem(
+        item_id=item_id,
+        title=title,
+        timestamp=datetime(2025, 1, 1, 12, 0, 0),
+        status=status,
+        task_data=task_dict,  # type: ignore[arg-type]
+    )
+
+
+def make_doc_item(
+    item_id: int = 100,
+    title: str = "Test doc",
+) -> DocumentItem:
+    return DocumentItem(
+        item_id=item_id,
+        title=title,
+        timestamp=datetime(2025, 1, 1, 12, 0, 0),
+        status="completed",
+        doc_id=item_id,
+    )
+
+
+def make_exec_item(
+    item_id: int = 200,
+    title: str = "Test execution",
+    status: str = "running",
+) -> AgentExecutionItem:
+    return AgentExecutionItem(
+        item_id=item_id,
+        title=title,
+        timestamp=datetime(2025, 1, 1, 12, 0, 0),
+        status=status,
+        execution={},  # type: ignore[arg-type]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test App
+# ---------------------------------------------------------------------------
+
+
+_VIEW_MODULE = "emdx.ui.activity.activity_view"
+_DATA_MODULE = "emdx.ui.activity.activity_data"
+
+
+class ActivityTestApp(App[None]):
+    """Minimal app that mounts a single ActivityView."""
+
+    def compose(self) -> ComposeResult:
+        yield ActivityView(id="activity-view")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_activity_deps() -> Generator[dict[str, MagicMock], None, None]:
+    """Patch DB calls used by ActivityView and its data loader."""
+    mock_loader = MagicMock()
+    mock_loader.load_all = AsyncMock(return_value=[])
+
+    with (
+        patch(f"{_VIEW_MODULE}.doc_db") as m_doc_db,
+        patch(f"{_VIEW_MODULE}.HAS_DOCS", True),
+        patch(
+            f"{_VIEW_MODULE}.ActivityDataLoader",
+            return_value=mock_loader,
+        ),
+        patch(
+            "emdx.ui.activity.activity_view.get_theme_indicator",
+            create=True,
+        ) as m_theme,
+    ):
+        m_doc_db.get_document.return_value = None
+        m_theme.return_value = ""
+        yield {
+            "doc_db": m_doc_db,
+            "loader": mock_loader,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _richlog_text(widget: RichLog) -> str:
+    """Extract plain text from a RichLog widget."""
+    return "\n".join(line.text for line in widget.lines)
+
+
+# ===================================================================
+# A. TaskItem unit tests
+# ===================================================================
+
+
+class TestTaskItem:
+    """Tests for the TaskItem dataclass."""
+
+    def test_item_type(self) -> None:
+        item = make_task_item()
+        assert item.item_type == "task"
+
+    def test_type_icon_open(self) -> None:
+        item = make_task_item(status="open")
+        assert item.type_icon == "."
+
+    def test_type_icon_active(self) -> None:
+        item = make_task_item(status="active")
+        assert item.type_icon == ">"
+
+    def test_type_icon_blocked(self) -> None:
+        item = make_task_item(status="blocked")
+        assert item.type_icon == "-"
+
+    def test_type_icon_done(self) -> None:
+        item = make_task_item(status="done")
+        assert item.type_icon == "v"
+
+    def test_type_icon_failed(self) -> None:
+        item = make_task_item(status="failed")
+        assert item.type_icon == "x"
+
+    @pytest.mark.asyncio
+    async def test_preview_content_basic(self) -> None:
+        item = make_task_item(title="Fix auth bug", status="open", priority=2)
+        content, header = await item.get_preview_content(None)
+        assert "Fix auth bug" in content
+        assert "open" in content
+        assert "2" in content
+        assert "Task #1" in header
+
+    @pytest.mark.asyncio
+    async def test_preview_content_with_description(self) -> None:
+        item = make_task_item(description="Detailed explanation here")
+        content, _ = await item.get_preview_content(None)
+        assert "Detailed explanation here" in content
+
+    @pytest.mark.asyncio
+    async def test_preview_content_with_epic(self) -> None:
+        task_dict = make_task_item(epic_key="AUTH").task_data
+        assert task_dict is not None
+        task_dict["epic_seq"] = 3
+        item = TaskItem(
+            item_id=1,
+            title="Task",
+            timestamp=datetime(2025, 1, 1),
+            status="open",
+            task_data=task_dict,  # type: ignore[arg-type]
+        )
+        content, _ = await item.get_preview_content(None)
+        assert "AUTH-3" in content
+
+
+# ===================================================================
+# B. Task action keybindings in ActivityView
+# ===================================================================
+
+
+class TestTaskActions:
+    """Tests for d/a/b task status keybindings."""
+
+    @pytest.mark.asyncio
+    async def test_d_marks_task_done(self, mock_activity_deps: dict[str, MagicMock]) -> None:
+        """Pressing d on a task item calls update_task with 'done'."""
+        task_item = make_task_item(item_id=42, status="open")
+        mock_activity_deps["loader"].load_all.return_value = [task_item]
+
+        with patch("emdx.models.tasks.update_task") as m_update:
+            app = ActivityTestApp()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                # Select the task
+                # Jump to TASKS section (past headers)
+                await pilot.press("T")
+                await pilot.pause()
+
+                await pilot.press("d")
+                await pilot.pause()
+
+                m_update.assert_called_once_with(42, status="done")
+
+    @pytest.mark.asyncio
+    async def test_a_marks_task_active(self, mock_activity_deps: dict[str, MagicMock]) -> None:
+        """Pressing a on a task item calls update_task with 'active'."""
+        task_item = make_task_item(item_id=42, status="open")
+        mock_activity_deps["loader"].load_all.return_value = [task_item]
+
+        with patch("emdx.models.tasks.update_task") as m_update:
+            app = ActivityTestApp()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                # Jump to TASKS section (past headers)
+                await pilot.press("T")
+                await pilot.pause()
+
+                await pilot.press("a")
+                await pilot.pause()
+
+                m_update.assert_called_once_with(42, status="active")
+
+    @pytest.mark.asyncio
+    async def test_b_marks_task_blocked(self, mock_activity_deps: dict[str, MagicMock]) -> None:
+        """Pressing b on a task item calls update_task with 'blocked'."""
+        task_item = make_task_item(item_id=42, status="open")
+        mock_activity_deps["loader"].load_all.return_value = [task_item]
+
+        with patch("emdx.models.tasks.update_task") as m_update:
+            app = ActivityTestApp()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                # Jump to TASKS section (past headers)
+                await pilot.press("T")
+                await pilot.pause()
+
+                await pilot.press("b")
+                await pilot.pause()
+
+                m_update.assert_called_once_with(42, status="blocked")
+
+    @pytest.mark.asyncio
+    async def test_d_noop_on_document(self, mock_activity_deps: dict[str, MagicMock]) -> None:
+        """Pressing d on a document item does not call update_task."""
+        doc_item = make_doc_item()
+        mock_activity_deps["loader"].load_all.return_value = [doc_item]
+
+        with patch("emdx.models.tasks.update_task") as m_update:
+            app = ActivityTestApp()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                # Jump to DOCS section to select the document
+                await pilot.press("D")
+                await pilot.pause()
+
+                await pilot.press("d")
+                await pilot.pause()
+
+                m_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_d_noop_when_already_done(self, mock_activity_deps: dict[str, MagicMock]) -> None:
+        """Pressing d on an already-done task does not call update_task."""
+        task_item = make_task_item(item_id=42, status="done")
+        mock_activity_deps["loader"].load_all.return_value = [task_item]
+
+        with patch("emdx.models.tasks.update_task") as m_update:
+            app = ActivityTestApp()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                # Jump to TASKS section (past headers)
+                await pilot.press("T")
+                await pilot.pause()
+
+                await pilot.press("d")
+                await pilot.pause()
+
+                m_update.assert_not_called()
+
+
+# ===================================================================
+# C. Dismiss/kill (x key) behavior
+# ===================================================================
+
+
+class TestDismissAction:
+    """Tests for x key behavior on different item types."""
+
+    @pytest.mark.asyncio
+    async def test_x_noop_on_task(self, mock_activity_deps: dict[str, MagicMock]) -> None:
+        """Pressing x on a task is a silent no-op."""
+        task_item = make_task_item(item_id=42, status="open")
+        mock_activity_deps["loader"].load_all.return_value = [task_item]
+
+        app = ActivityTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # Jump to TASKS section (past headers)
+            await pilot.press("T")
+            await pilot.pause()
+
+            # x should not raise or show error
+            await pilot.press("x")
+            await pilot.pause()
+
+    @pytest.mark.asyncio
+    async def test_x_noop_on_document(self, mock_activity_deps: dict[str, MagicMock]) -> None:
+        """Pressing x on a document is a silent no-op."""
+        doc_item = make_doc_item()
+        mock_activity_deps["loader"].load_all.return_value = [doc_item]
+
+        app = ActivityTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # Jump to DOCS section (past headers)
+            await pilot.press("D")
+            await pilot.pause()
+
+            await pilot.press("x")
+            await pilot.pause()
+
+
+# ===================================================================
+# D. Streaming code removal verification
+# ===================================================================
+
+
+class TestStreamingRemoval:
+    """Verify that dead streaming code has been removed."""
+
+    def test_no_agent_log_subscriber_class(self) -> None:
+        """AgentLogSubscriber should not exist in activity_view module."""
+        import emdx.ui.activity.activity_view as mod
+
+        assert not hasattr(mod, "AgentLogSubscriber")
+
+    def test_no_log_stream_attribute(self, mock_activity_deps: dict[str, MagicMock]) -> None:
+        """ActivityView instances should not have log_stream attribute."""
+        view = ActivityView()
+        assert not hasattr(view, "log_stream")
+
+    def test_no_log_subscriber_attribute(self, mock_activity_deps: dict[str, MagicMock]) -> None:
+        """ActivityView instances should not have log_subscriber attribute."""
+        view = ActivityView()
+        assert not hasattr(view, "log_subscriber")
+
+    def test_no_streaming_item_id_attribute(self, mock_activity_deps: dict[str, MagicMock]) -> None:
+        """ActivityView instances should not have streaming_item_id attribute."""
+        view = ActivityView()
+        assert not hasattr(view, "streaming_item_id")
+
+    def test_no_show_live_log_method(self) -> None:
+        """_show_live_log method should not exist."""
+        assert not hasattr(ActivityView, "_show_live_log")
+
+    def test_no_handle_log_content_method(self) -> None:
+        """_handle_log_content method should not exist."""
+        assert not hasattr(ActivityView, "_handle_log_content")
+
+    def test_no_stop_stream_method(self) -> None:
+        """_stop_stream method should not exist."""
+        assert not hasattr(ActivityView, "_stop_stream")
+
+    def test_no_log_stream_import(self) -> None:
+        """LogStream should not be imported in activity_view."""
+        import emdx.ui.activity.activity_view as mod
+
+        assert not hasattr(mod, "LogStream")
+        assert not hasattr(mod, "LogStreamSubscriber")
+
+    @pytest.mark.asyncio
+    async def test_document_preview_still_works(
+        self, mock_activity_deps: dict[str, MagicMock]
+    ) -> None:
+        """Document preview rendering still works after streaming removal."""
+        doc_item = make_doc_item(item_id=100, title="My Document")
+        mock_activity_deps["loader"].load_all.return_value = [doc_item]
+        mock_activity_deps["doc_db"].get_document.return_value = {
+            "id": 100,
+            "title": "My Document",
+            "content": "# My Document\n\nHello world",
+            "project": "test",
+            "created_at": "2025-01-01T12:00:00",
+            "access_count": 5,
+        }
+
+        app = ActivityTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # Jump to DOCS section (past headers)
+            await pilot.press("D")
+            await pilot.pause()
+
+            header = app.query_one("#preview-header", Static)
+            assert "100" in str(header.content)
+
+    @pytest.mark.asyncio
+    async def test_copy_mode_still_works(self, mock_activity_deps: dict[str, MagicMock]) -> None:
+        """Copy mode toggle still works after streaming removal."""
+        doc_item = make_doc_item(item_id=100, title="My Document")
+        mock_activity_deps["loader"].load_all.return_value = [doc_item]
+        mock_activity_deps["doc_db"].get_document.return_value = {
+            "id": 100,
+            "title": "My Document",
+            "content": "# My Document\n\nHello world",
+            "project": "test",
+            "created_at": "2025-01-01T12:00:00",
+            "access_count": 1,
+        }
+
+        app = ActivityTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # Jump to DOCS section (past headers)
+            await pilot.press("D")
+            await pilot.pause()
+
+            # Toggle copy mode
+            await pilot.press("c")
+            await pilot.pause()
+
+            view = app.query_one(ActivityView)
+            assert view._copy_mode is True
+
+            # Toggle back
+            await pilot.press("c")
+            await pilot.pause()
+            assert view._copy_mode is False


### PR DESCRIPTION
## Summary
- Adds `d`/`a`/`b` keybindings to mark tasks as done/active/blocked (guarded to task items only)
- Removes dead live-streaming code: `AgentLogSubscriber`, `_show_live_log()`, `_handle_log_content()`, `_stop_stream()`, `#preview-log` widget
- Preserves copy-mode and markdown preview for document viewing
- 26 new tests covering task actions, keybinding guards, and streaming removal verification

**Note:** This PR depends on #759 (Phase 1: TaskItem + unified data model). Merge #759 first, then rebase this.

## Test plan
- [ ] Verify `d`/`a`/`b` keys work on task items in Activity screen
- [ ] Verify `d`/`a`/`b` keys are no-ops on document/execution items
- [ ] Verify document preview still works after streaming code removal
- [ ] Run full test suite: `poetry run pytest tests/ -x -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)