### PR TITLE
feat: SubagentStop plugin hook for auto-saving research to KB

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "emdx plugin hooks: auto-save subagent research output to knowledge base",
+  "hooks": {
+    "SubagentStop": [
+      {
+        "matcher": "Explore|general-purpose",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/save-subagent-output.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/save-subagent-output.sh
+++ b/hooks/save-subagent-output.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SubagentStop hook: auto-save Task subagent output to the emdx knowledge base.
+#
+# Receives JSON on stdin with keys:
+#   agent_type, last_assistant_message, stop_hook_active
+#
+# Only saves substantive output (200+ chars) from Explore/general-purpose agents.
+# Skips delegate sessions (EMDX_AUTO_SAVE=1) to avoid double-saving.
+#
+# All saved docs are tagged "subagent,needs-review" for human curation.
+set -euo pipefail
+
+# Read full stdin JSON
+INPUT=$(cat)
+
+# Skip if inside a delegate session (has its own save-output.sh hook)
+if [[ "${EMDX_AUTO_SAVE:-}" == "1" ]]; then
+    exit 0
+fi
+
+# Single python3 block: parse JSON, apply filters, save to emdx.
+# Receives the raw JSON via env var to avoid shell escaping issues.
+export _EMDX_HOOK_INPUT="$INPUT"
+python3 -c '
+import json
+import os
+import subprocess
+import sys
+
+data = json.loads(os.environ["_EMDX_HOOK_INPUT"])
+
+# Guard: re-entry protection
+if data.get("stop_hook_active", False):
+    sys.exit(0)
+
+# Extract message
+msg = data.get("last_assistant_message", "")
+if not msg:
+    sys.exit(0)
+
+# Guard: skip short/trivial output
+if len(msg) < 200:
+    sys.exit(0)
+
+# Check emdx is available
+result = subprocess.run(["which", "emdx"], capture_output=True)
+if result.returncode != 0:
+    sys.exit(0)
+
+# Derive title from first non-empty line, truncated to 80 chars
+title = ""
+for line in msg.splitlines():
+    stripped = line.strip().lstrip("#").strip()
+    if stripped:
+        title = stripped[:80]
+        break
+if not title:
+    title = "Subagent output"
+
+# Save to KB
+try:
+    subprocess.run(
+        ["emdx", "save", "--title", title, "--tags", "subagent,needs-review"],
+        input=msg,
+        text=True,
+        capture_output=True,
+        timeout=20,
+    )
+except Exception:
+    pass
+' || true


### PR DESCRIPTION
## Summary

- Adds a `SubagentStop` plugin hook (`hooks/hooks.json`) that fires when Explore or general-purpose Task subagents complete
- Hook script (`hooks/save-subagent-output.sh`) auto-saves substantive output (200+ chars) to the emdx knowledge base
- All saved docs tagged `subagent,needs-review` for human curation
- Guards prevent double-saving in delegate sessions, re-entry, and trivial output

## Test plan

- [x] Manual test: pipe valid JSON with 200+ char message → doc saved with correct tags
- [x] Guard test: short message (<200 chars) → no doc saved
- [x] Guard test: `EMDX_AUTO_SAVE=1` → skipped (delegate session)
- [x] Guard test: `stop_hook_active: true` → skipped (re-entry)
- [ ] End-to-end: install plugin, spawn Task subagent, verify auto-save fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)