### PR TITLE
fix: filter wiki topic clusters by entity type (Issue #845)

### DIFF
--- a/emdx/commands/wiki.py
+++ b/emdx/commands/wiki.py
@@ -81,6 +81,17 @@ def wiki_topics(
     resolution: float = typer.Option(0.005, "--resolution", "-r", help="Clustering resolution"),
     save: bool = typer.Option(False, "--save", help="Save discovered topics to DB"),
     min_size: int = typer.Option(3, "--min-size", help="Minimum cluster size"),
+    entity_types: list[str] = typer.Option(
+        ["heading", "proper_noun"],
+        "--entity-types",
+        "-e",
+        help="Entity types to use for clustering (default: heading, proper_noun)",
+    ),
+    min_df: int = typer.Option(
+        2,
+        "--min-df",
+        help="Minimum document frequency for an entity to be included",
+    ),
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Show extra columns (model override, editorial prompt)"
     ),
@@ -92,6 +103,8 @@ def wiki_topics(
         emdx maintain wiki topics --save       # Save to DB
         emdx maintain wiki topics -r 0.01      # Finer resolution
         emdx maintain wiki topics --verbose    # Show model overrides and editorial prompts
+        emdx maintain wiki topics -e heading -e proper_noun -e concept  # Custom entity types
+        emdx maintain wiki topics --entity-types heading  # Only headings
     """
     from rich.table import Table
 
@@ -148,7 +161,12 @@ def wiki_topics(
         console=console,
     ) as progress:
         task = progress.add_task("Discovering topics...", total=None)
-        result = discover_topics(resolution=resolution, min_cluster_size=min_size)
+        result = discover_topics(
+            resolution=resolution,
+            min_cluster_size=min_size,
+            entity_types=entity_types or None,
+            min_df=min_df,
+        )
         progress.update(task, completed=True)
 
     console.print(


### PR DESCRIPTION
## Summary

- Add `entity_types` filter to `_get_entity_doc_matrix()` and `discover_topics()` in `wiki_clustering_service.py` — when specified, only entities of the given types are included in the co-occurrence graph
- Default `wiki topics` CLI to `--entity-types heading proper_noun`, avoiding noisy `tech_term`/`concept` singleton code identifiers that dominate cluster labels in code-heavy KBs
- Add `--min-df` flag to control minimum document frequency threshold for entity pruning
- Both parameters are fully optional and backward-compatible (passing no entity types uses all types, matching previous behavior)

## Test plan

- [x] `ruff check` passes with zero errors
- [x] `mypy` passes (no new errors)
- [x] All 54 wiki tests pass
- [ ] Manual: run `emdx maintain wiki topics` on a code-heavy KB and verify labels use headings/proper nouns instead of raw code identifiers
- [ ] Manual: run `emdx maintain wiki topics -e heading -e proper_noun -e concept` to verify custom entity type selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)