### PR TITLE
feat(tui): Task TUI sorting, filtering & discoverability (Issue #FEAT-55)

### DIFF
--- a/emdx/ui/modals.py
+++ b/emdx/ui/modals.py
@@ -193,6 +193,8 @@ class HelpMixin:
         "left": "←",
         "right": "→",
         "space": "Space",
+        "asterisk": "*",
+        "slash": "/",
     }
 
     def get_help_bindings(self) -> list[tuple[str, str, str]]:
@@ -240,13 +242,14 @@ class HelpMixin:
         category_order = [
             "Navigation",
             "Actions",
+            "Filters",
             "Editing",
             "Tags",
             "Search",
             "View",
             "Other",
             "General",
-        ]  # noqa: E501
+        ]
 
         def sort_key(item: tuple[str, str, str]) -> tuple[int, str]:
             cat = item[0]

--- a/emdx/ui/task_browser.py
+++ b/emdx/ui/task_browser.py
@@ -5,12 +5,32 @@ from typing import Self
 
 from textual.app import ComposeResult
 from textual.widget import Widget
-from textual.widgets import Static
+from textual.widgets import DataTable, Static
 
 from .modals import HelpMixin
-from .task_view import TaskView
+from .task_view import DONE_FOLD_PREFIX, HEADER_PREFIX, SEPARATOR_PREFIX, TaskView
 
 logger = logging.getLogger(__name__)
+
+# -- Footer key definitions per context --
+
+_TASK_FOOTER = (
+    "[dim]j/k[/dim] Navigate  "
+    "[dim]d[/dim] Done  [dim]a[/dim] Active  "
+    "[dim]b[/dim] Blocked  [dim]w[/dim] Won't do  "
+    "[dim]/[/dim] Filter  [dim]?[/dim] Help"
+)
+
+_EPIC_HEADER_FOOTER = (
+    "[dim]Enter[/dim] Expand/Collapse  "
+    "[dim]e[/dim] Epic Filter  "
+    "[dim]g[/dim] Group By  "
+    "[dim]/[/dim] Filter  [dim]?[/dim] Help"
+)
+
+_DONE_FOLD_FOOTER = "[dim]Enter[/dim] Expand  [dim]/[/dim] Filter  [dim]?[/dim] Help"
+
+_DEFAULT_FOOTER = "[dim]j/k[/dim] Navigate  [dim]/[/dim] Filter  [dim]?[/dim] Help"
 
 
 class TaskBrowser(HelpMixin, Widget):
@@ -50,7 +70,7 @@ class TaskBrowser(HelpMixin, Widget):
     }
 
     #task-help-bar {
-        height: 2;
+        height: 1;
         background: $surface;
         padding: 0 1;
     }
@@ -63,20 +83,49 @@ class TaskBrowser(HelpMixin, Widget):
     def compose(self) -> ComposeResult:
         self.task_view = TaskView(id="task-view")
         yield self.task_view
-        yield Static(
-            "[dim]1[/dim] Docs  [dim]2[/dim] Tasks  "
-            "[dim]j/k[/dim] Navigate  "
-            "[dim]d[/dim] Done  [dim]a[/dim] Active  "
-            "[dim]b[/dim] Blocked  [dim]w[/dim] Won't do  "
-            "[dim]p[/dim] Dup  [dim]u[/dim] Reopen  "
-            "[dim]/[/dim] Filter  "
-            "[dim]?[/dim] Help\n"
-            "[dim]o[/dim] Open  [dim]i[/dim] Active  "
-            "[dim]x[/dim] Blocked  [dim]f[/dim] Finished  "
-            "[dim]*[/dim] Clear  [dim]e[/dim] Epic  "
-            "[dim]g[/dim] Group",
-            id="task-help-bar",
-        )
+        yield Static(_TASK_FOOTER, id="task-help-bar")
+
+    def _get_current_row_key(self) -> str | None:
+        """Return the row key string for the currently highlighted row."""
+        if not self.task_view:
+            return None
+        try:
+            table = self.task_view.query_one("#task-table", DataTable)
+            if table.cursor_row is None or table.row_count == 0:
+                return None
+            return str(table.ordered_rows[table.cursor_row].key.value)
+        except Exception:
+            return None
+
+    def _update_footer_context(self) -> None:
+        """Update footer bar text based on the currently highlighted row."""
+        try:
+            bar = self.query_one("#task-help-bar", Static)
+        except Exception:
+            return
+
+        row_key = self._get_current_row_key()
+        if row_key is None:
+            bar.update(_DEFAULT_FOOTER)
+            return
+
+        if row_key.startswith(DONE_FOLD_PREFIX):
+            bar.update(_DONE_FOLD_FOOTER)
+        elif row_key.startswith(HEADER_PREFIX) or row_key.startswith(SEPARATOR_PREFIX):
+            bar.update(_EPIC_HEADER_FOOTER)
+        elif self.task_view:
+            # Check if this is an epic/group parent task
+            task = self.task_view._row_key_to_task.get(row_key)
+            if task and task.get("type") in ("epic", "group"):
+                bar.update(_EPIC_HEADER_FOOTER)
+            else:
+                bar.update(_TASK_FOOTER)
+        else:
+            bar.update(_TASK_FOOTER)
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """React to row highlight changes to update footer context."""
+        self._update_footer_context()
 
     def get_help_bindings(self) -> list[tuple[str, str, str]]:
         """Combine TaskBrowser + TaskView bindings for help display."""

--- a/emdx/ui/task_browser.py
+++ b/emdx/ui/task_browser.py
@@ -24,6 +24,15 @@ class TaskBrowser(HelpMixin, Widget):
         "mark_wontdo": "Actions",
         "mark_duplicate": "Actions",
         "mark_open": "Actions",
+        "filter_open": "Filters",
+        "filter_active": "Filters",
+        "filter_blocked": "Filters",
+        "filter_finished": "Filters",
+        "clear_all_filters": "Filters",
+        "filter_epic": "Filters",
+        "toggle_grouping": "View",
+        "open_urls": "Actions",
+        "toggle_collapse": "Navigation",
     }
 
     BINDINGS = [
@@ -41,7 +50,7 @@ class TaskBrowser(HelpMixin, Widget):
     }
 
     #task-help-bar {
-        height: 1;
+        height: 2;
         background: $surface;
         padding: 0 1;
     }
@@ -61,7 +70,11 @@ class TaskBrowser(HelpMixin, Widget):
             "[dim]b[/dim] Blocked  [dim]w[/dim] Won't do  "
             "[dim]p[/dim] Dup  [dim]u[/dim] Reopen  "
             "[dim]/[/dim] Filter  "
-            "[dim]?[/dim] Help",
+            "[dim]?[/dim] Help\n"
+            "[dim]o[/dim] Open  [dim]i[/dim] Active  "
+            "[dim]x[/dim] Blocked  [dim]f[/dim] Finished  "
+            "[dim]*[/dim] Clear  [dim]e[/dim] Epic  "
+            "[dim]g[/dim] Group",
             id="task-help-bar",
         )
 
