### PR TITLE
perf: defer sentence-transformers import to QA screen load

### DIFF
--- a/emdx/ui/run_browser.py
+++ b/emdx/ui/run_browser.py
@@ -19,18 +19,6 @@ def run_browser(theme: str | None = None) -> None:
 
     from .browser_container import BrowserContainer
 
-    # Eagerly import sentence-transformers BEFORE Textual enters application
-    # mode.  This library (or its torch dependency) corrupts terminal state
-    # on Python 3.13.  Importing it here — while the terminal is still in
-    # normal cooked mode — means the damage is harmless.  Textual's own
-    # startup will then set up raw mode + mouse tracking cleanly afterward.
-    try:
-        from sentence_transformers import SentenceTransformer  # noqa: F401
-
-        logger.info("Pre-loaded sentence-transformers for QA")
-    except ImportError:
-        pass
-
     app = BrowserContainer(initial_theme=theme)
     try:
         logger.info("=== STARTING BROWSER APP ===")

--- a/tests/test_qa_presenter.py
+++ b/tests/test_qa_presenter.py
@@ -87,7 +87,8 @@ class TestQAPresenterInitialization:
             patch("shutil.which", return_value="/usr/bin/claude"),
             patch.object(presenter, "_has_embeddings", return_value=False),
         ):
-            await presenter.initialize()
+            presenter.initialize_sync()
+            await presenter.preload_embeddings()
 
         assert presenter.state.has_claude_cli is True
         assert "Ready" in presenter.state.status_text
@@ -100,7 +101,8 @@ class TestQAPresenterInitialization:
             patch("shutil.which", return_value=None),
             patch.object(presenter, "_has_embeddings", return_value=False),
         ):
-            await presenter.initialize()
+            presenter.initialize_sync()
+            await presenter.preload_embeddings()
 
         assert presenter.state.has_claude_cli is False
         assert "Claude CLI not found" in presenter.state.status_text
@@ -113,7 +115,8 @@ class TestQAPresenterInitialization:
             patch("shutil.which", return_value="/usr/bin/claude"),
             patch.object(presenter, "_has_embeddings", return_value=True),
         ):
-            await presenter.initialize()
+            presenter.initialize_sync()
+            await presenter.preload_embeddings()
 
         assert presenter.state.has_embeddings is True
         assert "semantic" in presenter.state.status_text
@@ -127,7 +130,8 @@ class TestQAPresenterInitialization:
             patch("shutil.which", return_value="/usr/bin/claude"),
             patch.object(presenter, "_has_embeddings", return_value=False),
         ):
-            await presenter.initialize()
+            presenter.initialize_sync()
+            await presenter.preload_embeddings()
 
         mock_callback.assert_called()
         # Callback should receive the state


### PR DESCRIPTION
## Summary
- Remove eager sentence_transformers import from run_browser.py that added ~2.5s to every TUI launch
- Split QAPresenter.initialize() into initialize_sync() (fast: CLI check + load history) and preload_embeddings() (slow: ~2.5s import in background thread)
- QA screen paints instantly with history, shows "Loading embeddings..." status, blocks question submission until ready

## Test plan
- [ ] TUI launches instantly (no ~2.5s delay)
- [ ] Press 3 for QA — history loads immediately, status shows "Loading embeddings..."
- [ ] After ~2-3s status changes to "Ready | semantic retrieval"
- [ ] Submitting a question before loading finishes shows "Still loading — please wait" toast
- [ ] Submitting a question after loading works normally
- [ ] poetry run pytest tests/ -x -q -k qa passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)