### PR TITLE
fix: --done flag on task list shows only done tasks (Issue #1503)

### DIFF
--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -448,7 +448,7 @@ def blocked(
 def list_cmd(
     status: str | None = typer.Option(None, "-s", "--status", help="Filter by status (comma-sep)"),
     all: bool = typer.Option(False, "--all", "-a", help="Include delegate tasks"),
-    done: bool = typer.Option(False, "--done", help="Include done/failed tasks"),
+    done: bool = typer.Option(False, "--done", help="Show done tasks"),
     limit: int = typer.Option(20, "-n", "--limit"),
     epic: int | None = typer.Option(None, "-e", "--epic", help="Filter by epic ID"),
     cat: str | None = typer.Option(None, "-c", "--cat", help="Filter by category"),
@@ -456,7 +456,7 @@ def list_cmd(
 ) -> None:
     """List tasks.
 
-    By default shows open, active, and blocked tasks (hides done/failed).
+    By default shows open, active, and blocked tasks (hides done).
 
     Examples:
         emdx task list
@@ -468,10 +468,10 @@ def list_cmd(
     """
     if status:
         status_list = [s.strip() for s in status.split(",")]
-    elif not done:
-        status_list = ["open", "active", "blocked"]
+    elif done:
+        status_list = ["done"]
     else:
-        status_list = None
+        status_list = ["open", "active", "blocked"]
 
     exclude_delegate = not all
     task_list = tasks.list_tasks(


### PR DESCRIPTION
## Summary

- `emdx task list --done` previously set `status_list = None`, removing all filtering and showing every status (open, active, blocked, done, failed, wontdo, closed)
- Now it filters to `["done"]` — done means done
- Updated help text from "Include done/failed tasks" to "Show done tasks"

## Test plan

- [ ] `emdx task list --done` shows only done tasks
- [ ] `emdx task list` still shows open/active/blocked (default unchanged)
- [ ] `emdx task list -s failed` still works for explicit status filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)