### PR TITLE
docs: fix stale references in development-setup.md (Issue #1455)

### DIFF
--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -127,7 +127,7 @@ run_migrations()
 
 #### **Database Location**
 - **Default**: `~/.emdx/emdx.db`
-- **Custom**: Set `EMDX_DB_PATH` environment variable
+- **Custom**: Set `EMDX_DATABASE_URL` environment variable
 - **Testing**: Temporary databases created automatically
 
 ### **TUI Development**
@@ -154,13 +154,12 @@ tests/
 ├── conftest.py              # Pytest configuration and fixtures
 ├── test_commands_core.py    # Core command tests (save, find, view)
 ├── test_commands_tags.py    # Tag command tests
-├── test_commands_groups.py  # Group command tests
 ├── test_task_commands.py    # Task command tests
 ├── test_database.py         # Database operations
 ├── test_documents.py        # Document CRUD
 ├── test_core.py             # Core CLI commands
 ├── test_log_browser.py      # TUI component tests
-└── ...                      # 52 test files total (see testing.md)
+└── ...                      # 65 test files total
 ```
 
 ### **Common Test Patterns**
@@ -385,7 +384,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 ```
-This allows callers to configure logging as needed. The `emdx/utils/logging.py` module provides `get_logger()` for cases requiring automatic file handler setup, but standard library usage is preferred for most modules.
+This allows callers to configure logging as needed. The `emdx/utils/logging_utils.py` module provides `get_logger()` for cases requiring automatic file handler setup, but standard library usage is preferred for most modules.
 
 #### **Console Output Standards**
 Use the shared console instance for CLI output:
@@ -394,7 +393,7 @@ from emdx.utils.output import console
 
 console.print("[green]Success![/green]")
 ```
-This ensures consistent formatting across the CLI. Use `emdx/utils/cli.py` decorators for standardized error handling.
+This ensures consistent formatting across the CLI.
 
 ### **Commit Message Format**
 ```


### PR DESCRIPTION
## Summary
- Corrected `emdx/utils/logging.py` → `emdx/utils/logging_utils.py` (actual file path)
- Removed reference to nonexistent `emdx/utils/cli.py`
- Updated test file count from 52 to 65 (current actual count)
- Fixed env var name `EMDX_DB_PATH` → `EMDX_DATABASE_URL` (matches `main.py` line 172)
- Removed stale `test_commands_groups.py` from test listing (group system was removed)

## Test plan
- [ ] Verify all referenced file paths exist in the codebase
- [ ] Confirm `EMDX_DATABASE_URL` matches the env var used in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)