### PR TITLE
fix: hide fully-done epics in task browser epic group view

### DIFF
--- a/emdx/ui/task_view.py
+++ b/emdx/ui/task_view.py
@@ -481,6 +481,9 @@ class TaskView(Widget):
             ]
             if not child_tasks and not epic_tasks:
                 continue
+            # Skip fully-finished epics with no open children
+            if not child_tasks and epic_tasks and epic_tasks[0]["status"] in finished:
+                continue
 
             if not first_group:
                 table.add_row(


### PR DESCRIPTION
## Summary
- Done epics with no open children were still showing as group headers in the "by epic" task view
- Skip the entire epic group when the epic is finished (done/failed/wontdo) and has zero open child tasks
- Fixes #1234 appearing at top of the epic-grouped task list despite being 100% complete

## Test plan
- [x] `test_task_browser.py` — 72 tests pass
- [ ] Open TUI task browser, group by epic, verify done epics no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)