### PR TITLE
chore: Release v0.20.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "emdx",
-  "version": "0.18.0",
+  "version": "0.20.0",
   "description": "Knowledge base skills for Claude Code. Save research, delegate parallel work, and maintain session memory across conversations.",
   "author": {
     "name": "Alex Rockwell"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # emdx
 
-[![Version](https://img.shields.io/badge/version-0.19.0-blue.svg)](https://github.com/arockwell/emdx/releases)
+[![Version](https://img.shields.io/badge/version-0.20.0-blue.svg)](https://github.com/arockwell/emdx/releases)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
 

--- a/emdx/__init__.py
+++ b/emdx/__init__.py
@@ -6,7 +6,7 @@ import hashlib
 import time
 from pathlib import Path
 
-__version__ = "0.19.0"
+__version__ = "0.20.0"
 
 
 # Generate a unique build identifier based on current timestamp and file modification times

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "emdx"
-version = "0.19.0"
+version = "0.20.0"
 description = "Send agents. Save everything. Track what's next."
 authors = ["Alex Rockwell <arockwell@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Release v0.20.0 — the TUI release.

- Unified activity dashboard with three-tier view and section jump navigation
- Auto-wikify (three layers: title match, semantic, entity extraction)
- Claude Code hooks replacing delegate monolith lifecycle
- Task browser: live filter, epic grouping, status filter keys
- Structured delegate `--json` output
- `wontdo` status, `task priority`, display IDs
- Context-aware prime, QA presenter extraction

19 PRs merged since v0.19.0. 1445 tests passing.

## Checklist
- [x] `pyproject.toml` version bumped
- [x] `emdx/__init__.py` version bumped
- [x] `.claude-plugin/plugin.json` version bumped
- [x] `README.md` badge updated
- [x] `CHANGELOG.md` written
- [x] Tests passing