### PR TITLE
feat(tui): clickable #N doc refs in QA answers (Issue #FEAT-55)

### DIFF
--- a/tests/test_qa_screen.py
+++ b/tests/test_qa_screen.py
@@ -11,7 +11,7 @@ from textual.app import App, ComposeResult
 from textual.widgets import DataTable, Input, Markdown, RichLog, Static
 
 from emdx.ui.qa.qa_presenter import QAEntry, QASource, QAStateVM
-from emdx.ui.qa.qa_screen import QAScreen
+from emdx.ui.qa.qa_screen import QAScreen, _linkify_doc_refs
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -365,3 +365,26 @@ class TestQAZoom:
             await pilot.pause()
             assert not qa._zoomed
             assert not history.has_class("zoom-hidden")
+
+
+# ---------------------------------------------------------------------------
+# Tests: Linkify doc refs
+# ---------------------------------------------------------------------------
+
+
+class TestLinkifyDocRefs:
+    def test_basic_ref(self) -> None:
+        assert _linkify_doc_refs("See #42 for details") == "See [#42](emdx://doc/42) for details"
+
+    def test_multiple_refs(self) -> None:
+        result = _linkify_doc_refs("Sources: #42, #55")
+        assert "[#42](emdx://doc/42)" in result
+        assert "[#55](emdx://doc/55)" in result
+
+    def test_no_double_linkify(self) -> None:
+        already = "[#42](emdx://doc/42)"
+        assert _linkify_doc_refs(already) == already
+
+    def test_no_refs(self) -> None:
+        text = "No references here"
+        assert _linkify_doc_refs(text) == text


### PR DESCRIPTION
## Summary

- `#N` document references in QA answers are now clickable markdown links
- Clicking a doc ref opens the fullscreen document preview modal
- Uses `emdx://doc/N` URL scheme with Textual's `Markdown.LinkClicked` event
- Set `open_links=False` on the Markdown widget to prevent launching a browser
- Regex uses negative lookbehind to avoid double-linkifying already-linked refs

## Test plan

- [x] 4 unit tests for `_linkify_doc_refs` (basic, multiple, no-double, no-refs)
- [x] All 23 QA screen tests pass
- [x] Full suite: 1633 passed
- [x] ruff + mypy clean
- [ ] Manual: ask a question in QA, click a `#N` source ref → preview opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)