### PR TITLE
test: add non-interactive auto-confirm tests (Issue #9)

### DIFF
--- a/tests/test_non_interactive.py
+++ b/tests/test_non_interactive.py
@@ -1,0 +1,101 @@
+"""Tests for non-interactive terminal detection and auto-confirmation behavior.
+
+Verifies that commands with confirmation prompts automatically skip them
+when stdin is not a TTY (e.g. running inside Claude Code or piped input).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from emdx.utils.output import is_non_interactive
+
+runner = CliRunner()
+
+
+def _out(result: Any) -> str:
+    """Strip ANSI escape sequences from CliRunner output for assertions."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# is_non_interactive() unit tests
+# ---------------------------------------------------------------------------
+class TestIsNonInteractive:
+    """Unit tests for the is_non_interactive() utility function."""
+
+    @patch("sys.stdin")
+    def test_returns_true_when_not_tty(self, mock_stdin: Any) -> None:
+        """Non-TTY stdin (piped, agent mode) returns True."""
+        mock_stdin.isatty.return_value = False
+        assert is_non_interactive() is True
+
+    @patch("sys.stdin")
+    def test_returns_false_when_tty(self, mock_stdin: Any) -> None:
+        """Interactive TTY stdin returns False."""
+        mock_stdin.isatty.return_value = True
+        assert is_non_interactive() is False
+
+
+# ---------------------------------------------------------------------------
+# executions killall non-interactive test
+# ---------------------------------------------------------------------------
+class TestExecutionsKillallNonInteractive:
+    """Tests for non-interactive auto-confirmation in executions killall."""
+
+    @patch("emdx.commands.executions.update_execution_status")
+    @patch("emdx.commands.executions.get_running_executions")
+    @patch("emdx.commands.executions.is_non_interactive", return_value=True)
+    def test_killall_auto_confirms_non_interactive(
+        self, mock_ni: Any, mock_get_running: Any, mock_update: Any
+    ) -> None:
+        """killall skips confirmation when stdin is not a TTY."""
+        from emdx.commands.executions import app as exec_app
+
+        exec1 = MagicMock()
+        exec1.id = 1
+        exec1.doc_title = "Task A"
+        exec2 = MagicMock()
+        exec2.id = 2
+        exec2.doc_title = "Task B"
+        mock_get_running.return_value = [exec1, exec2]
+
+        result = runner.invoke(exec_app, ["killall"])
+        assert result.exit_code == 0
+        out = _out(result)
+        assert "Killed 2 execution" in out
+        assert mock_update.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# maintain index --clear non-interactive test
+# ---------------------------------------------------------------------------
+class TestMaintainIndexClearNonInteractive:
+    """Tests for non-interactive auto-confirmation in maintain index --clear."""
+
+    @patch("emdx.commands.maintain_index.is_non_interactive", return_value=True)
+    def test_index_clear_auto_confirms_non_interactive(self, mock_ni: Any) -> None:
+        """--clear skips confirmation when stdin is not a TTY."""
+        mock_service = MagicMock()
+        mock_service.clear_index.return_value = 42
+
+        with patch(
+            "emdx.services.embedding_service.EmbeddingService",
+            return_value=mock_service,
+        ):
+            import typer
+
+            from emdx.commands.maintain_index import index_embeddings
+
+            test_app = typer.Typer()
+            test_app.command()(index_embeddings)
+
+            result = runner.invoke(test_app, ["--clear"])
+            assert result.exit_code == 0
+            out = _out(result)
+            assert "Cleared 42 embeddings" in out
+            mock_service.clear_index.assert_called_once()


### PR DESCRIPTION
## Summary

- Verified that all 13 confirmation prompts in the codebase already have `is_non_interactive()` guards (the feature implementation was already complete)
- Added comprehensive test coverage for the non-interactive auto-skip code path across 8 commands:
  - `is_non_interactive()` utility function unit tests (TTY vs non-TTY)
  - `trash purge` — auto-confirms without `--force` in non-TTY
  - `trash restore --all` — auto-confirms in non-TTY
  - `tags rename` — auto-confirms without `--force` in non-TTY
  - `tags merge` — auto-confirms without `--force` in non-TTY
  - `task delete` — auto-confirms without `--force` in non-TTY
  - `executions killall` — auto-confirms in non-TTY
  - `maintain index --clear` — auto-confirms in non-TTY

## Files Changed

- `tests/test_non_interactive.py` — new test file with unit tests for `is_non_interactive()`, executions killall, and maintain index --clear
- `tests/test_commands_trash.py` — added non-interactive tests for purge and restore --all
- `tests/test_commands_tags.py` — added non-interactive tests for rename and merge
- `tests/test_task_commands.py` — added non-interactive test for task delete

## Test plan

- [x] All 140 tests pass (4 skipped)
- [x] Zero new mypy errors introduced
- [x] ruff lint and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)