### PR TITLE
feat: add marketplace.json for plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "arockwell-emdx",
+  "description": "Knowledge base skills for Claude Code. Save research, delegate parallel work, and maintain session memory across conversations.",
+  "owner": {
+    "name": "Alex Rockwell"
+  },
+  "plugins": [
+    {
+      "name": "emdx",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/arockwell/emdx.git"
+      },
+      "description": "Knowledge base skills for Claude Code. Save research, delegate parallel work, and maintain session memory across conversations.",
+      "version": "0.21.0",
+      "author": {
+        "name": "Alex Rockwell"
+      },
+      "category": "productivity",
+      "homepage": "https://github.com/arockwell/emdx",
+      "repository": "https://github.com/arockwell/emdx",
+      "license": "MIT",
+      "keywords": ["knowledge-base", "research", "delegate", "persistence", "memory"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` so emdx can be installed via Claude Code's plugin marketplace
- Users can now run `/plugin marketplace add arockwell/emdx` followed by `/plugin install emdx@arockwell-emdx`
- Skills like `/emdx:save`, `/emdx:delegate`, `/emdx:research` become available in any project

## Test plan
- [ ] Run `/plugin marketplace add arockwell/emdx` from a fresh Claude Code session
- [ ] Run `/plugin install emdx@arockwell-emdx`
- [ ] Verify skills appear with `emdx:` namespace in a non-emdx project

🤖 Generated with [Claude Code](https://claude.com/claude-code)