### PR TITLE
feat: add doc_type column to documents table (Issue #1283)

### DIFF
--- a/emdx/database/documents.py
+++ b/emdx/database/documents.py
@@ -45,16 +45,26 @@ def save_document(
     project: str | None = None,
     tags: list[str] | None = None,
     parent_id: int | None = None,
+    doc_type: str | None = None,
 ) -> int:
     """Save a document to the knowledge base"""
     with db_connection.get_connection() as conn:
-        cursor = conn.execute(
-            """
-            INSERT INTO documents (title, content, project, parent_id)
-            VALUES (?, ?, ?, ?)
-        """,
-            (title, content, project, parent_id),
-        )
+        if doc_type is not None:
+            cursor = conn.execute(
+                """
+                INSERT INTO documents (title, content, project, parent_id, doc_type)
+                VALUES (?, ?, ?, ?, ?)
+            """,
+                (title, content, project, parent_id, doc_type),
+            )
+        else:
+            cursor = conn.execute(
+                """
+                INSERT INTO documents (title, content, project, parent_id)
+                VALUES (?, ?, ?, ?)
+            """,
+                (title, content, project, parent_id),
+            )
 
         # Get lastrowid before commit (required by SQLite)
         doc_id = cursor.lastrowid

--- a/emdx/database/types.py
+++ b/emdx/database/types.py
@@ -29,6 +29,7 @@ class DocumentRow(TypedDict):
     relationship: str | None
     archived_at: datetime | None
     stage: str | None
+    doc_type: str
 
 
 class DocumentListItem(TypedDict):

--- a/emdx/services/wiki_synthesis_service.py
+++ b/emdx/services/wiki_synthesis_service.py
@@ -436,6 +436,7 @@ def _save_article(
         with db.get_connection() as conn:
             conn.execute(
                 "UPDATE documents SET content = ?, title = ?, "
+                "doc_type = 'wiki', "
                 "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
                 (content, outline.suggested_title, doc_id),
             )
@@ -467,6 +468,7 @@ def _save_article(
         title=outline.suggested_title,
         content=content,
         tags=[WIKI_ARTICLE_TAG],
+        doc_type="wiki",
     )
 
     # Create wiki_articles metadata row


### PR DESCRIPTION
## Summary
- Adds migration 046: `doc_type TEXT DEFAULT 'user'` column on `documents` table with index, backfills existing wiki-article tagged docs to `doc_type='wiki'`
- Updates `save_document()` to accept optional `doc_type` parameter
- Updates `wiki_synthesis_service._save_article()` to set `doc_type='wiki'` on both new and updated wiki documents
- Updates `DocumentRow` TypedDict with `doc_type` field

This enables filtering document views by type, preventing wiki-generated content from polluting default user document listings.

## Test plan
- [x] All 1445 tests pass (16 skipped)
- [x] ruff check passes with zero errors on changed files
- [x] ruff format passes on changed files
- [x] mypy passes via pre-commit hook
- [ ] Manual: run migration on existing DB, verify wiki-article docs get backfilled

🤖 Generated with [Claude Code](https://claude.com/claude-code)