### PR TITLE
refactor: fold stale command into maintain subgroup (Issue #1411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,7 +421,7 @@ Two new commands for staying on top of agent activity:
 - **`emdx briefing`** — Generate an activity summary of recent delegate work
 
 #### Knowledge decay — stale docs and `touch` (#583)
-Documents now track freshness. `emdx maintain --stale` identifies documents that haven't been accessed recently. `emdx touch <id>` marks a document as still relevant, resetting its decay clock.
+Documents now track freshness. `emdx maintain stale list` identifies documents that haven't been accessed recently. `emdx maintain stale touch <id>` marks a document as still relevant, resetting its decay clock.
 
 #### Task system overhaul (#576, #582, #609)
 Tasks gained structure and visibility:

--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -1235,23 +1235,23 @@ emdx briefing --save --model sonnet
 
 ---
 
-## ⏳ Staleness Tracking (`emdx stale`)
+## ⏳ Staleness Tracking (`emdx maintain stale`)
 
 Track knowledge decay and identify documents needing review.
 
 ```bash
 # Show stale documents prioritized by urgency
-emdx stale list
+emdx maintain stale list
 ```
 
-### **emdx stale touch**
+### **emdx maintain stale touch**
 
 Reset a document's staleness timer without incrementing the view count.
 
 ```bash
 # Touch single document
-emdx stale touch 42
+emdx maintain stale touch 42
 
 # Touch multiple documents
-emdx stale touch 42 43 44
+emdx maintain stale touch 42 43 44
 ```

--- a/emdx/commands/maintain.py
+++ b/emdx/commands/maintain.py
@@ -1100,6 +1100,7 @@ def maintain_callback(
         cleanup      Clean up execution resources (branches, processes)
         cleanup-dirs Clean up temporary directories
         analyze      Analyze knowledge base health and patterns
+        stale        Knowledge decay and staleness tracking
     """
     if ctx.invoked_subcommand is not None:
         return
@@ -1916,6 +1917,11 @@ def wiki_runs_command(
 
 
 app.add_typer(wiki_app, name="wiki", help="Auto-wiki generation")
+
+# Register stale as a subcommand group of maintain
+from emdx.commands.stale import app as stale_app  # noqa: E402
+
+app.add_typer(stale_app, name="stale", help="Knowledge decay and staleness tracking")
 
 
 if __name__ == "__main__":

--- a/emdx/commands/stale.py
+++ b/emdx/commands/stale.py
@@ -2,8 +2,8 @@
 Knowledge decay commands for emdx.
 
 Provides staleness tracking to surface documents that need review:
-- `emdx stale` - Show documents needing review, prioritized by urgency
-- `emdx touch` - Reset staleness timer without incrementing view count
+- `emdx maintain stale list` - Show documents needing review, prioritized by urgency
+- `emdx maintain stale touch` - Reset staleness timer without incrementing view count
 """
 
 from datetime import datetime
@@ -230,12 +230,11 @@ def stale_list(
     Tag weights: security=3, gameplan=2, active=2, reference=2, default=1.
 
     Examples:
-        emdx stale              # Show all stale documents
-        emdx stale -l critical  # Show only critical ones
-        emdx stale --critical-days 15  # Custom threshold
+        emdx maintain stale list              # Show all stale documents
+        emdx maintain stale list -l critical  # Show only critical ones
+        emdx maintain stale list --critical-days 15  # Custom threshold
     """
     try:
-
         stale_docs = _get_stale_documents(
             critical_days=critical_days,
             warning_days=warning_days,
@@ -323,7 +322,7 @@ def stale_list(
 
         console.print(table)
         console.print()
-        console.print("[dim]💡 Use 'emdx touch <id>' to mark as reviewed[/dim]")
+        console.print("[dim]💡 Use 'emdx maintain stale touch <id>' to mark as reviewed[/dim]")
         console.print("[dim]💡 Use 'emdx view <id>' to review (also resets staleness)[/dim]")
 
     except Exception as e:
@@ -341,11 +340,10 @@ def touch(
     Use this when you've verified a document is still current.
 
     Examples:
-        emdx touch 42           # Touch single document
-        emdx touch 42 43 44     # Touch multiple documents
+        emdx maintain stale touch 42           # Touch single document
+        emdx maintain stale touch 42 43 44     # Touch multiple documents
     """
     try:
-
         touched = []
         not_found = []
 

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -91,7 +91,6 @@ from emdx.commands.core import app as core_app  # noqa: E402
 from emdx.commands.gist import app as gist_app  # noqa: E402
 from emdx.commands.maintain import app as maintain_app  # noqa: E402
 from emdx.commands.prime import prime as prime_command  # noqa: E402
-from emdx.commands.stale import app as stale_app  # noqa: E402
 from emdx.commands.status import status as status_command  # noqa: E402
 from emdx.commands.tags import app as tag_app  # noqa: E402
 from emdx.commands.tasks import app as tasks_app  # noqa: E402
@@ -137,9 +136,6 @@ app.add_typer(tasks_app, name="task", help="Agent work queue")
 
 # Add maintain as a subcommand group (includes maintain, cleanup, cleanup-dirs, analyze)
 app.add_typer(maintain_app, name="maintain", help="Maintenance and analysis tools")
-
-# Add stale as a subcommand group for knowledge decay
-app.add_typer(stale_app, name="stale", help="Knowledge decay and staleness tracking")
 
 # Add the prime command for Claude session priming
 app.command(name="prime")(prime_command)

--- a/tests/test_commands_stale.py
+++ b/tests/test_commands_stale.py
@@ -118,7 +118,7 @@ class TestStaleCommand:
 
     def test_stale_list_help(self) -> None:
         """Stale list command shows help."""
-        result = runner.invoke(app, ["stale", "list", "--help"])
+        result = runner.invoke(app, ["maintain", "stale", "list", "--help"])
         assert result.exit_code == 0
         assert "CRITICAL" in result.output
         assert "WARNING" in result.output
@@ -126,7 +126,7 @@ class TestStaleCommand:
 
     def test_stale_list_empty(self) -> None:
         """No stale documents shows success message."""
-        result = runner.invoke(app, ["stale", "list"])
+        result = runner.invoke(app, ["maintain", "stale", "list"])
         assert result.exit_code == 0
         assert "fresh" in result.output.lower() or "no stale" in result.output.lower()
 
@@ -145,7 +145,7 @@ class TestStaleCommand:
             )
             conn.commit()
 
-        result = runner.invoke(app, ["stale", "list", "--json"])
+        result = runner.invoke(app, ["maintain", "stale", "list", "--json"])
         assert result.exit_code == 0
         # Should be valid JSON
         import json
@@ -171,13 +171,13 @@ class TestTouchCommand:
 
     def test_touch_help(self) -> None:
         """Touch command shows help."""
-        result = runner.invoke(app, ["stale", "touch", "--help"])
+        result = runner.invoke(app, ["maintain", "stale", "touch", "--help"])
         assert result.exit_code == 0
         assert "staleness" in result.output.lower()
 
     def test_touch_nonexistent(self) -> None:
         """Touching nonexistent document reports not found."""
-        result = runner.invoke(app, ["stale", "touch", "99999"])
+        result = runner.invoke(app, ["maintain", "stale", "touch", "99999"])
         assert "not found" in result.output.lower() or result.exit_code == 1
 
     def test_touch_existing_doc(self) -> None:
@@ -187,7 +187,7 @@ class TestTouchCommand:
 
         doc_id = save_document("Test Doc", "Test content")
 
-        result = runner.invoke(app, ["stale", "touch", str(doc_id)])
+        result = runner.invoke(app, ["maintain", "stale", "touch", str(doc_id)])
         assert result.exit_code == 0
         assert "touched" in result.output.lower()
 
@@ -198,7 +198,7 @@ class TestTouchCommand:
         doc1 = save_document("Test Doc 1", "Content 1")
         doc2 = save_document("Test Doc 2", "Content 2")
 
-        result = runner.invoke(app, ["stale", "touch", str(doc1), str(doc2)])
+        result = runner.invoke(app, ["maintain", "stale", "touch", str(doc1), str(doc2)])
         assert result.exit_code == 0
         assert "2" in result.output  # Should mention 2 documents
 


### PR DESCRIPTION
## Summary
- Moved `emdx stale list` and `emdx stale touch` to `emdx maintain stale list` and `emdx maintain stale touch`
- Removed top-level `stale` registration from `main.py`; registered `stale_app` as a sub-typer under the `maintain` group in `maintain.py`
- Updated all CLI help text, docstrings, docs, CHANGELOG, and test invocations to use the new `maintain stale` path

## Test plan
- [x] All 19 stale command tests pass with updated paths
- [x] Full test suite passes (1475 passed, 16 skipped)
- [x] `ruff check` passes with zero errors
- [x] Pre-commit hooks pass (ruff, format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)