### PR TITLE
feat: add `task cat rename` for category rename/merge (Issue #842)

### DIFF
--- a/emdx/models/types.py
+++ b/emdx/models/types.py
@@ -71,6 +71,12 @@ class CategoryWithStatsDict(CategoryDict):
     total_count: int
 
 
+class CategoryRenameResultDict(TypedDict):
+    tasks_moved: int
+    epics_moved: int
+    old_category_deleted: bool
+
+
 class TagStatsDict(TypedDict):
     id: int
     name: str


### PR DESCRIPTION
## Summary

- Adds `emdx task cat rename OLD NEW` command that moves all tasks from one category into another
- Handles sequence renumbering automatically — if the target category already has tasks, incoming tasks get the next available sequence numbers (no conflicts)
- Retitles tasks from `OLD-N: title` to `NEW-M: title` with the new sequence
- Deletes the source category after all tasks are moved
- Supports `--name` flag to set the target category's display name

Closes #842

## Test plan

- [x] 38 tests pass (`pytest tests/test_categories.py`)
- [x] Simple rename (target doesn't exist) — creates target, moves tasks, deletes source
- [x] Merge into existing category — renumbers to avoid seq conflicts
- [x] Epics moved along with regular tasks
- [x] `--name` override works
- [x] Error cases: same key, source not found, invalid target key
- [x] Case-insensitive input
- [x] CLI command wiring (success, not found, same key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)