### PR TITLE
fix: pass limit to synthesis _run_single in _run_parallel (Issue #1426)

### DIFF
--- a/emdx/commands/delegate.py
+++ b/emdx/commands/delegate.py
@@ -1008,6 +1008,7 @@ def _run_parallel(
             model=model,
             quiet=True,
             parent_task_id=parent_task_id,
+            limit=limit,
         )
         if synthesis_result_obj.doc_id:
             doc_ids.append(synthesis_result_obj.doc_id)


### PR DESCRIPTION
## Summary

- Wire `limit` parameter through to the synthesis `_run_single` call in `_run_parallel`
- Individual parallel tasks correctly received `limit`, but when `--synthesize` was used, the synthesis task ran without any cost limit
- Added test verifying limit is passed to the synthesis call

## Test plan

- [x] New test `test_parallel_synthesize_passes_limit` verifies the synthesis `_run_single` call receives `limit`
- [x] All existing delegate tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)