### PR TITLE
fix: wiki generate --dry-run summary counter (Issue #847)

### DIFF
--- a/emdx/commands/wiki.py
+++ b/emdx/commands/wiki.py
@@ -329,17 +329,25 @@ def wiki_generate(
         )
         elapsed = _time.time() - start
 
-        if result.skipped:
+        if result.skipped and result.skip_reason != "dry run":
             skipped += 1
             console.print(f"[dim]{result.skip_reason} ({elapsed:.1f}s)[/dim]")
         else:
             generated += 1
-            console.print(
-                f"[green]#{result.document_id}[/green] "
-                f"'{result.topic_label[:40]}' "
-                f"({result.input_tokens:,}+{result.output_tokens:,} tok, "
-                f"${result.cost_usd:.4f}, {elapsed:.1f}s)"
-            )
+            if dry_run:
+                console.print(
+                    f"[cyan]would generate[/cyan] "
+                    f"'{result.topic_label[:40]}' "
+                    f"(~{result.input_tokens:,}+{result.output_tokens:,} tok, "
+                    f"~${result.cost_usd:.4f}, {elapsed:.1f}s)"
+                )
+            else:
+                console.print(
+                    f"[green]#{result.document_id}[/green] "
+                    f"'{result.topic_label[:40]}' "
+                    f"({result.input_tokens:,}+{result.output_tokens:,} tok, "
+                    f"${result.cost_usd:.4f}, {elapsed:.1f}s)"
+                )
             if result.warnings:
                 for w in result.warnings:
                     console.print(f"    [yellow]⚠ {w}[/yellow]")

--- a/emdx/services/wiki_synthesis_service.py
+++ b/emdx/services/wiki_synthesis_service.py
@@ -978,7 +978,7 @@ def generate_wiki(
         )
         results.append(result)
 
-        if result.skipped:
+        if result.skipped and result.skip_reason != "dry run":
             skipped += 1
         else:
             generated += 1


### PR DESCRIPTION
## Summary

- `wiki generate --dry-run` showed "Estimated 0 articles (skipped N)" because dry-run results were counted as skipped instead of generated
- `generate_article()` returns `skipped=True, skip_reason="dry run"` in dry-run mode, but both the CLI command and `generate_wiki()` service treated all `skipped=True` results as truly skipped
- This also broke the batch `--limit` check since `generated` never incremented

## Changes

- **`emdx/services/wiki_synthesis_service.py`**: In `generate_wiki()`, check `skip_reason != "dry run"` before counting as skipped
- **`emdx/commands/wiki.py`**: Same fix in `wiki_generate()` CLI command, plus improved per-topic output showing "would generate" with estimated costs in dry-run mode

## Test plan

- [x] Existing wiki tests pass (31+31 tests)
- [x] ruff lint + format + mypy all pass
- [ ] Manual: `emdx maintain wiki generate --all --dry-run` should now show correct article/skip counts