@@ -100,6 +113,7 @@ class TaskBrowser(HelpMixin, Widget):
         category_order = [
             "Navigation",
             "Actions",
+            "Filters",
             "View",
             "Other",
             "General",

--- a/emdx/ui/task_view.py
+++ b/emdx/ui/task_view.py
@@ -71,6 +71,7 @@ STATUS_ALIASES = {"closed": "done"}
 # Row key prefix for section headers
 HEADER_PREFIX = "header:"
 SEPARATOR_PREFIX = "sep:"
+DONE_FOLD_PREFIX = "done-fold:"
 
 
 def _format_time_ago(dt_str: str | None) -> str:
@@ -320,6 +321,7 @@ class TaskView(Widget):
         self._epic_filter: str | None = None  # Filter to specific epic key
         self._collapsed: set[int] = set()  # Explicitly collapsed parent IDs
         self._expanded: set[int] = set()  # Explicitly expanded parent IDs
+        self._done_folds_expanded: set[int] = set()  # Epic IDs with done-fold open
         self._zoomed: bool = False
         self._sidebar_visible: bool = True
         self._current_task: TaskDict | None = None
@@ -843,32 +845,67 @@ class TaskView(Widget):
             if pid is not None and pid in self._collapsed:
                 continue
 
-            # Render children flat, sorted by status order
-            filtered_kids: list[TaskDict] = []
-            status_set = set(visible_statuses)
+            # Split children into active and done groups
+            active_kids: list[TaskDict] = []
+            done_kids: list[TaskDict] = []
             for task in kids:
-                normalized = STATUS_ALIASES.get(
-                    task["status"],
-                    task["status"],
-                )
-                if normalized in status_set:
-                    filtered_kids.append(task)
-            # Sort by status order
+                normalized = STATUS_ALIASES.get(task["status"], task["status"])
+                if normalized in finished:
+                    done_kids.append(task)
+                else:
+                    active_kids.append(task)
+
+            # Sort active kids by status order
             status_rank = {s: i for i, s in enumerate(STATUS_ORDER)}
-            filtered_kids.sort(
+            active_kids.sort(
                 key=lambda t: status_rank.get(
                     STATUS_ALIASES.get(t["status"], t["status"]),
                     len(STATUS_ORDER),
                 ),
             )
-            for i, task in enumerate(filtered_kids):
-                is_last = i == len(filtered_kids) - 1
+
+            # Sort done kids by completed_at descending (most recent first)
+            done_kids.sort(
+                key=lambda t: t.get("completed_at") or t.get("updated_at") or "",
+                reverse=True,
+            )
+
+            # Determine if done-fold is expanded
+            done_fold_open = pid is not None and pid in self._done_folds_expanded
+            has_done = len(done_kids) > 0
+
+            # Render active children
+            for i, task in enumerate(active_kids):
+                is_last = i == len(active_kids) - 1 and not has_done
                 connector = "└─" if is_last else "├─"
-                self._render_task_row(
-                    table,
-                    task,
-                    tree_prefix=connector,
-                )
+                self._render_task_row(table, task, tree_prefix=connector)
+
+            # Render done children
+            if has_done:
+                if pid is None or showing_finished:
+                    # Ungrouped or explicit filter: show done kids inline
+                    for i, task in enumerate(done_kids):
+                        is_last = i == len(done_kids) - 1
+                        connector = "└─" if is_last else "├─"
+                        self._render_task_row(table, task, tree_prefix=connector)
+                else:
+                    # Epic children: collapsible done-fold
+                    arrow = "▾" if done_fold_open else "▸"
+                    fold_label = f"{len(done_kids)} completed {arrow}"
+                    is_last_row = not done_fold_open
+                    connector = "└─" if is_last_row else "├─"
+                    table.add_row(
+                        Text(f"{connector}✅", style="dim"),
+                        Text(""),
+                        Text(fold_label, style="dim italic"),
+                        Text(""),
+                        key=f"{DONE_FOLD_PREFIX}{pid}",
+                    )
+                    if done_fold_open:
+                        for i, task in enumerate(done_kids):
+                            is_last = i == len(done_kids) - 1
+                            connector = "└─" if is_last else "├─"
+                            self._render_task_row(table, task, tree_prefix=connector)
 
         # Render done epics — collapsed by default, expandable
         if done_parents and (showing_finished or not self._status_filter):
@@ -1544,7 +1581,23 @@ class TaskView(Widget):
     # Collapse/expand
 
     def _toggle_collapse(self) -> None:
-        """Toggle collapse state of the selected parent task."""
+        """Toggle collapse state of the selected parent task or done-fold."""
+        # Check if cursor is on a done-fold row
+        table = self.query_one("#task-table", DataTable)
+        try:
+            if table.cursor_row is not None and table.row_count > 0:
+                row_key = str(table.ordered_rows[table.cursor_row].key.value)
+                if row_key.startswith(DONE_FOLD_PREFIX):
+                    epic_id = int(row_key[len(DONE_FOLD_PREFIX) :])
+                    if epic_id in self._done_folds_expanded:
+                        self._done_folds_expanded.discard(epic_id)
+                    else:
+                        self._done_folds_expanded.add(epic_id)
+                    self._render_task_table()
+                    return
+        except (IndexError, AttributeError, ValueError):
+            pass
+
         task = self._get_selected_task()
         if not task:
             return

--- a/emdx/ui/task_view.py
+++ b/emdx/ui/task_view.py
@@ -15,6 +15,7 @@ from rich.console import Console as RichConsole
 from rich.text import Text
 from textual import events
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, ScrollableContainer, Vertical
 from textual.timer import Timer
 from textual.widget import Widget
@@ -185,6 +186,15 @@ class TaskView(Widget):
         ("slash", "show_filter", "Filter"),
         ("escape", "clear_filter", "Clear Filter"),
         ("z", "toggle_zoom", "Zoom"),
+        ("o", "filter_open", "Open Only"),
+        ("i", "filter_active", "Active Only"),
+        ("x", "filter_blocked", "Blocked Only"),
+        ("f", "filter_finished", "Finished"),
+        ("asterisk", "clear_all_filters", "Clear Filters"),
+        ("e", "filter_epic", "Epic Filter"),
+        ("g", "toggle_grouping", "Group By"),
+        ("O", "open_urls", "Open URLs"),
+        Binding("enter", "toggle_collapse", "Expand/Collapse", show=True),
     ]
 
     DEFAULT_CSS = """
@@ -298,14 +308,6 @@ class TaskView(Widget):
         scrollbar-gutter: stable;
     }
     """
-
-    # Status filter key mapping: key -> set of statuses to show
-    STATUS_FILTERS: dict[str, set[str]] = {
-        "o": {"open"},
-        "i": {"active"},
-        "x": {"blocked"},
-        "f": {"done", "failed", "wontdo", "duplicate"},
-    }
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -741,21 +743,39 @@ class TaskView(Widget):
                 parent_ids.append(eid)
                 seen.add(eid)
 
-        # Sort: active epics first (alphabetically by title),
-        # then done, then ungrouped (None) last
-        def _sort_key(pid: int | None) -> tuple[int, str]:
+        # Sort: active epics first, then done, then ungrouped last.
+        # Within each bucket: epics with in-progress children first,
+        # then by most recent child activity (DESC), then epic age.
+        def _max_child_timestamp(pid: int | None) -> str:
+            kids = children_by_parent.get(pid, [])
+            if not kids:
+                return ""
+            return max(
+                (k.get("updated_at") or k.get("created_at") or "" for k in kids),
+                default="",
+            )
+
+        def _sort_key(pid: int | None) -> tuple[int, int, str, str]:
             if pid is None:
-                return (2, "")
+                return (2, 0, "", "")
             epic = epic_task_by_id.get(pid) or self._epics.get(pid)
-            title = epic.get("title", "") if epic else ""
             kids = children_by_parent.get(pid, [])
             has_open = any(k["status"] not in finished for k in kids)
-            if has_open:
-                return (0, title.lower())
             epic_status = epic.get("status", "done") if epic else "done"
-            if epic_status not in finished:
-                return (0, title.lower())
-            return (1, title.lower())
+            # Bucket: 0=active, 1=done, 2=ungrouped
+            bucket = 0 if (has_open or epic_status not in finished) else 1
+            # Epics with active/in-progress children float to top
+            has_active = any(k["status"] == "active" for k in kids)
+            active_rank = 0 if has_active else 1
+            # Most recent child activity (invert for DESC sort)
+            max_ts = _max_child_timestamp(pid)
+            inv_ts = "".join(chr(0xFFFF - ord(c)) for c in max_ts) if max_ts else "\uffff"
+            # Epic creation as tiebreaker (DESC)
+            epic_created = epic.get("created_at", "") if epic else ""
+            inv_created = (
+                "".join(chr(0xFFFF - ord(c)) for c in epic_created) if epic_created else "\uffff"
+            )
+            return (bucket, active_rank, inv_ts, inv_created)
 
         parent_ids.sort(key=_sort_key)
         # Ensure None (ungrouped) is in the list
@@ -855,12 +875,15 @@ class TaskView(Widget):
                 else:
                     active_kids.append(task)
 
-            # Sort active kids by status order
+            # Sort active kids by status order, then oldest-first (queue)
             status_rank = {s: i for i, s in enumerate(STATUS_ORDER)}
             active_kids.sort(
-                key=lambda t: status_rank.get(
-                    STATUS_ALIASES.get(t["status"], t["status"]),
-                    len(STATUS_ORDER),
+                key=lambda t: (
+                    status_rank.get(
+                        STATUS_ALIASES.get(t["status"], t["status"]),
+                        len(STATUS_ORDER),
+                    ),
+                    t.get("created_at") or "",
                 ),
             )
 
@@ -891,7 +914,14 @@ class TaskView(Widget):
                 else:
                     # Epic children: collapsible done-fold
                     arrow = "▾" if done_fold_open else "▸"
-                    fold_label = f"{len(done_kids)} completed {arrow}"
+                    latest_ts = (
+                        done_kids[0].get("completed_at") or done_kids[0].get("updated_at") or ""
+                    )
+                    recency = _format_time_ago(latest_ts)
+                    if recency:
+                        fold_label = f"{len(done_kids)} completed (latest: {recency}) {arrow}"
+                    else:
+                        fold_label = f"{len(done_kids)} completed {arrow}"
                     is_last_row = not done_fold_open
                     connector = "└─" if is_last_row else "├─"
                     table.add_row(
@@ -948,9 +978,25 @@ class TaskView(Widget):
                         "",
                         key=f"{HEADER_PREFIX}epic:{pid}",
                     )
-                # Show children if expanded
-                if pid not in self._collapsed:
-                    kids = children_by_parent.get(pid, [])
+                # Show fold summary or expanded children
+                kids = children_by_parent.get(pid, [])
+                if pid in self._collapsed:
+                    # Collapsed: show fold summary with recency hint
+                    if kids:
+                        latest = kids[0].get("completed_at") or kids[0].get("updated_at") or ""
+                        recency = _format_time_ago(latest)
+                        if recency:
+                            fold_label = f"{len(kids)} completed (latest: {recency}) ▸"
+                        else:
+                            fold_label = f"{len(kids)} completed ▸"
+                        table.add_row(
+                            Text(""),
+                            Text(""),
+                            Text(f"  {fold_label}", style="dim"),
+                            Text(""),
+                            key=f"{DONE_FOLD_PREFIX}epic:{pid}",
+                        )
+                else:
                     for i, task in enumerate(kids):
                         is_last = i == len(kids) - 1
                         connector = "└─" if is_last else "├─"
@@ -1082,7 +1128,11 @@ class TaskView(Widget):
         table.focus()
 
     def on_key(self, event: events.Key) -> None:
-        """Block vim keys when filter input has focus; handle status filter keys."""
+        """Block vim/action keys when filter input has focus.
+
+        Also handles ``enter`` for collapse/expand since DataTable
+        consumes it before BINDINGS can dispatch.
+        """
         try:
             filter_input = self.query_one("#task-filter-input", Input)
             if filter_input.has_focus:
@@ -1111,50 +1161,75 @@ class TaskView(Widget):
                 if event.key in vim_keys:
                     return
         except Exception as e:
-            logger.warning(f"Failed to check focused widget for vim key passthrough: {e}")
+            logger.warning(
+                "Failed to check focused widget for vim key passthrough: %s",
+                e,
+            )
 
-        # Status filter keys (only when filter input is not focused)
-        if event.key in self.STATUS_FILTERS:
-            new_filter = self.STATUS_FILTERS[event.key]
-            # Toggle: pressing same key again clears the filter
-            if self._status_filter == new_filter:
-                self._status_filter = None
-            else:
-                self._status_filter = new_filter
-            self._apply_filter()
-            event.prevent_default()
-            event.stop()
-        elif event.key == "asterisk":
-            self._status_filter = None
-            self._epic_filter = None
-            self._apply_filter()
-            event.prevent_default()
-            event.stop()
-        elif event.key == "e":
-            # Toggle epic filter to current task's epic
-            task = self._get_selected_task()
-            epic_key = task.get("epic_key") if task else None
-            if epic_key and self._epic_filter != epic_key:
-                self._epic_filter = epic_key
-            else:
-                self._epic_filter = None
-            self._apply_filter()
-            event.prevent_default()
-            event.stop()
-        elif event.key == "g":
-            self._group_by = "epic" if self._group_by == "status" else "status"
-            self._render_task_table()
-            self._update_status_bar()
-            event.prevent_default()
-            event.stop()
-        elif event.key == "O":
-            self._open_task_urls()
-            event.prevent_default()
-            event.stop()
-        elif event.key == "enter":
+        # Enter must be handled here because DataTable consumes it
+        # before BINDINGS can dispatch.
+        if event.key == "enter":
             self._toggle_collapse()
             event.prevent_default()
             event.stop()
+
+    # ------------------------------------------------------------------
+    # Status / epic / grouping filter actions
+    # ------------------------------------------------------------------
+
+    def _toggle_status_filter(self, statuses: set[str]) -> None:
+        """Toggle a status filter on/off."""
+        if self._status_filter == statuses:
+            self._status_filter = None
+        else:
+            self._status_filter = statuses
+        self._apply_filter()
+
+    def action_filter_open(self) -> None:
+        """Show only open/ready tasks."""
+        self._toggle_status_filter({"open"})
+
+    def action_filter_active(self) -> None:
+        """Show only active tasks."""
+        self._toggle_status_filter({"active"})
+
+    def action_filter_blocked(self) -> None:
+        """Show only blocked tasks."""
+        self._toggle_status_filter({"blocked"})
+
+    def action_filter_finished(self) -> None:
+        """Show only finished tasks (done/failed/wontdo/duplicate)."""
+        self._toggle_status_filter({"done", "failed", "wontdo", "duplicate"})
+
+    def action_clear_all_filters(self) -> None:
+        """Clear all status and epic filters."""
+        self._status_filter = None
+        self._epic_filter = None
+        self._apply_filter()
+
+    def action_filter_epic(self) -> None:
+        """Toggle epic filter to the current task's epic."""
+        task = self._get_selected_task()
+        epic_key = task.get("epic_key") if task else None
+        if epic_key and self._epic_filter != epic_key:
+            self._epic_filter = epic_key
+        else:
+            self._epic_filter = None
+        self._apply_filter()
+
+    def action_toggle_grouping(self) -> None:
+        """Toggle between epic and status grouping."""
+        self._group_by = "epic" if self._group_by == "status" else "status"
+        self._render_task_table()
+        self._update_status_bar()
+
+    def action_open_urls(self) -> None:
+        """Open first URL found in the selected task."""
+        self._open_task_urls()
+
+    def action_toggle_collapse(self) -> None:
+        """Toggle collapse state of the selected parent task."""
+        self._toggle_collapse()
 
     def on_input_changed(self, event: Input.Changed) -> None:
         """Handle filter input changes with debouncing."""
@@ -1588,11 +1663,24 @@ class TaskView(Widget):
             if table.cursor_row is not None and table.row_count > 0:
                 row_key = str(table.ordered_rows[table.cursor_row].key.value)
                 if row_key.startswith(DONE_FOLD_PREFIX):
-                    epic_id = int(row_key[len(DONE_FOLD_PREFIX) :])
-                    if epic_id in self._done_folds_expanded:
-                        self._done_folds_expanded.discard(epic_id)
+                    suffix = row_key[len(DONE_FOLD_PREFIX) :]
+                    # "done-fold:epic:N" = done-epics section fold
+                    if suffix.startswith("epic:"):
+                        epic_id = int(suffix[len("epic:") :])
+                        # Toggle in _collapsed (controls done-epic expand)
+                        if epic_id in self._collapsed:
+                            self._collapsed.discard(epic_id)
+                            self._expanded.add(epic_id)
+                        else:
+                            self._collapsed.add(epic_id)
+                            self._expanded.discard(epic_id)
                     else:
-                        self._done_folds_expanded.add(epic_id)
+                        # "done-fold:N" = active-epic done children fold
+                        epic_id = int(suffix)
+                        if epic_id in self._done_folds_expanded:
+                            self._done_folds_expanded.discard(epic_id)
+                        else:
+                            self._done_folds_expanded.add(epic_id)
                     self._render_task_table()
                     return
         except (IndexError, AttributeError, ValueError):

--- a/emdx/ui/task_view.py
+++ b/emdx/ui/task_view.py
@@ -75,10 +75,12 @@ SEPARATOR_PREFIX = "sep:"
 DONE_FOLD_PREFIX = "done-fold:"
 
 
-def _format_time_ago(dt_str: str | None) -> str:
+def _format_time_ago(dt_str: str | datetime | None) -> str:
     """Format a datetime string as relative time, or absolute date if > 7 days."""
     if not dt_str:
         return ""
+    if isinstance(dt_str, datetime):
+        dt_str = dt_str.isoformat()
     try:
         if "T" in dt_str:
             dt = datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
@@ -186,10 +188,10 @@ class TaskView(Widget):
         ("slash", "show_filter", "Filter"),
         ("escape", "clear_filter", "Clear Filter"),
         ("z", "toggle_zoom", "Zoom"),
-        ("o", "filter_open", "Open Only"),
-        ("i", "filter_active", "Active Only"),
-        ("x", "filter_blocked", "Blocked Only"),
-        ("f", "filter_finished", "Finished"),
+        ("o", "filter_open", "Toggle Open"),
+        ("i", "filter_active", "Toggle Active"),
+        ("x", "filter_blocked", "Toggle Blocked"),
+        ("f", "filter_finished", "Toggle Finished"),
         ("asterisk", "clear_all_filters", "Clear Filters"),
         ("e", "filter_epic", "Epic Filter"),
         ("g", "toggle_grouping", "Group By"),
@@ -317,7 +319,7 @@ class TaskView(Widget):
         self._epics: dict[int, EpicTaskDict] = {}  # keyed by epic task ID
         self._filter_text: str = ""
         self._debounce_timer: Timer | None = None
-        self._status_filter: set[str] | None = None  # None = show all
+        self._hidden_statuses: set[str] = set()  # statuses to hide (empty = show all)
         self._initial_select_done = False
         self._group_by: str = "epic"  # "epic" or "status"
         self._epic_filter: str | None = None  # Filter to specific epic key
@@ -698,10 +700,8 @@ class TaskView(Widget):
         Orphan tasks (no parent) go to UNGROUPED.
         """
         finished = {"done", "failed", "wontdo", "duplicate"}
-        showing_finished = bool(self._status_filter and self._status_filter & finished)
-        visible_statuses = (
-            STATUS_ORDER if showing_finished else [s for s in STATUS_ORDER if s not in finished]
-        )
+        showing_finished = not bool(self._hidden_statuses & finished)
+        visible_statuses = [s for s in STATUS_ORDER if s not in self._hidden_statuses]
 
         # Group children by parent_task_id.
         # First pass: collect all tasks and find which IDs are parents.
@@ -750,10 +750,11 @@ class TaskView(Widget):
             kids = children_by_parent.get(pid, [])
             if not kids:
                 return ""
-            return max(
+            raw = max(
                 (k.get("updated_at") or k.get("created_at") or "" for k in kids),
                 default="",
             )
+            return str(raw) if raw else ""
 
         def _sort_key(pid: int | None) -> tuple[int, int, str, str]:
             if pid is None:
@@ -771,7 +772,8 @@ class TaskView(Widget):
             max_ts = _max_child_timestamp(pid)
             inv_ts = "".join(chr(0xFFFF - ord(c)) for c in max_ts) if max_ts else "\uffff"
             # Epic creation as tiebreaker (DESC)
-            epic_created = epic.get("created_at", "") if epic else ""
+            raw_created = epic.get("created_at", "") if epic else ""
+            epic_created = str(raw_created) if raw_created else ""
             inv_created = (
                 "".join(chr(0xFFFF - ord(c)) for c in epic_created) if epic_created else "\uffff"
             )
@@ -788,7 +790,7 @@ class TaskView(Widget):
         for pid in parent_ids:
             kids = children_by_parent.get(pid, [])
             has_open = any(k["status"] not in finished for k in kids)
-            if has_open or showing_finished or pid is None:
+            if has_open or pid is None:
                 active_parents.append(pid)
             else:
                 # pid cannot be None here (handled by `pid is None` above)
@@ -905,8 +907,8 @@ class TaskView(Widget):
 
             # Render done children
             if has_done:
-                if pid is None or showing_finished:
-                    # Ungrouped or explicit filter: show done kids inline
+                if pid is None:
+                    # Ungrouped: show done kids inline
                     for i, task in enumerate(done_kids):
                         is_last = i == len(done_kids) - 1
                         connector = "└─" if is_last else "├─"
@@ -938,7 +940,7 @@ class TaskView(Widget):
                             self._render_task_row(table, task, tree_prefix=connector)
 
         # Render done epics — collapsed by default, expandable
-        if done_parents and (showing_finished or not self._status_filter):
+        if done_parents and showing_finished:
             # Auto-collapse done parents that haven't been explicitly toggled
             for pid in done_parents:
                 if pid not in self._collapsed and pid not in self._expanded:
@@ -1046,7 +1048,7 @@ class TaskView(Widget):
             parts.append(f"[dim]{counts['wontdo']} wontdo[/dim]")
 
         if not any(counts.values()):
-            if self._filter_text or self._status_filter:
+            if self._filter_text or self._hidden_statuses:
                 parts.append("[yellow]no matches[/yellow]")
             else:
                 parts.append("[dim]no tasks[/dim]")
@@ -1057,9 +1059,9 @@ class TaskView(Widget):
         if self._group_by == "status":
             mode_parts.append("[magenta]by status[/magenta]")
 
-        if self._status_filter:
-            labels = [STATUS_LABELS.get(s, s) for s in sorted(self._status_filter)]
-            mode_parts.append(f"[magenta]{'+'.join(labels)}[/magenta]")
+        if self._hidden_statuses:
+            labels = [STATUS_LABELS.get(s, s) for s in sorted(self._hidden_statuses)]
+            mode_parts.append(f"[magenta]hiding: {'+'.join(labels)}[/magenta]")
 
         if self._epic_filter:
             mode_parts.append(f"[cyan]epic: {self._epic_filter}[/cyan]")
@@ -1090,7 +1092,7 @@ class TaskView(Widget):
 
     def _task_passes_filters(self, task: TaskDict) -> bool:
         """Check if a task passes text, status, and epic filters."""
-        if self._status_filter and task["status"] not in self._status_filter:
+        if task["status"] in self._hidden_statuses:
             return False
         if self._epic_filter and task.get("epic_key") != self._epic_filter:
             return False
@@ -1178,32 +1180,34 @@ class TaskView(Widget):
     # ------------------------------------------------------------------
 
     def _toggle_status_filter(self, statuses: set[str]) -> None:
-        """Toggle a status filter on/off."""
-        if self._status_filter == statuses:
-            self._status_filter = None
+        """Toggle visibility of specific statuses."""
+        if statuses <= self._hidden_statuses:
+            # Already hidden — show them
+            self._hidden_statuses -= statuses
         else:
-            self._status_filter = statuses
+            # Currently visible — hide them
+            self._hidden_statuses |= statuses
         self._apply_filter()
 
     def action_filter_open(self) -> None:
-        """Show only open/ready tasks."""
+        """Toggle visibility of open/ready tasks."""
         self._toggle_status_filter({"open"})
 
     def action_filter_active(self) -> None:
-        """Show only active tasks."""
+        """Toggle visibility of active tasks."""
         self._toggle_status_filter({"active"})
 
     def action_filter_blocked(self) -> None:
-        """Show only blocked tasks."""
+        """Toggle visibility of blocked tasks."""
         self._toggle_status_filter({"blocked"})
 
     def action_filter_finished(self) -> None:
-        """Show only finished tasks (done/failed/wontdo/duplicate)."""
+        """Toggle visibility of finished tasks (done/failed/wontdo/duplicate)."""
         self._toggle_status_filter({"done", "failed", "wontdo", "duplicate"})
 
     def action_clear_all_filters(self) -> None:
         """Clear all status and epic filters."""
-        self._status_filter = None
+        self._hidden_statuses = set()
         self._epic_filter = None
         self._apply_filter()
 

--- a/tests/test_task_browser.py
+++ b/tests/test_task_browser.py
@@ -1629,6 +1629,119 @@ class TestEpicGrouping:
             old_idx = next(i for i, t in enumerate(titles) if "Old finish" in t)
             assert finished_idx < old_idx
 
+    @pytest.mark.asyncio
+    async def test_epics_sorted_by_recent_child_activity(self, mock_task_data: MockDict) -> None:
+        """Epics with more recently updated children appear first."""
+        mock_task_data["list_tasks"].return_value = [
+            make_task(
+                id=1,
+                title="Old child",
+                status="open",
+                epic_key="STALE",
+                parent_task_id=500,
+                updated_at="2025-01-01T00:00:00",
+            ),
+            make_task(
+                id=2,
+                title="Recent child",
+                status="open",
+                epic_key="FRESH",
+                parent_task_id=501,
+                updated_at="2025-06-15T12:00:00",
+            ),
+        ]
+        mock_task_data["list_epics"].return_value = [
+            make_epic(id=500, epic_key="STALE"),
+            make_epic(id=501, epic_key="FRESH"),
+        ]
+        app = TaskTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            table = app.query_one("#task-table", DataTable)
+            titles = _table_cell_texts(table, "title")
+            fresh_idx = next(i for i, t in enumerate(titles) if "FRESH" in t)
+            stale_idx = next(i for i, t in enumerate(titles) if "STALE" in t)
+            assert fresh_idx < stale_idx, "Epic with recently-updated child should appear first"
+
+    @pytest.mark.asyncio
+    async def test_epics_with_active_children_float_to_top(self, mock_task_data: MockDict) -> None:
+        """Epics with in-progress children appear before those without."""
+        mock_task_data["list_tasks"].return_value = [
+            make_task(
+                id=1,
+                title="Idle child",
+                status="open",
+                epic_key="IDLE",
+                parent_task_id=600,
+                updated_at="2025-06-15T12:00:00",
+            ),
+            make_task(
+                id=2,
+                title="Active child",
+                status="active",
+                epic_key="BUSY",
+                parent_task_id=601,
+                updated_at="2025-01-01T00:00:00",
+            ),
+        ]
+        mock_task_data["list_epics"].return_value = [
+            make_epic(id=600, epic_key="IDLE"),
+            make_epic(id=601, epic_key="BUSY"),
+        ]
+        app = TaskTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            table = app.query_one("#task-table", DataTable)
+            titles = _table_cell_texts(table, "title")
+            busy_idx = next(i for i, t in enumerate(titles) if "BUSY" in t)
+            idle_idx = next(i for i, t in enumerate(titles) if "IDLE" in t)
+            assert busy_idx < idle_idx, "Epic with active child should float above idle epic"
+
+    @pytest.mark.asyncio
+    async def test_children_sorted_oldest_first(self, mock_task_data: MockDict) -> None:
+        """Tasks within an epic are sorted oldest-first (queue discipline)."""
+        mock_task_data["list_tasks"].return_value = [
+            make_task(
+                id=1,
+                title="Newest task",
+                status="open",
+                epic_key="Q",
+                parent_task_id=700,
+                created_at="2025-03-01T00:00:00",
+            ),
+            make_task(
+                id=2,
+                title="Middle task",
+                status="open",
+                epic_key="Q",
+                parent_task_id=700,
+                created_at="2025-02-01T00:00:00",
+            ),
+            make_task(
+                id=3,
+                title="Oldest task",
+                status="open",
+                epic_key="Q",
+                parent_task_id=700,
+                created_at="2025-01-01T00:00:00",
+            ),
+        ]
+        mock_task_data["list_epics"].return_value = [
+            make_epic(id=700, epic_key="Q"),
+        ]
+        app = TaskTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            table = app.query_one("#task-table", DataTable)
+            task_titles = _task_titles(table)
+            q_tasks = [t for t in task_titles if t in {"Oldest task", "Middle task", "Newest task"}]
+            assert q_tasks == ["Oldest task", "Middle task", "Newest task"], (
+                f"Expected oldest-first queue order, got {q_tasks}"
+            )
+
 
 # ===================================================================
 # K. Won't Do Status
@@ -2150,3 +2263,209 @@ class TestCollapseExpand:
             # DEAD epic header visible but children hidden
             assert any("DEAD" in t for t in titles)
             assert not any("Done child" in t for t in titles)
+
+
+# ===================================================================
+# N. Help Modal Shows Filter Keybindings (FEAT-58)
+# ===================================================================
+
+
+class TestHelpModalFilterKeys:
+    """Verify that pressing ? shows the new filter keybindings."""
+
+    @pytest.mark.asyncio
+    async def test_help_modal_shows_filter_keys(self, mock_task_data: MockDict) -> None:
+        """Pressing ? opens help modal containing the new filter bindings."""
+        from emdx.ui.task_browser import TaskBrowser
+
+        class HelpApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield TaskBrowser()
+
+        app = HelpApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("question_mark")
+            await pilot.pause()
+
+            from emdx.ui.modals import KeybindingsHelpScreen
+
+            screen = app.screen
+            assert isinstance(screen, KeybindingsHelpScreen)
+
+            help_rows = screen.query(".help-row")
+            help_text = " ".join(str(row.content) for row in help_rows)
+
+            assert "Open Only" in help_text
+            assert "Active Only" in help_text
+            assert "Blocked Only" in help_text
+            assert "Finished" in help_text
+            assert "Clear Filters" in help_text
+            assert "Epic Filter" in help_text
+            assert "Group By" in help_text
+            assert "Open URLs" in help_text
+            assert "Expand/Collapse" in help_text
+
+    @pytest.mark.asyncio
+    async def test_help_bar_includes_filter_keys(self, mock_task_data: MockDict) -> None:
+        """Help bar text includes the new filter key hints."""
+        from emdx.ui.task_browser import TaskBrowser
+
+        class HelpBarApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield TaskBrowser()
+
+        app = HelpBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one("#task-help-bar", Static)
+            content = str(bar.content)
+            assert "Open" in content
+            assert "Blocked" in content
+            assert "Finished" in content
+            assert "Clear" in content
+            assert "Epic" in content
+            assert "Group" in content
+
+
+# ===================================================================
+# O. Done-Fold Recency Hint (FEAT-61)
+# ===================================================================
+
+
+class TestDoneFoldRecency:
+    """Tests for the recency hint on collapsed done-fold rows."""
+
+    @pytest.mark.asyncio
+    async def test_done_fold_shows_recency_hint(self, mock_task_data: MockDict) -> None:
+        """Collapsed done epic shows fold row with 'latest:' recency hint."""
+        mock_task_data["list_tasks"].return_value = [
+            make_task(
+                id=1,
+                title="Active work",
+                status="open",
+                epic_key="LIVE",
+                parent_task_id=200,
+            ),
+            make_task(
+                id=2,
+                title="Done child",
+                status="done",
+                epic_key="DEAD",
+                parent_task_id=201,
+                completed_at="2025-01-01T12:00:00",
+            ),
+            make_task(
+                id=3,
+                title="Also done",
+                status="done",
+                epic_key="DEAD",
+                parent_task_id=201,
+                completed_at="2025-01-02T12:00:00",
+            ),
+        ]
+        mock_task_data["list_epics"].return_value = [
+            make_epic(id=200, epic_key="LIVE"),
+            make_epic(
+                id=201,
+                epic_key="DEAD",
+                status="done",
+                child_count=2,
+                children_done=2,
+                children_open=0,
+            ),
+        ]
+        app = TaskTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            table = app.query_one("#task-table", DataTable)
+            titles = _table_cell_texts(table, "title")
+            fold_rows = [t for t in titles if "completed" in t and "▸" in t]
+            assert len(fold_rows) >= 1, f"No fold row found in: {titles}"
+            assert "latest:" in fold_rows[0]
+
+    @pytest.mark.asyncio
+    async def test_done_fold_without_completed_at(self, mock_task_data: MockDict) -> None:
+        """Fold row falls back to updated_at when completed_at is missing."""
+        mock_task_data["list_tasks"].return_value = [
+            make_task(
+                id=1,
+                title="Active work",
+                status="open",
+                epic_key="LIVE",
+                parent_task_id=200,
+            ),
+            make_task(
+                id=2,
+                title="Done child",
+                status="done",
+                epic_key="DEAD",
+                parent_task_id=201,
+                completed_at=None,
+                updated_at="2025-01-01T12:00:00",
+            ),
+        ]
+        mock_task_data["list_epics"].return_value = [
+            make_epic(id=200, epic_key="LIVE"),
+            make_epic(
+                id=201,
+                epic_key="DEAD",
+                status="done",
+                child_count=1,
+                children_done=1,
+                children_open=0,
+            ),
+        ]
+        app = TaskTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            table = app.query_one("#task-table", DataTable)
+            titles = _table_cell_texts(table, "title")
+            fold_rows = [t for t in titles if "completed" in t and "▸" in t]
+            assert len(fold_rows) >= 1
+            assert "latest:" in fold_rows[0]
+
+    @pytest.mark.asyncio
+    async def test_done_fold_no_dates(self, mock_task_data: MockDict) -> None:
+        """Fold row without any dates shows count but no 'latest:' hint."""
+        mock_task_data["list_tasks"].return_value = [
+            make_task(
+                id=1,
+                title="Active work",
+                status="open",
+                epic_key="LIVE",
+                parent_task_id=200,
+            ),
+            make_task(
+                id=2,
+                title="Done child",
+                status="done",
+                epic_key="DEAD",
+                parent_task_id=201,
+                completed_at=None,
+                updated_at=None,
+                created_at=None,
+            ),
+        ]
+        mock_task_data["list_epics"].return_value = [
+            make_epic(id=200, epic_key="LIVE"),
+            make_epic(
+                id=201,
+                epic_key="DEAD",
+                status="done",
+                child_count=1,
+                children_done=1,
+                children_open=0,
+            ),
+        ]
+        app = TaskTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            table = app.query_one("#task-table", DataTable)
+            titles = _table_cell_texts(table, "title")
+            fold_rows = [t for t in titles if "completed" in t and "▸" in t]
+            assert len(fold_rows) >= 1
+            assert "latest:" not in fold_rows[0]

--- a/tests/test_task_browser.py
+++ b/tests/test_task_browser.py
@@ -718,7 +718,7 @@ class TestScreenSwitching:
 
     @pytest.mark.asyncio
     async def test_help_bar_shows_key_hints(self, mock_task_data: MockDict) -> None:
-        """TaskBrowser help bar shows essential keybinding hints."""
+        """TaskBrowser help bar shows task-context keybinding hints."""
         from emdx.ui.task_browser import TaskBrowser
 
         class HelpBarApp(App[None]):
@@ -730,14 +730,9 @@ class TestScreenSwitching:
             await pilot.pause()
             bar = app.query_one("#task-help-bar", Static)
             content = str(bar.content)
-            assert "1" in content
-            assert "2" in content
-            assert "Docs" in content
-            assert "Tasks" in content
             assert "Done" in content
             assert "Active" in content
             assert "Blocked" in content
-            assert "Reopen" in content
             assert "Help" in content
             assert "Filter" in content
 
@@ -1152,8 +1147,8 @@ class TestStatusFilter:
     """Tests for quick status filter keys (o/i/x/f/*)."""
 
     @pytest.mark.asyncio
-    async def test_o_filters_to_open_only(self, mock_task_data: MockDict) -> None:
-        """Pressing o shows only open/ready tasks."""
+    async def test_o_hides_open_tasks(self, mock_task_data: MockDict) -> None:
+        """Pressing o hides open/ready tasks (toggle model)."""
         mock_task_data["list_tasks"].return_value = [
             make_task(id=1, title="Open task", status="open"),
             make_task(id=2, title="Active task", status="active"),
@@ -1170,13 +1165,12 @@ class TestStatusFilter:
 
             assert table.row_count < initial_count
             task_titles = _task_titles(table)
-            assert any("Open task" in t for t in task_titles)
-            assert not any("Active task" in t for t in task_titles)
-            assert not any("Done task" in t for t in task_titles)
+            assert not any("Open task" in t for t in task_titles)
+            assert any("Active task" in t for t in task_titles)
 
     @pytest.mark.asyncio
-    async def test_i_filters_to_active_only(self, mock_task_data: MockDict) -> None:
-        """Pressing i shows only active tasks."""
+    async def test_i_hides_active_tasks(self, mock_task_data: MockDict) -> None:
+        """Pressing i hides active tasks (toggle model)."""
         mock_task_data["list_tasks"].return_value = [
             make_task(id=1, title="Open task", status="open"),
             make_task(id=2, title="Active task", status="active"),
@@ -1190,13 +1184,12 @@ class TestStatusFilter:
 
             table = app.query_one("#task-table", DataTable)
             task_titles = _task_titles(table)
-            assert any("Active task" in t for t in task_titles)
-            assert not any("Open task" in t for t in task_titles)
-            assert not any("Done task" in t for t in task_titles)
+            assert not any("Active task" in t for t in task_titles)
+            assert any("Open task" in t for t in task_titles)
 
     @pytest.mark.asyncio
-    async def test_x_filters_to_blocked_only(self, mock_task_data: MockDict) -> None:
-        """Pressing x shows only blocked tasks."""
+    async def test_x_hides_blocked_tasks(self, mock_task_data: MockDict) -> None:
+        """Pressing x hides blocked tasks (toggle model)."""
         mock_task_data["list_tasks"].return_value = [
             make_task(id=1, title="Open task", status="open"),
             make_task(id=2, title="Blocked task", status="blocked"),
@@ -1209,12 +1202,12 @@ class TestStatusFilter:
 
             table = app.query_one("#task-table", DataTable)
             task_titles = _task_titles(table)
-            assert any("Blocked task" in t for t in task_titles)
-            assert not any("Open task" in t for t in task_titles)
+            assert not any("Blocked task" in t for t in task_titles)
+            assert any("Open task" in t for t in task_titles)
 
     @pytest.mark.asyncio
-    async def test_f_filters_to_done_and_failed(self, mock_task_data: MockDict) -> None:
-        """Pressing f shows done and failed tasks."""
+    async def test_f_hides_finished_tasks(self, mock_task_data: MockDict) -> None:
+        """Pressing f hides done/failed/wontdo/duplicate tasks (toggle model)."""
         mock_task_data["list_tasks"].return_value = [
             make_task(id=1, title="Open task", status="open"),
             make_task(id=2, title="Done task", status="done"),
@@ -1228,9 +1221,9 @@ class TestStatusFilter:
 
             table = app.query_one("#task-table", DataTable)
             task_titles = _task_titles(table)
-            assert any("Done task" in t for t in task_titles)
-            assert any("Failed task" in t for t in task_titles)
-            assert not any("Open task" in t for t in task_titles)
+            assert not any("Done task" in t for t in task_titles)
+            assert not any("Failed task" in t for t in task_titles)
+            assert any("Open task" in t for t in task_titles)
 
     @pytest.mark.asyncio
     async def test_asterisk_clears_status_filter(self, mock_task_data: MockDict) -> None:
@@ -1279,8 +1272,10 @@ class TestStatusFilter:
             assert table.row_count == initial_count
 
     @pytest.mark.asyncio
-    async def test_status_filter_shows_label_in_status_bar(self, mock_task_data: MockDict) -> None:
-        """Status bar shows the active status filter label."""
+    async def test_status_filter_shows_hiding_label_in_status_bar(
+        self, mock_task_data: MockDict
+    ) -> None:
+        """Status bar shows 'hiding: READY' when open tasks are hidden."""
         mock_task_data["list_tasks"].return_value = [
             make_task(id=1, title="Open task", status="open"),
             make_task(id=2, title="Active task", status="active"),
@@ -1292,11 +1287,13 @@ class TestStatusFilter:
             await pilot.pause()
 
             bar = app.query_one("#task-status-bar", Static)
-            assert "READY" in str(bar.content)
+            bar_text = str(bar.content)
+            assert "hiding:" in bar_text
+            assert "READY" in bar_text
 
     @pytest.mark.asyncio
     async def test_status_filter_composes_with_text_filter(self, mock_task_data: MockDict) -> None:
-        """Status filter and text filter work together."""
+        """Status filter (hide) and text filter work together."""
         mock_task_data["list_tasks"].return_value = [
             make_task(id=1, title="Fix auth bug", status="open"),
             make_task(id=2, title="Fix deploy bug", status="open"),
@@ -1306,8 +1303,8 @@ class TestStatusFilter:
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            # Filter to open only
-            await pilot.press("o")
+            # Hide finished tasks (done/failed/wontdo/duplicate)
+            await pilot.press("f")
             await pilot.pause()
 
             # Add text filter for "auth"
@@ -1319,7 +1316,7 @@ class TestStatusFilter:
 
             table = app.query_one("#task-table", DataTable)
             task_titles = _task_titles(table)
-            # Only "Fix auth bug" (open + matches "auth")
+            # Only "Fix auth bug" (open + matches "auth", done regression hidden)
             assert len(task_titles) == 1
             assert "auth" in task_titles[0].lower()
 
@@ -1348,19 +1345,111 @@ class TestStatusFilter:
 
     @pytest.mark.asyncio
     async def test_status_filter_no_matches(self, mock_task_data: MockDict) -> None:
-        """Status filter with no matching tasks shows 'no matches'."""
+        """Hiding all present statuses shows 'no matches'."""
         mock_task_data["list_tasks"].return_value = [
             make_task(id=1, title="Open task", status="open"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
             await pilot.pause()
-            # Filter to active — but there are none
-            await pilot.press("i")
+            # Hide open — the only status present
+            await pilot.press("o")
             await pilot.pause()
 
             bar = app.query_one("#task-status-bar", Static)
             assert "no matches" in str(bar.content)
+
+    @pytest.mark.asyncio
+    async def test_multiple_toggles_combine(self, mock_task_data: MockDict) -> None:
+        """Pressing o then i hides both open and active tasks."""
+        mock_task_data["list_tasks"].return_value = [
+            make_task(id=1, title="Open task", status="open"),
+            make_task(id=2, title="Active task", status="active"),
+            make_task(id=3, title="Blocked task", status="blocked"),
+        ]
+        app = TaskTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            # Hide open
+            await pilot.press("o")
+            await pilot.pause()
+            # Also hide active
+            await pilot.press("i")
+            await pilot.pause()
+
+            table = app.query_one("#task-table", DataTable)
+            task_titles = _task_titles(table)
+            assert not any("Open task" in t for t in task_titles)
+            assert not any("Active task" in t for t in task_titles)
+            assert any("Blocked task" in t for t in task_titles)
+
+    @pytest.mark.asyncio
+    async def test_toggle_unhide_after_hide(self, mock_task_data: MockDict) -> None:
+        """Pressing f twice: first hides finished, second shows them again."""
+        mock_task_data["list_tasks"].return_value = [
+            make_task(id=1, title="Open task", status="open"),
+            make_task(id=2, title="Done task", status="done"),
+        ]
+        app = TaskTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            table = app.query_one("#task-table", DataTable)
+            initial_count = table.row_count
+
+            # Hide finished
+            await pilot.press("f")
+            await pilot.pause()
+            assert table.row_count < initial_count
+
+            # Unhide finished
+            await pilot.press("f")
+            await pilot.pause()
+            assert table.row_count == initial_count
+
+    @pytest.mark.asyncio
+    async def test_clear_all_resets_hidden(self, mock_task_data: MockDict) -> None:
+        """Pressing * clears all hidden statuses and epic filter."""
+        mock_task_data["list_tasks"].return_value = [
+            make_task(id=1, title="Open task", status="open"),
+            make_task(id=2, title="Active task", status="active"),
+            make_task(id=3, title="Done task", status="done"),
+        ]
+        app = TaskTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            table = app.query_one("#task-table", DataTable)
+            initial_count = table.row_count
+
+            # Hide multiple statuses
+            await pilot.press("o")
+            await pilot.pause()
+            await pilot.press("i")
+            await pilot.pause()
+            assert table.row_count < initial_count
+
+            # Clear all
+            await pilot.press("asterisk")
+            await pilot.pause()
+            assert table.row_count == initial_count
+
+    @pytest.mark.asyncio
+    async def test_status_bar_shows_hiding_label(self, mock_task_data: MockDict) -> None:
+        """Status bar shows 'hiding: DONE+...' when finished tasks are hidden."""
+        mock_task_data["list_tasks"].return_value = [
+            make_task(id=1, title="Open task", status="open"),
+            make_task(id=2, title="Done task", status="done"),
+        ]
+        app = TaskTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("f")
+            await pilot.pause()
+
+            bar = app.query_one("#task-status-bar", Static)
+            bar_text = str(bar.content)
+            assert "hiding:" in bar_text
+            assert "DONE" in bar_text
 
 
 # ===================================================================
@@ -1473,7 +1562,7 @@ class TestEpicGrouping:
 
     @pytest.mark.asyncio
     async def test_epic_grouping_composes_with_filters(self, mock_task_data: MockDict) -> None:
-        """Epic grouping (default) works together with status and text filters."""
+        """Epic grouping (default) works together with status hide filters."""
         mock_task_data["list_tasks"].return_value = [
             make_task(id=1, title="Fix auth", status="open", epic_key="AUTH", parent_task_id=100),
             make_task(id=2, title="Fix deploy", status="open", epic_key="AUTH", parent_task_id=100),
@@ -1486,13 +1575,13 @@ class TestEpicGrouping:
         app = TaskTestApp()
         async with app.run_test() as pilot:
             await pilot.pause()
-            # Filter to open only (epic grouping is default)
-            await pilot.press("o")
+            # Hide active tasks (epic grouping is default)
+            await pilot.press("i")
             await pilot.pause()
 
             table = app.query_one("#task-table", DataTable)
             titles = _table_cell_texts(table, "title")
-            # AUTH tasks are open, TUI task is active — TUI should be gone
+            # AUTH tasks are open (visible), TUI task is active (hidden)
             assert any("AUTH" in t for t in titles)
             assert not any("TUI" in t for t in titles)
 
@@ -1753,16 +1842,14 @@ class TestWontdoStatus:
 
     @pytest.mark.asyncio
     async def test_wontdo_icon_and_color(self, mock_task_data: MockDict) -> None:
-        """Wontdo tasks show the ⊘ icon with dim styling."""
+        """Wontdo tasks show the 🚫 icon with dim styling."""
         mock_task_data["list_tasks"].return_value = [
             make_task(id=1, title="Skipped task", status="wontdo"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
             await pilot.pause()
-            # Filter to finished tasks so the wontdo task is visible
-            await pilot.press("f")
-            await pilot.pause()
+            # Wontdo task visible by default (ungrouped, shown inline)
             table = app.query_one("#task-table", DataTable)
             icons = _table_cell_texts(table, "icon")
             task_icons = [i for i in icons if i.strip()]
@@ -1792,8 +1879,8 @@ class TestWontdoStatus:
                 m_update.assert_called_once_with(1, status="wontdo")
 
     @pytest.mark.asyncio
-    async def test_f_filter_includes_wontdo(self, mock_task_data: MockDict) -> None:
-        """Pressing f shows wontdo tasks alongside done and failed."""
+    async def test_f_filter_hides_wontdo(self, mock_task_data: MockDict) -> None:
+        """Pressing f hides wontdo tasks alongside done and failed."""
         mock_task_data["list_tasks"].return_value = [
             make_task(id=1, title="Open task", status="open"),
             make_task(id=2, title="Done task", status="done"),
@@ -1807,9 +1894,9 @@ class TestWontdoStatus:
 
             table = app.query_one("#task-table", DataTable)
             task_titles = _task_titles(table)
-            assert any("Done task" in t for t in task_titles)
-            assert any("Wontdo task" in t for t in task_titles)
-            assert not any("Open task" in t for t in task_titles)
+            assert not any("Done task" in t for t in task_titles)
+            assert not any("Wontdo task" in t for t in task_titles)
+            assert any("Open task" in t for t in task_titles)
 
     @pytest.mark.asyncio
     async def test_wontdo_epic_collapsed_at_bottom(self, mock_task_data: MockDict) -> None:
@@ -2254,13 +2341,10 @@ class TestCollapseExpand:
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            # Enable finished filter to see COMPLETED section
-            await pilot.press("f")
-            await pilot.pause()
-
+            # COMPLETED section visible by default (no statuses hidden)
             table = app.query_one("#task-table", DataTable)
             titles = _table_cell_texts(table, "title")
-            # DEAD epic header visible but children hidden
+            # DEAD epic header visible but children hidden (collapsed)
             assert any("DEAD" in t for t in titles)
             assert not any("Done child" in t for t in titles)
 
@@ -2296,10 +2380,10 @@ class TestHelpModalFilterKeys:
             help_rows = screen.query(".help-row")
             help_text = " ".join(str(row.content) for row in help_rows)
 
-            assert "Open Only" in help_text
-            assert "Active Only" in help_text
-            assert "Blocked Only" in help_text
-            assert "Finished" in help_text
+            assert "Toggle Open" in help_text
+            assert "Toggle Active" in help_text
+            assert "Toggle Blocked" in help_text
+            assert "Toggle Finished" in help_text
             assert "Clear Filters" in help_text
             assert "Epic Filter" in help_text
             assert "Group By" in help_text
@@ -2308,7 +2392,7 @@ class TestHelpModalFilterKeys:
 
     @pytest.mark.asyncio
     async def test_help_bar_includes_filter_keys(self, mock_task_data: MockDict) -> None:
-        """Help bar text includes the new filter key hints."""
+        """Help bar text shows context-appropriate keys (task row default)."""
         from emdx.ui.task_browser import TaskBrowser
 
         class HelpBarApp(App[None]):
@@ -2320,12 +2404,10 @@ class TestHelpModalFilterKeys:
             await pilot.pause()
             bar = app.query_one("#task-help-bar", Static)
             content = str(bar.content)
-            assert "Open" in content
+            # Default footer shows task-action keys
+            assert "Done" in content
             assert "Blocked" in content
-            assert "Finished" in content
-            assert "Clear" in content
-            assert "Epic" in content
-            assert "Group" in content
+            assert "Navigate" in content
 
 
 # ===================================================================
@@ -2469,3 +2551,177 @@ class TestDoneFoldRecency:
             fold_rows = [t for t in titles if "completed" in t and "▸" in t]
             assert len(fold_rows) >= 1
             assert "latest:" not in fold_rows[0]
+
+
+# ===================================================================
+# P. Context-Sensitive Footer (FEAT-59)
+# ===================================================================
+
+
+class TestContextSensitiveFooter:
+    """Tests for the dynamic footer bar that changes with selection."""
+
+    @pytest.mark.asyncio
+    async def test_footer_shows_task_context_keys(self, mock_task_data: MockDict) -> None:
+        """Footer shows task-action keys when a normal task row is selected."""
+        from emdx.ui.task_browser import TaskBrowser
+
+        mock_task_data["list_tasks"].return_value = [
+            make_task(id=1, title="My task", status="open"),
+        ]
+
+        class FooterApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield TaskBrowser()
+
+        app = FooterApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # Navigate down until we land on a task: row
+            table = app.query_one("#task-table", DataTable)
+            for _i in range(table.row_count):
+                await pilot.press("j")
+                await pilot.pause()
+                if table.cursor_row is not None:
+                    key = str(table.ordered_rows[table.cursor_row].key.value)
+                    if key.startswith("task:"):
+                        break
+
+            bar = app.query_one("#task-help-bar", Static)
+            content = str(bar.content)
+            assert "Done" in content
+            assert "Active" in content
+            assert "Blocked" in content
+            assert "Navigate" in content
+            assert "Help" in content
+            # Should NOT show epic-header keys
+            assert "Expand/Collapse" not in content
+
+    @pytest.mark.asyncio
+    async def test_footer_shows_epic_context_keys(self, mock_task_data: MockDict) -> None:
+        """Footer shows epic keys when an epic header row is highlighted."""
+        from emdx.ui.task_browser import TaskBrowser
+
+        mock_task_data["list_tasks"].return_value = [
+            make_task(
+                id=100,
+                title="Epic: AUTH",
+                status="open",
+                epic_key="AUTH",
+                type="epic",
+            ),
+            make_task(
+                id=1,
+                title="Child task",
+                status="open",
+                epic_key="AUTH",
+                parent_task_id=100,
+            ),
+        ]
+        mock_task_data["list_epics"].return_value = [
+            make_epic(id=100, epic_key="AUTH"),
+        ]
+
+        class FooterApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield TaskBrowser()
+
+        app = FooterApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            table = app.query_one("#task-table", DataTable)
+            # Navigate to the epic row (task:100 with type="epic")
+            for _ in range(table.row_count):
+                await pilot.press("k")
+                await pilot.pause()
+            # Scan for the epic task row
+            found_epic = False
+            for _i in range(table.row_count):
+                if table.cursor_row is not None:
+                    key = str(table.ordered_rows[table.cursor_row].key.value)
+                    if key == "task:100":
+                        found_epic = True
+                        # Press j then k to trigger highlight event
+                        await pilot.press("j")
+                        await pilot.pause()
+                        await pilot.press("k")
+                        await pilot.pause()
+                        break
+                await pilot.press("j")
+                await pilot.pause()
+
+            assert found_epic, "Epic row task:100 not found"
+            bar = app.query_one("#task-help-bar", Static)
+            content = str(bar.content)
+            assert "Expand/Collapse" in content
+            assert "Epic Filter" in content
+            assert "Group By" in content
+            # Should NOT show task-action keys
+            assert "Done" not in content
+            assert "Active" not in content
+
+    @pytest.mark.asyncio
+    async def test_footer_shows_done_fold_context(self, mock_task_data: MockDict) -> None:
+        """Footer shows expand hint when a done-fold row is highlighted."""
+        from emdx.ui.task_browser import TaskBrowser
+
+        mock_task_data["list_tasks"].return_value = [
+            make_task(
+                id=1,
+                title="Open task",
+                status="open",
+                epic_key="AUTH",
+                parent_task_id=100,
+            ),
+            make_task(
+                id=2,
+                title="Done task 1",
+                status="done",
+                epic_key="AUTH",
+                parent_task_id=100,
+            ),
+            make_task(
+                id=3,
+                title="Done task 2",
+                status="done",
+                epic_key="AUTH",
+                parent_task_id=100,
+            ),
+        ]
+        mock_task_data["list_epics"].return_value = [
+            make_epic(
+                id=100,
+                epic_key="AUTH",
+                child_count=3,
+                children_done=2,
+                children_open=1,
+            ),
+        ]
+
+        class FooterApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield TaskBrowser()
+
+        app = FooterApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # Navigate down to find the done-fold row
+            table = app.query_one("#task-table", DataTable)
+            found_fold = False
+            for _i in range(table.row_count):
+                await pilot.press("j")
+                await pilot.pause()
+                if table.cursor_row is not None:
+                    key = str(table.ordered_rows[table.cursor_row].key.value)
+                    if key.startswith("done-fold:"):
+                        found_fold = True
+                        break
+
+            if found_fold:
+                bar = app.query_one("#task-help-bar", Static)
+                content = str(bar.content)
+                assert "Expand" in content
+                assert "Filter" in content
+                assert "Help" in content
+                # Should NOT show task-action keys
+                assert "Done" not in content

--- a/tests/test_task_browser.py
+++ b/tests/test_task_browser.py
@@ -1552,7 +1552,7 @@ class TestEpicGrouping:
 
     @pytest.mark.asyncio
     async def test_epic_grouping_hides_done_in_mixed_group(self, mock_task_data: MockDict) -> None:
-        """Done/failed children are hidden by default in active epics."""
+        """Done/failed children are hidden behind a fold in active epics."""
         mock_task_data["list_tasks"].return_value = [
             make_task(id=1, title="Open work", status="open", epic_key="MIX", parent_task_id=300),
             make_task(
@@ -1573,9 +1573,61 @@ class TestEpicGrouping:
             titles = _table_cell_texts(table, "title")
             assert any("MIX" in t for t in titles)
             assert any("Open work" in t for t in titles)
-            # Done/failed tasks hidden by default
+            # Done/failed tasks hidden behind fold by default
             assert not any("Finished work" in t for t in titles)
             assert not any("Failed work" in t for t in titles)
+            # Fold row shows count
+            assert any("2 completed" in t for t in titles)
+
+    @pytest.mark.asyncio
+    async def test_done_fold_expands_on_enter(self, mock_task_data: MockDict) -> None:
+        """Pressing Enter on the done-fold row reveals completed tasks."""
+        mock_task_data["list_tasks"].return_value = [
+            make_task(id=1, title="Open work", status="open", epic_key="MIX", parent_task_id=300),
+            make_task(
+                id=2,
+                title="Finished work",
+                status="done",
+                epic_key="MIX",
+                parent_task_id=300,
+                completed_at="2026-03-05 12:00:00",
+            ),
+            make_task(
+                id=3,
+                title="Old finish",
+                status="done",
+                epic_key="MIX",
+                parent_task_id=300,
+                completed_at="2026-03-01 12:00:00",
+            ),
+        ]
+        mock_task_data["list_epics"].return_value = [
+            make_epic(id=300, epic_key="MIX"),
+        ]
+        app = TaskTestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            table = app.query_one("#task-table", DataTable)
+            # Navigate to the done-fold row
+            for row_idx, row in enumerate(table.ordered_rows):
+                if str(row.key.value).startswith("done-fold:"):
+                    table.move_cursor(row=row_idx)
+                    break
+            await pilot.pause()
+
+            # Press Enter to expand
+            await pilot.press("enter")
+            await pilot.pause()
+
+            titles = _table_cell_texts(table, "title")
+            # Both done tasks now visible
+            assert any("Finished work" in t for t in titles)
+            assert any("Old finish" in t for t in titles)
+            # Most recently completed appears first (check order)
+            finished_idx = next(i for i, t in enumerate(titles) if "Finished work" in t)
+            old_idx = next(i for i, t in enumerate(titles) if "Old finish" in t)
+            assert finished_idx < old_idx
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Complete overhaul of the Task TUI for better sorting, filtering, and discoverability. Implements the FEAT-55 epic across 6 subtasks in 2 waves.

### Wave 1
- **Epic sort by activity**: Epics sort by most recent child activity instead of alphabetically; epics with active children float to top
- **Oldest-first child ordering**: Queue discipline — longest-waiting tasks surface first within each epic
- **Discoverable keybindings**: 9 hidden `on_key` handlers moved to proper `BINDINGS` so they appear in help modal
- **Done-fold recency hint**: Collapsible "N completed (latest: 2h ago) ▸" shows when work was last completed

### Wave 2
- **Context-sensitive footer** (FEAT-59): Dynamic 1-line footer shows relevant keybindings based on what's highlighted (task row vs epic header vs done-fold)
- **Toggle filter model** (FEAT-60): `o/i/x/f` now toggle hide/show instead of exclusive "show only" — multiple filters combine additively
- **datetime crash fix**: SQLite returns `datetime` objects for timestamp fields, causing `TypeError` in sort and silent failure in recency hints

## Test plan

- [x] 106 tests passing in `test_task_browser.py`
- [x] ruff lint + format clean
- [x] mypy passing
- [x] Pre-commit hooks passing
- [x] Manual TUI testing: done-fold renders with recency hint, footer updates on navigation, toggle filters combine correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)