### PR TITLE
feat: add command aliases using Click's get_command() pattern (Issue #1429)

### DIFF
--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -12,9 +12,10 @@ from emdx.commands.categories import app as categories_app
 from emdx.commands.epics import app as epics_app
 from emdx.models import tasks
 from emdx.models.types import TaskDict
+from emdx.utils.lazy_group import make_alias_group
 from emdx.utils.output import console, is_non_interactive, print_json
 
-app = typer.Typer(help="Agent work queue")
+app = typer.Typer(help="Agent work queue", cls=make_alias_group({"create": "add"}))
 app.add_typer(epics_app, name="epic", help="Manage task epics")
 app.add_typer(categories_app, name="cat", help="Manage task categories")
 

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 import typer
 
 from emdx import __version__
-from emdx.utils.lazy_group import LazyTyperGroup, register_lazy_commands
+from emdx.utils.lazy_group import LazyTyperGroup, register_aliases, register_lazy_commands
 
 # =============================================================================
 # LAZY COMMANDS - Heavy features (defer import until invoked)
@@ -79,6 +79,9 @@ def create_disabled_command(name: str) -> Callable[[], None]:
 # Register lazy commands BEFORE importing any Typer apps
 # This ensures the registry is populated when LazyTyperGroup is instantiated
 register_lazy_commands(get_lazy_subcommands(), get_lazy_help())
+
+# Register top-level command aliases (alias -> canonical name)
+register_aliases({"show": "view"})
 
 # =============================================================================
 # EAGER IMPORTS - Core KB commands (fast, always needed)


### PR DESCRIPTION
## Summary

- Add alias support to the CLI via `get_command()` override pattern (no argv rewriting)
- **Top-level**: `emdx show 42` works like `emdx view 42` — alias registered via global `_ALIAS_REGISTRY`
- **Task subgroup**: `emdx task create "title"` works like `emdx task add "title"` — alias via `make_alias_group()` factory

### Implementation

- `_AliasFormatMixin`: Mixin that annotates help output with alias info (e.g. `view (show)`) for non-Rich help mode
- `AliasGroup(TyperGroup)`: Lightweight group with alias resolution, suitable for subcommand groups
- `make_alias_group()`: Factory that produces `AliasGroup` subclasses with baked-in aliases, needed because Typer doesn't pass custom kwargs to `cls`
- `LazyTyperGroup`: Extended with alias support via the same mixin + global alias registry

### Files changed

- `emdx/utils/lazy_group.py` — Core alias infrastructure (AliasGroup, make_alias_group, registry)
- `emdx/main.py` — Register top-level `show` → `view` alias
- `emdx/commands/tasks.py` — Use `make_alias_group({"create": "add"})` as task app's `cls`

## Test plan

- [x] `emdx show --help` shows view command help
- [x] `emdx task create --help` shows add command help
- [x] All existing tests pass (34 lazy loading, 34 CLI, 102 task command tests)
- [x] `ruff check .` passes with zero errors
- [x] Pre-commit hooks (ruff, ruff-format, mypy) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)