### PR TITLE
fix: unified task/epic ID resolution and epic attach command (#870-#873)

### DIFF
--- a/emdx/commands/epics.py
+++ b/emdx/commands/epics.py
@@ -10,6 +10,21 @@ app = typer.Typer(help="Manage task epics")
 
 ICONS = {"open": "○", "active": "●", "done": "✓", "failed": "✗", "blocked": "⊘"}
 
+EPIC_ID_HELP = "Epic ID (e.g. 510 or SEC-1)"
+
+
+def _resolve_epic_id(identifier: str) -> int:
+    """Resolve an epic identifier string to a database ID.
+
+    Accepts integer IDs (510) or category keys (SEC-1).
+    Prints an error and raises typer.Exit(1) if resolution fails.
+    """
+    task_id = tasks.resolve_task_id(identifier)
+    if task_id is None:
+        console.print(f"[red]Epic not found: {identifier}[/red]")
+        raise typer.Exit(1)
+    return task_id
+
 
 @app.command()
 def create(
@@ -28,7 +43,8 @@ def create(
         epic = tasks.get_task(epic_id)
         seq = epic["epic_seq"] if epic else None
         key_label = f"{cat.upper()}-{seq}" if seq else f"#{epic_id}"
-        console.print(f"[green]Created epic {key_label}: {name}[/green]")
+        id_suffix = f" (#{epic_id})" if seq else ""
+        console.print(f"[green]Created epic {key_label}{id_suffix}: {name}[/green]")
     except ValueError as e:
         console.print(f"[red]{e}[/red]")
         raise typer.Exit(1) from None
@@ -79,13 +95,15 @@ def list_cmd(
 
 @app.command()
 def view(
-    epic_id: int = typer.Argument(..., help="Epic task ID"),
+    epic_id_str: str = typer.Argument(..., metavar="EPIC_ID", help=EPIC_ID_HELP),
 ) -> None:
     """View an epic and its tasks.
 
     Examples:
         emdx task epic view 510
+        emdx task epic view SEC-1
     """
+    epic_id = _resolve_epic_id(epic_id_str)
     epic = tasks.get_epic_view(epic_id)
     if not epic:
         console.print(f"[red]Epic #{epic_id} not found[/red]")
@@ -116,7 +134,7 @@ def view(
 
 @app.command()
 def delete(
-    epic_id: int = typer.Argument(..., help="Epic task ID to delete"),
+    epic_id_str: str = typer.Argument(..., metavar="EPIC_ID", help=EPIC_ID_HELP),
     force: bool = typer.Option(
         False, "--force", "-f", help="Delete even if open/active child tasks exist"
     ),
@@ -128,8 +146,9 @@ def delete(
 
     Examples:
         emdx task epic delete 510
-        emdx task epic delete 510 --force
+        emdx task epic delete SEC-1 --force
     """
+    epic_id = _resolve_epic_id(epic_id_str)
     try:
         result = tasks.delete_epic(epic_id, force=force)
         console.print(f"[green]Deleted epic #{epic_id}[/green]")
@@ -142,13 +161,15 @@ def delete(
 
 @app.command()
 def done(
-    epic_id: int = typer.Argument(..., help="Epic task ID"),
+    epic_id_str: str = typer.Argument(..., metavar="EPIC_ID", help=EPIC_ID_HELP),
 ) -> None:
     """Mark an epic as done.
 
     Examples:
         emdx task epic done 510
+        emdx task epic done SEC-1
     """
+    epic_id = _resolve_epic_id(epic_id_str)
     epic = tasks.get_task(epic_id)
     if not epic:
         console.print(f"[red]Epic #{epic_id} not found[/red]")
@@ -160,13 +181,15 @@ def done(
 
 @app.command()
 def active(
-    epic_id: int = typer.Argument(..., help="Epic task ID"),
+    epic_id_str: str = typer.Argument(..., metavar="EPIC_ID", help=EPIC_ID_HELP),
 ) -> None:
     """Mark an epic as active.
 
     Examples:
         emdx task epic active 510
+        emdx task epic active SEC-1
     """
+    epic_id = _resolve_epic_id(epic_id_str)
     epic = tasks.get_task(epic_id)
     if not epic:
         console.print(f"[red]Epic #{epic_id} not found[/red]")
@@ -174,3 +197,44 @@ def active(
 
     tasks.update_task(epic_id, status="active")
     console.print(f"[green]● Active:[/green] Epic #{epic_id} {epic['title']}")
+
+
+TASK_ID_HELP = "Task ID (e.g. 42 or TOOL-12)"
+
+
+@app.command()
+def attach(
+    task_ids: list[str] = typer.Argument(..., help=TASK_ID_HELP),
+    epic: str = typer.Option(..., "-e", "--epic", help=EPIC_ID_HELP),
+) -> None:
+    """Attach existing tasks to an epic.
+
+    Tasks inherit the epic's category key and get assigned a sequence number.
+
+    Examples:
+        emdx task epic attach TOOL-14 --epic TOOL-68
+        emdx task epic attach TOOL-14 TOOL-15 TOOL-16 --epic SEC-1
+        emdx task epic attach 42 43 --epic 510
+    """
+    epic_id = _resolve_epic_id(epic)
+
+    resolved_ids: list[int] = []
+    for tid_str in task_ids:
+        resolved = tasks.resolve_task_id(tid_str)
+        if resolved is None:
+            console.print(f"[red]Invalid task ID: {tid_str}[/red]")
+            raise typer.Exit(1)
+        resolved_ids.append(resolved)
+
+    try:
+        count = tasks.attach_to_epic(resolved_ids, epic_id)
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1) from None
+
+    epic_task = tasks.get_task(epic_id)
+    epic_label = f"#{epic_id}"
+    if epic_task and epic_task.get("epic_key") and epic_task.get("epic_seq"):
+        epic_label = f"{epic_task['epic_key']}-{epic_task['epic_seq']}"
+
+    console.print(f"[green]✅ Attached {count} task(s) to epic {epic_label}[/green]")


### PR DESCRIPTION
- Show both category key and integer ID in epic create message (#870)
- Accept category keys (e.g. SEC-1) in all epic commands: view, done,
  active, delete (#871)
- Accept category keys in task add --epic and task list --epic (#871)
- Fix resolve_task_id to verify bare integer IDs exist in database,
  with fallback to epic_seq matching (#872)
- Add task epic attach command for retroactively attaching tasks to
  epics (#873)
- Add attach_to_epic model function that sets parent_task_id and
  inherits epic category key with auto-sequencing

https://claude.ai/code/session_015FbTSEysUSwRu56QXhsNhr