### PR TITLE
feat: wire QA presenter into QA screen (Issue #TUI-10)

### DIFF
--- a/emdx/ui/qa/qa_screen.py
+++ b/emdx/ui/qa/qa_screen.py
@@ -1,18 +1,13 @@
 """
 QA Screen - Conversational Q&A over your knowledge base.
 
-Runs claude CLI directly via subprocess.Popen, bypassing UnifiedExecutor
-to avoid terminal corruption that breaks Textual's mouse event parsing.
+Delegates retrieval and answer generation to QAPresenter, which handles
+terminal state save/restore around threaded operations to prevent
+Textual's mouse/key handling from breaking.
 """
 
 import asyncio
-import json
 import logging
-import queue
-import shutil
-import subprocess
-import threading
-import time
 from typing import Any
 
 from textual import events
@@ -23,6 +18,7 @@ from textual.widget import Widget
 from textual.widgets import Input, Markdown, Static
 
 from ..modals import HelpMixin
+from .qa_presenter import QAEntry, QAPresenter, QAStateVM
 
 logger = logging.getLogger(__name__)
 
@@ -33,196 +29,6 @@ def _next_msg_id() -> str:
     global _msg_counter
     _msg_counter += 1
     return f"qa-msg-{_msg_counter}"
-
-
-# ---------------------------------------------------------------------------
-# Subprocess helpers (run in thread pool, no UnifiedExecutor)
-# ---------------------------------------------------------------------------
-
-_DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
-_ANSWER_TIMEOUT = 120.0
-
-
-def _save_terminal_state() -> "list[Any] | None":
-    """Save current terminal attributes so they can be restored later.
-
-    Something in the retrieval/subprocess pipeline resets the terminal
-    from raw mode to cooked mode, which kills Textual's mouse and key
-    handling.  We save before and restore after.
-    """
-    import sys
-    import termios
-
-    try:
-        fd = sys.stdin.fileno()
-        return termios.tcgetattr(fd)  # type: ignore[no-any-return]
-    except Exception:
-        return None
-
-
-def _restore_terminal_state(saved: "list[Any] | None") -> None:
-    """Restore terminal attributes saved by _save_terminal_state."""
-    import sys
-    import termios
-
-    if saved is None:
-        return
-    try:
-        fd = sys.stdin.fileno()
-        current = termios.tcgetattr(fd)
-        if current != saved:
-            logger.info(
-                "Terminal state changed — restoring (lflag %#x -> %#x)",
-                current[3],
-                saved[3],
-            )
-            termios.tcsetattr(fd, termios.TCSANOW, saved)
-    except Exception as e:
-        logger.warning("Failed to restore terminal state: %s", e)
-
-
-def _run_claude(question: str, context: str) -> str:
-    """Run claude CLI directly — bypasses UnifiedExecutor."""
-    system_prompt = (
-        "You answer questions using the provided knowledge base context.\n\n"
-        "Rules:\n"
-        "- Only answer based on the provided documents\n"
-        "- Cite document IDs when referencing information "
-        "(e.g., 'According to Document #42...')\n"
-        "- If the context doesn't contain relevant information, say so clearly\n"
-        "- Be concise but complete\n"
-        "- If documents contain conflicting information, note the discrepancy"
-    )
-    user_message = f"Context from my knowledge base:\n\n{context}\n\n---\n\nQuestion: {question}"
-    prompt = f"<system>\n{system_prompt}\n</system>\n\n{user_message}"
-
-    cmd = [
-        "claude",
-        "--print",
-        prompt,
-        "--model",
-        _DEFAULT_MODEL,
-        "--output-format",
-        "stream-json",
-        "--verbose",
-    ]
-
-    process = subprocess.Popen(
-        cmd,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        start_new_session=True,
-    )
-
-    stdout_q: queue.Queue[str | None] = queue.Queue()
-
-    def reader(pipe: Any, q: queue.Queue[str | None]) -> None:
-        try:
-            for line in pipe:
-                q.put(line)
-        finally:
-            q.put(None)
-
-    t = threading.Thread(target=reader, args=(process.stdout, stdout_q), daemon=True)
-    t.start()
-
-    stdout_lines: list[str] = []
-    while True:
-        try:
-            line = stdout_q.get(timeout=_ANSWER_TIMEOUT)
-        except queue.Empty:
-            break
-        if line is None:
-            break
-        stdout_lines.append(line)
-
-    t.join(timeout=5.0)
-    process.wait()
-
-    # Parse result from stream-json
-    for line in stdout_lines:
-        try:
-            data = json.loads(line)
-            if data.get("type") == "result":
-                result: str = data.get("result", "(no result)")
-                return result
-        except (json.JSONDecodeError, KeyError):
-            continue
-
-    return "(no answer parsed)"
-
-
-def _retrieve_context(question: str, limit: int = 8) -> tuple[list[tuple[int, str, str]], str]:
-    """Retrieve relevant documents for context."""
-    import re
-
-    from emdx.database import db
-
-    docs: list[tuple[int, str, str]] = []
-    seen: set[int] = set()
-
-    # Check for explicit doc references (#42)
-    doc_refs = re.findall(r"#(\d+)", question)
-    if doc_refs:
-        with db.get_connection() as conn:
-            cursor = conn.cursor()
-            for ref in doc_refs:
-                try:
-                    cursor.execute(
-                        "SELECT id, title, content FROM documents WHERE id = ? AND is_deleted = 0",
-                        (int(ref),),
-                    )
-                    row = cursor.fetchone()
-                    if row and row[0] not in seen:
-                        docs.append(row)
-                        seen.add(row[0])
-                except ValueError:
-                    pass
-
-    # Keyword retrieval
-    remaining = limit - len(docs)
-    if remaining > 0:
-        terms = re.sub(r"[^\w\s]", " ", question).strip()
-        if terms:
-            try:
-                with db.get_connection() as conn:
-                    cursor = conn.cursor()
-                    cursor.execute(
-                        "SELECT d.id, d.title, d.content FROM documents d "
-                        "JOIN documents_fts fts ON d.id = fts.rowid "
-                        "WHERE fts.documents_fts MATCH ? AND d.is_deleted = 0 "
-                        "ORDER BY rank LIMIT ?",
-                        (terms, remaining),
-                    )
-                    for row in cursor.fetchall():
-                        if row[0] not in seen:
-                            docs.append(row)
-                            seen.add(row[0])
-                            if len(docs) >= limit:
-                                break
-            except Exception as e:
-                logger.debug(f"FTS retrieval failed: {e}")
-
-    # NOTE: Semantic fallback (EmbeddingService) is intentionally excluded here.
-    # Importing torch/sentence-transformers resets the terminal from raw to
-    # cooked mode, which kills Textual's mouse and key handling.
-    # Keyword FTS + explicit #ID references cover the common Q&A cases well.
-
-    # Build context string
-    parts = []
-    for doc_id, title, content in docs:
-        truncated = content[:3000] if len(content) > 3000 else content
-        parts.append(f"# Document #{doc_id}: {title}\n\n{truncated}")
-    context = "\n\n---\n\n".join(parts)
-
-    return docs, context
-
-
-# ---------------------------------------------------------------------------
-# QAScreen widget
-# ---------------------------------------------------------------------------
 
 
 class QAScreen(HelpMixin, Widget):
@@ -309,11 +115,11 @@ class QAScreen(HelpMixin, Widget):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._is_asking = False
-        self._has_claude_cli = shutil.which("claude") is not None
+        self._presenter = QAPresenter(
+            on_state_update=self._on_state_update,
+            on_answer_chunk=self._on_chunk,
+        )
         self._source_ids: list[int] = []
-        self._entries: list[dict[str, Any]] = []
-        self._pending_question: str | None = None  # In-flight question text
         # Background task that survives widget unmount/remount
         self._bg_task: asyncio.Task[None] | None = None
 
@@ -342,17 +148,21 @@ class QAScreen(HelpMixin, Widget):
         If we have prior conversation entries, rebuild them instead of
         showing the welcome message.
         """
-        has_state = bool(self._entries) or self._is_asking
+        entries = self._presenter.state.entries
+        has_state = bool(entries) or self._presenter.state.is_asking
         logger.info(
-            "QAScreen mounted (entries=%d, asking=%s, pending=%s)",
-            len(self._entries),
-            self._is_asking,
-            self._pending_question is not None,
+            "QAScreen mounted (entries=%d, asking=%s)",
+            len(entries),
+            self._presenter.state.is_asking,
         )
-        if has_state:
-            self._rebuild_conversation()
-        else:
+
+        if not has_state:
+            # First mount — initialize presenter and show welcome
+            await self._presenter.initialize()
             self._show_welcome()
+        else:
+            self._rebuild_conversation()
+
         # Focus conversation, not Input — avoids mouse sequence corruption
         self.query_one("#qa-conversation", ScrollableContainer).focus()
 
@@ -388,19 +198,17 @@ class QAScreen(HelpMixin, Widget):
         )
 
     def _rebuild_conversation(self) -> None:
-        """Rebuild conversation DOM from saved entries.
+        """Rebuild conversation DOM from presenter state.
 
         Called on re-mount after switching screens.  The child widgets
-        were destroyed by remove_children() but _entries survived on
-        the Python object.
+        were destroyed by remove_children() but presenter state survived.
         """
-        for entry in self._entries:
-            self._append_message(f"\n[bold cyan]Q:[/bold cyan] {entry['question']}\n")
-            self._render_entry(entry)
-
-        if self._is_asking and self._pending_question:
-            self._append_message(f"\n[bold cyan]Q:[/bold cyan] {self._pending_question}\n")
-            self._set_thinking("[dim]Still generating answer...[/dim]")
+        for entry in self._presenter.state.entries:
+            self._append_message(f"\n[bold cyan]Q:[/bold cyan] {entry.question}\n")
+            if entry.is_loading:
+                self._set_thinking("[dim]Still generating answer...[/dim]")
+            else:
+                self._render_entry(entry)
 
     def _update_status(self, text: str) -> None:
         """Update the status bar text."""
@@ -416,11 +224,11 @@ class QAScreen(HelpMixin, Widget):
         question = event.value.strip()
         if not question:
             return
-        if self._is_asking:
+        if self._presenter.state.is_asking:
             self.notify("Still waiting — press Escape to cancel", timeout=2)
             return
 
-        if not self._has_claude_cli:
+        if not self._presenter.state.has_claude_cli:
             self.notify("Claude CLI not found", severity="error", timeout=3)
             return
 
@@ -428,21 +236,46 @@ class QAScreen(HelpMixin, Widget):
         event.input.value = ""
         self.query_one("#qa-conversation", ScrollableContainer).focus()
 
-        # Show the question
+        # Show the question immediately
         self._append_message(f"\n[bold cyan]Q:[/bold cyan] {question}\n")
+        self._set_thinking("[dim]Searching knowledge base...[/dim]")
 
         # Launch as a free-standing asyncio task so it survives widget
         # unmount/remount (run_worker gets cancelled on unmount).
-        self._is_asking = True
-        self._pending_question = question
-        self._bg_task = asyncio.get_event_loop().create_task(self._fetch_and_store(question))
+        self._bg_task = asyncio.get_event_loop().create_task(self._presenter.ask(question))
+
+    async def _on_state_update(self, state: QAStateVM) -> None:
+        """React to presenter state changes."""
+        if not self._is_mounted_in_dom():
+            return
+
+        self._update_status(state.status_text)
+
+        if state.is_asking and state.entries:
+            entry = state.entries[-1]
+            if entry.is_loading:
+                src_count = len(entry.sources)
+                if src_count > 0:
+                    self._set_thinking(
+                        f"[dim]Found {src_count} sources — generating answer...[/dim]"
+                    )
+
+        # Entry just finished
+        if not state.is_asking and state.entries:
+            latest = state.entries[-1]
+            if not latest.is_loading:
+                self._remove_thinking()
+                self._render_entry(latest)
+
+    async def _on_chunk(self, chunk: str) -> None:
+        """Handle streaming answer chunk. Currently unused (whole-answer mode)."""
+        pass
 
     def _cancel_asking(self) -> None:
         """Cancel the current Q&A operation and reset state."""
+        self._presenter.cancel()
         if self._bg_task and not self._bg_task.done():
             self._bg_task.cancel()
-        self._is_asking = False
-        self._pending_question = None
         self._remove_thinking()
         self._append_message("[dim italic]Cancelled[/dim italic]")
         self._append_message("[dim]─────────────────────────────────────────[/dim]")
@@ -477,82 +310,21 @@ class QAScreen(HelpMixin, Widget):
         except Exception:
             return False
 
-    def _render_entry(self, entry: dict[str, Any]) -> None:
+    def _render_entry(self, entry: QAEntry) -> None:
         """Render a single Q&A entry into the conversation DOM."""
         self._append_message("[bold green]A:[/bold green]")
-        self._append_markdown(entry["answer"])
-        docs = entry.get("sources", [])
+        self._append_markdown(entry.answer)
         meta_parts: list[str] = []
-        if docs:
-            self._source_ids = [d[0] for d in docs]
-            source_parts = [f"#{d[0]} {d[1]}" for d in docs]
+        if entry.sources:
+            self._source_ids = [s.doc_id for s in entry.sources]
+            source_parts = [f"#{s.doc_id} {s.title}" for s in entry.sources]
             meta_parts.append(f"Sources: {' · '.join(source_parts)}")
-        elapsed = entry.get("elapsed")
-        if elapsed is not None:
-            meta_parts.append(f"{elapsed:.1f}s")
+        if entry.elapsed_ms:
+            elapsed_s = entry.elapsed_ms / 1000
+            meta_parts.append(f"{elapsed_s:.1f}s")
         if meta_parts:
             self._append_message(f"[dim]{' | '.join(meta_parts)}[/dim]")
         self._append_message("[dim]─────────────────────────────────────────[/dim]")
-
-    async def _fetch_and_store(self, question: str) -> None:
-        """Fetch context + answer and store in _entries.
-
-        This is a free-standing asyncio task (NOT a Textual worker) so
-        it survives widget unmount/remount when switching screens.
-        UI updates are best-effort — if we're unmounted, they silently
-        fail and on_mount will rebuild from _entries.
-        """
-        t0 = time.monotonic()
-        self._set_thinking("[dim]Searching knowledge base...[/dim]")
-        self._update_status("Retrieving context...")
-
-        # Save terminal state on the main thread before background work.
-        term_state = _save_terminal_state()
-
-        try:
-            docs, context = await asyncio.to_thread(_retrieve_context, question)
-            _restore_terminal_state(term_state)
-
-            t_retrieve = time.monotonic() - t0
-            src_count = len(docs)
-            self._set_thinking(
-                f"[dim]Found {src_count} sources ({t_retrieve:.1f}s) — generating answer...[/dim]"
-            )
-            self._update_status("Generating answer...")
-
-            answer = await asyncio.to_thread(_run_claude, question, context)
-            _restore_terminal_state(term_state)
-
-            t_total = time.monotonic() - t0
-
-            # Always store — this is the durable state
-            entry: dict[str, Any] = {
-                "question": question,
-                "answer": answer,
-                "sources": docs,
-                "elapsed": t_total,
-            }
-            self._entries.append(entry)
-
-            # Render if we're still in the DOM
-            self._remove_thinking()
-            if self._is_mounted_in_dom():
-                self._render_entry(entry)
-                self._update_status(f"Done | {src_count} sources | {t_total:.1f}s")
-
-        except asyncio.CancelledError:
-            logger.info("Q&A task cancelled")
-            self._remove_thinking()
-            return
-        except Exception as e:
-            logger.error(f"Q&A failed: {e}", exc_info=True)
-            self._remove_thinking()
-            if self._is_mounted_in_dom():
-                self._append_message(f"[bold red]Error:[/bold red] {e}")
-                self._update_status(f"Error: {e}")
-        finally:
-            self._is_asking = False
-            self._pending_question = None
 
     # -- Actions --
 
@@ -571,33 +343,31 @@ class QAScreen(HelpMixin, Widget):
         """Clear conversation history."""
         container = self.query_one("#qa-conversation", ScrollableContainer)
         container.remove_children()
-        self._entries.clear()
+        self._presenter.clear_history()
         self._source_ids.clear()
         self._show_welcome()
         self.notify("History cleared", timeout=1)
 
     def action_save_exchange(self) -> None:
         """Save the most recent Q&A exchange as a document."""
-        if not self._entries:
+        entries = self._presenter.state.entries
+        if not entries:
             self.notify("Nothing to save", timeout=2)
             return
 
-        entry = self._entries[-1]
-        question = entry["question"]
-        answer = entry["answer"]
-        docs = entry["sources"]
+        entry = entries[-1]
 
-        content = f"# Q: {question}\n\n{answer}\n"
-        if docs:
+        content = f"# Q: {entry.question}\n\n{entry.answer}\n"
+        if entry.sources:
             content += "\n## Sources\n\n"
-            for d in docs:
-                content += f"- Document #{d[0]}: {d[1]}\n"
+            for s in entry.sources:
+                content += f"- Document #{s.doc_id}: {s.title}\n"
 
         try:
             from emdx.models.documents import save_document
 
             doc_id = save_document(
-                title=f"Q&A: {question[:60]}",
+                title=f"Q&A: {entry.question[:60]}",
                 content=content,
                 tags=["qa", "auto"],
             )
@@ -608,7 +378,7 @@ class QAScreen(HelpMixin, Widget):
 
     async def action_exit_qa(self) -> None:
         """Cancel current question if asking, otherwise exit Q&A screen."""
-        if self._is_asking:
+        if self._presenter.state.is_asking:
             self._cancel_asking()
             return
         if hasattr(self.app, "switch_browser"):
@@ -634,12 +404,12 @@ class QAScreen(HelpMixin, Widget):
     def save_state(self) -> dict[str, Any]:
         """Save current state for restoration.
 
-        Conversation data lives in self._entries which survives on the
-        cached widget instance. on_mount rebuilds the DOM from entries.
+        Conversation data lives in the presenter which survives on the
+        cached widget instance. on_mount rebuilds the DOM from presenter state.
         """
         return {
-            "entry_count": len(self._entries),
-            "is_asking": self._is_asking,
+            "entry_count": len(self._presenter.state.entries),
+            "is_asking": self._presenter.state.is_asking,
         }
 
     def restore_state(self, state: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

- Wire QAPresenter into QAScreen, replacing ~130 lines of inline retrieval and Claude invocation with the presenter's typed dataclass-based flow
- Move terminal state save/restore into the presenter, wrapping both _retrieve and _stream_answer to prevent Textual terminal corruption
- Restore semantic search (previously disabled due to terminal corruption fears, now safe with save/restore wrapping)
- Replace untyped dict entries with QAEntry/QASource dataclasses throughout the screen
- Add _on_state_update callback architecture for reactive UI updates
- Add _on_chunk stub as hook point for future streaming (TUI-11)
- Add 5 terminal state tests to test_qa_presenter.py

## Test plan

- [x] ruff check passes (zero errors)
- [x] mypy passes on all modified files
- [x] pytest tests/test_qa_presenter.py - 39/39 tests pass
- [ ] Manual TUI test: Q&A tab, ask question, verify answer renders, sources show, status updates, Escape cancels

Generated with Claude Code