### PR TITLE
feat: add two-pane layout with source panel for QA (Issue #TUI-13)

### DIFF
--- a/emdx/ui/qa/qa_presenter.py
+++ b/emdx/ui/qa/qa_presenter.py
@@ -66,6 +66,7 @@ class QASource:
 
     doc_id: int
     title: str
+    snippet: str = ""
 
 
 @dataclass
@@ -197,8 +198,15 @@ class QAPresenter:
             if self._cancel_event.is_set():
                 return
 
-            # Build sources list
-            entry.sources = [QASource(doc_id=d[0], title=d[1]) for d in docs]
+            # Build sources list with content snippets
+            entry.sources = [
+                QASource(
+                    doc_id=d[0],
+                    title=d[1],
+                    snippet=d[2][:200] if len(d) > 2 else "",
+                )
+                for d in docs
+            ]
 
             # 2. Stream the answer
             self._state.status_text = "Generating answer..."

--- a/tests/test_qa_presenter.py
+++ b/tests/test_qa_presenter.py
@@ -25,6 +25,13 @@ class TestQADataclasses:
         source = QASource(doc_id=42, title="Test Document")
         assert source.doc_id == 42
         assert source.title == "Test Document"
+        assert source.snippet == ""
+
+    def test_qa_source_with_snippet(self) -> None:
+        """Verify QASource with explicit snippet value."""
+        source = QASource(doc_id=7, title="Doc", snippet="Some content preview...")
+        assert source.doc_id == 7
+        assert source.snippet == "Some content preview..."
 
     def test_qa_entry_defaults(self) -> None:
         """Verify QAEntry dataclass has correct defaults."""
@@ -40,7 +47,10 @@ class TestQADataclasses:
 
     def test_qa_entry_full_fields(self) -> None:
         """Verify QAEntry with all fields set."""
-        sources = [QASource(doc_id=1, title="Doc 1"), QASource(doc_id=2, title="Doc 2")]
+        sources = [
+            QASource(doc_id=1, title="Doc 1", snippet="Preview of doc 1"),
+            QASource(doc_id=2, title="Doc 2", snippet="Preview of doc 2"),
+        ]
         entry = QAEntry(
             question="How does authentication work?",
             answer="Authentication uses JWT tokens...",


### PR DESCRIPTION
## Summary

- Adds a right-side source panel (40/60 split) to the QA screen showing retrieved documents with numbered items, titles, and content snippets
- Clicking a source shows the full document rendered as markdown inline with a back button to return to the source list
- Snippets are markdown-stripped for clean plain-text display in the list view
- Tab toggles focus between input and conversation; Escape closes preview/cancels/exits

## Technical notes

- Uses Textual Markdown widget for preview (handles sizing correctly unlike RichLog in hidden containers)
- Unique IDs on dynamically mounted source items to avoid DuplicateIds from Textual async remove_children()
- QASource dataclass extended with snippet field populated from first 200 chars of document content

## Test plan

- [x] pytest tests/test_qa_presenter.py — 42 tests pass
- [x] ruff check — clean
- [x] ruff format --check — clean
- [x] Pre-commit hooks pass (ruff, mypy)
- [ ] Manual: Q&A screen — ask question — verify source panel populates on right
- [ ] Manual: click source — verify markdown preview renders inline
- [ ] Manual: click Back — verify source list restores
- [ ] Manual: Tab/Shift+Tab toggles input focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)