### PR TITLE
fix: hide done tasks in epic grouping on task screen (Issue #1429)

### DIFF
--- a/emdx/ui/task_view.py
+++ b/emdx/ui/task_view.py
@@ -412,12 +412,9 @@ class TaskView(Widget):
         finished = {"done", "failed", "wontdo"}
         first_group = True
         for epic_key in epic_keys:
-            tasks = tasks_by_epic[epic_key]
+            # Hide finished tasks in epic grouping
+            tasks = [t for t in tasks_by_epic[epic_key] if t["status"] not in finished]
             if not tasks:
-                continue
-
-            # Hide epic groups where all tasks are done/failed
-            if all(t["status"] in finished for t in tasks):
                 continue
 
             if not first_group:


### PR DESCRIPTION
## Summary

- Filter out done/failed/wontdo tasks when viewing tasks grouped by epic (`g` key), so only actionable tasks are visible
- Previously, individual done tasks still appeared within epics that had open tasks — now they're hidden
- Epic headers still show full progress counts (e.g., "AUTH (7/10 done)") from the database
- Simplifies the existing "hide all-done groups" logic — filtering tasks first makes empty groups naturally skipped

## Test plan

- [x] `poetry run pytest tests/test_task_browser.py -x -q` — 72 tests pass (1 new)
- [x] `poetry run ruff check emdx/ui/task_view.py` — lint clean
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)
- [ ] Manual: run TUI, press `g` to toggle epic grouping, confirm done tasks are hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)