### PR TITLE
docs: add delegate cleanup gotchas to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,12 @@ grep -E "ERROR|WARNING|CRITICAL" ~/.config/emdx/tui_debug.log | tail -30
 - `logger.debug("msg")` will NOT appear in TUI logs — emdx.* level is INFO. Use `logger.info()` or `logger.warning()` for debug output that must be visible.
 - TUI logs and CLI logs go to DIFFERENT files. If you're debugging the GUI, check `tui_debug.log`, not `emdx.log`.
 
+## Delegate Cleanup Gotchas
+
+- When delegates remove functions, they sometimes miss: (1) tests importing the removed code, (2) private methods called from OTHER files, (3) entirely dead files that should be deleted not just pruned
+- Always check CI after delegate cleanup PRs — `ImportError` in tests is the most common failure mode
+- When multiple delegate PRs touch the same file, merge one at a time — they WILL conflict with each other
+
 ## Known Gotchas
 
 - **`emdx find` does not support OR/AND/NOT** — `escape_fts5_query()` quotes each term, making operators literal. Use separate find calls or `--tags` with `--any-tags`.


### PR DESCRIPTION
## Summary

- Add "Delegate Cleanup Gotchas" section to CLAUDE.md documenting pitfalls learned from the dead code cleanup session
- Three key lessons: (1) delegates miss test imports of removed code, (2) private methods called cross-file get incorrectly removed, (3) parallel PRs touching the same file will conflict

## Test plan

- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)