### PR TITLE
feat: show KEY-N display IDs in task command output (Issue #3423)

### DIFF
--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -44,6 +44,13 @@ def _blocker_summary(task_id: int) -> str:
     return f"{names}{extra}"
 
 
+def _display_id(task: TaskDict) -> str:
+    """Return KEY-N display ID if available, otherwise #id."""
+    if task.get("epic_key") and task.get("epic_seq"):
+        return f"{task['epic_key']}-{task['epic_seq']}"
+    return f"#{task['id']}"
+
+
 def _resolve_id(
     identifier: str,
     json_output: bool = False,
@@ -107,11 +114,13 @@ def add(
         epic_key=epic_key,
         depends_on=depends_on,
     )
-    msg = f"[green]✅ Task #{task_id}:[/green] {title}"
+
+    task_data = tasks.get_task(task_id)
+    display_id = _display_id(task_data) if task_data else f"#{task_id}"
+
+    msg = f"[green]✅ Task {display_id}:[/green] {title}"
     if doc:
         msg += f" [dim](doc #{doc})[/dim]"
-    if epic_key:
-        msg += f" [dim]({epic_key})[/dim]"
     if depends_on:
         dep_ids = " ".join(f"#{d}" for d in depends_on)
         msg += f" [dim](after {dep_ids})[/dim]"
@@ -180,7 +189,7 @@ def done(
     if json_output:
         print_json({"id": task_id, "title": task["title"], "status": "done"})
     else:
-        console.print(f"[green]✓ Done:[/green] #{task_id} {task['title']}")
+        console.print(f"[green]✓ Done:[/green] {_display_id(task)} {task['title']}")
 
 
 @app.command()
@@ -203,10 +212,9 @@ def view(
         raise typer.Exit(1)
 
     icon = ICONS.get(task["status"], "?")
-    # Header
-    label = f"#{task_id}"
-    if task.get("epic_key") and task.get("epic_seq"):
-        label = f"{task['epic_key']}-{task['epic_seq']} (#{task_id})"
+    # Header: show KEY-N with raw ID in parens for cross-reference
+    display = _display_id(task)
+    label = f"{display} (#{task_id})" if display != f"#{task_id}" else display
     console.print(f"\n[bold]{icon} {label}: {task['title']}[/bold]")
 
     # Metadata line
@@ -298,7 +306,7 @@ def active(
     if note:
         tasks.log_progress(task_id, note)
 
-    console.print(f"[blue]● Active:[/blue] #{task_id} {task['title']}")
+    console.print(f"[blue]● Active:[/blue] {_display_id(task)} {task['title']}")
 
 
 @app.command()
@@ -324,15 +332,15 @@ def log(
 
     if message:
         tasks.log_progress(task_id, message)
-        console.print(f"[green]Logged:[/green] #{task_id} — {message}")
+        console.print(f"[green]Logged:[/green] {_display_id(task)} — {message}")
         return
 
     entries = tasks.get_task_log(task_id, limit=20)
     if not entries:
-        console.print(f"[yellow]No log entries for #{task_id}[/yellow]")
+        console.print(f"[yellow]No log entries for {_display_id(task)}[/yellow]")
         return
 
-    console.print(f"\n[bold]Log for #{task_id}: {task['title']}[/bold]")
+    console.print(f"\n[bold]Log for {_display_id(task)}: {task['title']}[/bold]")
     for entry in entries:
         ts = entry.get("created_at", "")
         console.print(f"  [dim]{ts}[/dim] {entry['message']}")
@@ -358,7 +366,7 @@ def note(
         raise typer.Exit(1)
 
     tasks.log_progress(task_id, message)
-    console.print(f"[green]Logged:[/green] #{task_id} — {message}")
+    console.print(f"[green]Logged:[/green] {_display_id(task)} — {message}")
 
 
 @app.command()
@@ -385,7 +393,7 @@ def blocked(
     if reason:
         tasks.log_progress(task_id, f"Blocked: {reason}")
 
-    msg = f"[yellow]⊘ Blocked:[/yellow] #{task_id} {task['title']}"
+    msg = f"[yellow]⊘ Blocked:[/yellow] {_display_id(task)} {task['title']}"
     if reason:
         msg += f"\n  [dim]{reason}[/dim]"
     console.print(msg)
@@ -505,7 +513,7 @@ def priority(
         if json_output:
             print_json({"id": task_id, "title": task["title"], "priority": current})
         else:
-            console.print(f"#{task_id} {task['title']}: priority {current}")
+            console.print(f"{_display_id(task)} {task['title']}: priority {current}")
         return
 
     if value < 1 or value > 5:
@@ -519,7 +527,7 @@ def priority(
     if json_output:
         print_json({"id": task_id, "title": task["title"], "priority": value})
     else:
-        console.print(f"[green]✅ #{task_id}[/green] priority set to {value}")
+        console.print(f"[green]✅ {_display_id(task)}[/green] priority set to {value}")
 
 
 @app.command()
@@ -541,14 +549,14 @@ def delete(
         raise typer.Exit(1)
 
     if not force and not is_non_interactive():
-        console.print(f"Delete task #{task_id}: {task['title']}?")
+        console.print(f"Delete task {_display_id(task)}: {task['title']}?")
         confirm = typer.confirm("Are you sure?")
         if not confirm:
             console.print("[yellow]Cancelled[/yellow]")
             return
 
     tasks.delete_task(task_id)
-    console.print(f"[green]✅ Deleted #{task_id}[/green]")
+    console.print(f"[green]✅ Deleted {_display_id(task)}[/green]")
 
 
 # --- Task dependency subcommands ---

--- a/tests/test_task_commands.py
+++ b/tests/test_task_commands.py
@@ -22,6 +22,12 @@ class TestTaskAdd:
     @patch("emdx.commands.tasks.tasks")
     def test_add_simple_task(self, mock_tasks):
         mock_tasks.create_task.return_value = 1
+        mock_tasks.get_task.return_value = {
+            "id": 1,
+            "title": "Fix the auth bug",
+            "epic_key": None,
+            "epic_seq": None,
+        }
         result = runner.invoke(app, ["add", "Fix the auth bug"])
         assert result.exit_code == 0
         out = _out(result)
@@ -37,8 +43,29 @@ class TestTaskAdd:
         )
 
     @patch("emdx.commands.tasks.tasks")
+    def test_add_task_shows_epic_key(self, mock_tasks):
+        mock_tasks.create_task.return_value = 10
+        mock_tasks.get_task.return_value = {
+            "id": 10,
+            "title": "FEAT-3: Add auth",
+            "epic_key": "FEAT",
+            "epic_seq": 3,
+        }
+        result = runner.invoke(app, ["add", "Add auth", "--cat", "FEAT"])
+        assert result.exit_code == 0
+        out = _out(result)
+        assert "Task FEAT-3" in out
+        assert "Add auth" in out
+
+    @patch("emdx.commands.tasks.tasks")
     def test_add_task_with_doc_id(self, mock_tasks):
         mock_tasks.create_task.return_value = 2
+        mock_tasks.get_task.return_value = {
+            "id": 2,
+            "title": "Implement this",
+            "epic_key": None,
+            "epic_seq": None,
+        }
         result = runner.invoke(app, ["add", "Implement this", "--doc", "42"])
         assert result.exit_code == 0
         out = _out(result)
@@ -57,6 +84,12 @@ class TestTaskAdd:
     @patch("emdx.commands.tasks.tasks")
     def test_add_task_with_doc_id_short_flag(self, mock_tasks):
         mock_tasks.create_task.return_value = 3
+        mock_tasks.get_task.return_value = {
+            "id": 3,
+            "title": "Another task",
+            "epic_key": None,
+            "epic_seq": None,
+        }
         result = runner.invoke(app, ["add", "Another task", "-d", "99"])
         assert result.exit_code == 0
         out = _out(result)
@@ -74,6 +107,12 @@ class TestTaskAdd:
     @patch("emdx.commands.tasks.tasks")
     def test_add_task_with_description(self, mock_tasks):
         mock_tasks.create_task.return_value = 4
+        mock_tasks.get_task.return_value = {
+            "id": 4,
+            "title": "Refactor tests",
+            "epic_key": None,
+            "epic_seq": None,
+        }
         result = runner.invoke(
             app, ["add", "Refactor tests", "--description", "Split into unit and integration"]
         )
@@ -93,6 +132,12 @@ class TestTaskAdd:
     @patch("emdx.commands.tasks.tasks")
     def test_add_task_with_description_short_flag(self, mock_tasks):
         mock_tasks.create_task.return_value = 5
+        mock_tasks.get_task.return_value = {
+            "id": 5,
+            "title": "Task",
+            "epic_key": None,
+            "epic_seq": None,
+        }
         result = runner.invoke(app, ["add", "Task", "-D", "Details here"])
         assert result.exit_code == 0
         mock_tasks.create_task.assert_called_once_with(
@@ -107,6 +152,12 @@ class TestTaskAdd:
     @patch("emdx.commands.tasks.tasks")
     def test_add_task_with_all_options(self, mock_tasks):
         mock_tasks.create_task.return_value = 6
+        mock_tasks.get_task.return_value = {
+            "id": 6,
+            "title": "Full task",
+            "epic_key": None,
+            "epic_seq": None,
+        }
         result = runner.invoke(app, ["add", "Full task", "-d", "10", "-D", "Full description"])
         assert result.exit_code == 0
         out = _out(result)
@@ -906,6 +957,12 @@ class TestTaskAddWithAfter:
     @patch("emdx.commands.tasks.tasks")
     def test_add_with_single_after(self, mock_tasks):
         mock_tasks.create_task.return_value = 10
+        mock_tasks.get_task.return_value = {
+            "id": 10,
+            "title": "Deploy",
+            "epic_key": None,
+            "epic_seq": None,
+        }
         result = runner.invoke(app, ["add", "Deploy", "--after", "5"])
         assert result.exit_code == 0
         out = _out(result)
@@ -923,6 +980,12 @@ class TestTaskAddWithAfter:
     @patch("emdx.commands.tasks.tasks")
     def test_add_with_multiple_after(self, mock_tasks):
         mock_tasks.create_task.return_value = 20
+        mock_tasks.get_task.return_value = {
+            "id": 20,
+            "title": "Release",
+            "epic_key": None,
+            "epic_seq": None,
+        }
         result = runner.invoke(app, ["add", "Release", "--after", "10", "--after", "11"])
         assert result.exit_code == 0
         out = _out(result)


### PR DESCRIPTION
## Summary

- Added `_display_id()` helper that returns `KEY-N` (e.g. `FEAT-16`) when a task has an epic_key/epic_seq, falling back to `#id` otherwise
- Updated all task command output (add, done, active, blocked, log, note, priority, delete, view) to use the human-friendly display ID
- Added test for the new epic key display in `task add` output

Before: `✅ Task #1042: Add auth (FEAT)`
After: `✅ Task FEAT-16: Add auth`

## Test plan

- [x] All 102 existing task command tests pass
- [x] New test verifies `task add --cat FEAT` shows `FEAT-3` in output
- [x] ruff lint and format pass
- [x] mypy passes on changed production code (test file has pre-existing untyped-def warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)