### PR TITLE
fix: z zoom toggle doesn't unzoom (TUI-35)

### DIFF
--- a/emdx/ui/activity/activity_view.py
+++ b/emdx/ui/activity/activity_view.py
@@ -644,6 +644,7 @@ class ActivityView(HelpMixin, Widget):
         if self._zoomed:
             activity_panel.add_class("zoom-hidden")
             preview_panel.add_class("zoom-full")
+            self.query_one("#preview-content", RichLog).focus()
         else:
             activity_panel.remove_class("zoom-hidden")
             preview_panel.remove_class("zoom-full")

--- a/emdx/ui/qa/qa_screen.py
+++ b/emdx/ui/qa/qa_screen.py
@@ -597,6 +597,7 @@ class QAScreen(HelpMixin, Widget):
         if self._zoomed:
             history_panel.add_class("zoom-hidden")
             answer_panel.add_class("zoom-full")
+            self.query_one("#qa-answer-panel").focus()
         else:
             history_panel.remove_class("zoom-hidden")
             answer_panel.remove_class("zoom-full")

--- a/emdx/ui/task_view.py
+++ b/emdx/ui/task_view.py
@@ -1000,6 +1000,7 @@ class TaskView(Widget):
         if self._zoomed:
             list_panel.add_class("zoom-hidden")
             detail_panel.add_class("zoom-full")
+            self.query_one("#task-detail-log", RichLog).focus()
         else:
             list_panel.remove_class("zoom-hidden")
             detail_panel.remove_class("zoom-full")


### PR DESCRIPTION
## Summary

- When pressing `z` to zoom the detail pane, the DataTable gets `display: none` which causes Textual to drop focus entirely (`focused=None`)
- With no focused widget, subsequent `z` key presses never reach the widget's bindings — the user gets stuck in zoomed mode
- Fix: explicitly focus the detail panel's RichLog/container when zooming in so key events keep flowing through the DOM
- Applied to all three screens: Tasks, QA, Activity

## Test plan

- [x] All 124 TUI tests pass
- [x] ruff + mypy pass
- [x] Pilot test confirms: zoom in → `focused: RichLog`, zoom out → `focused: DataTable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)