### PR TITLE
fix: pass --allowedTools to delegate subprocess (Issue #FIX-4)

### DIFF
--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -595,6 +595,21 @@ def _run_single(
     resolved_model = resolve_model_alias(model or "opus", CliTool.CLAUDE)
     cmd = ["claude", "--print", "--model", resolved_model]
 
+    # Grant tool permissions so delegates can operate without interactive approval.
+    # --print mode can't prompt for permission, so we must pre-authorize tools.
+    allowed = [
+        "Bash(git:*)",
+        "Bash(poetry:*)",
+        "Bash(ruff:*)",
+        "Bash(mypy:*)",
+        "Bash(pytest:*)",
+        "Bash(emdx:*)",
+    ]
+    if pr or branch:
+        allowed.append("Bash(gh pr:*)")
+        allowed.append("Bash(gh issue:*)")
+    cmd += ["--allowedTools", " ".join(allowed)]
+
     # Run the subprocess — hooks handle priming, saving, and task tracking
     effective_timeout = timeout if timeout is not None else DELEGATE_EXECUTION_TIMEOUT
     start_time = time.monotonic()


### PR DESCRIPTION
## Summary
- Delegates using `--pr` or `--branch` were silently failing to create PRs because `claude --print` mode can't prompt for interactive permission approval
- Root cause: `gh pr create` wasn't in the user's `~/.claude/settings.json` allow list, and `--print` mode has no way to ask
- Fix: pass `--allowedTools` flag to the Claude subprocess with git, poetry, linting, and emdx commands pre-authorized
- When `--pr` or `--branch` is set, also authorize `gh pr` and `gh issue` commands

## Test plan
- [ ] Run `emdx delegate --pr "simple task"` and verify PR is created
- [ ] Run `emdx delegate "simple task"` (no --pr) and verify gh pr is NOT in allowed tools
- [ ] Run `poetry run pytest tests/test_delegate_commands.py -x -q` (95 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)