### PR TITLE
fix(tui): strip duplicate KEY-N prefix from task detail panes

### DIFF
--- a/emdx/ui/task_view.py
+++ b/emdx/ui/task_view.py
@@ -1281,8 +1281,9 @@ class TaskView(Widget):
         header_label = f"{icon} {badge}" if badge else f"{icon} Task"
         header.update(header_label)
 
-        # Title
-        detail_log.write(f"[bold]{task['title']}[/bold]")
+        # Title (strip KEY-N prefix since badge already shows it)
+        title = _strip_epic_prefix(task["title"], task.get("epic_key"), task.get("epic_seq"))
+        detail_log.write(f"[bold]{title}[/bold]")
         detail_log.write("")
 
         if self._sidebar_visible:
@@ -1418,8 +1419,9 @@ class TaskView(Widget):
         epic_header = f"{icon} {badge}" if badge else f"{icon} Epic"
         header.update(epic_header)
 
-        # Title
-        detail_log.write(f"[bold]{task['title']}[/bold]")
+        # Title (strip KEY-N prefix since badge already shows it)
+        title = _strip_epic_prefix(task["title"], task.get("epic_key"), task.get("epic_seq"))
+        detail_log.write(f"[bold]{title}[/bold]")
         detail_log.write("")
 
         # Progress summary from cached epic data
@@ -1457,7 +1459,9 @@ class TaskView(Widget):
                 for child in epic_view["children"]:
                     c_icon = STATUS_ICONS.get(child["status"], "?")
                     c_color = STATUS_COLORS.get(child["status"], "")
-                    c_title = child["title"][:55]
+                    c_title = _strip_epic_prefix(
+                        child["title"], child.get("epic_key"), child.get("epic_seq")
+                    )[:55]
                     seq = child.get("epic_seq")
                     prefix = f"{epic_key}-{seq}" if epic_key and seq else ""
                     if c_color:


### PR DESCRIPTION
## Summary

- Task detail pane showed the KEY-N display ID (e.g. `FEAT-50`) twice — once in the header badge and again in the title text
- Applied `_strip_epic_prefix()` to three detail pane rendering paths: regular task detail, epic detail header, and epic child task listing

## Test plan

- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `mypy` passes
- [x] 90 task browser tests pass (`tests/test_task_browser.py`)
- [ ] Manual: open TUI, select a task with a KEY-N title — verify the prefix appears only in the badge, not repeated in the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)