### PR TITLE
feat(models): Document dataclass replaces TypedDict cast zoo (Issue #ARCH-24)

### DIFF
--- a/emdx/commands/briefing.py
+++ b/emdx/commands/briefing.py
@@ -450,7 +450,7 @@ def _briefing_save(hours: int, model: str | None) -> None:
 
     if docs:
         doc_lines = ["## Documents Created"]
-        doc_lines.extend(f"- #{d['id']}: {d['title']}" for d in docs[:15])
+        doc_lines.extend(f"- #{d.id}: {d.title}" for d in docs[:15])
         sections.append("\n".join(doc_lines))
 
     sections.append(

--- a/emdx/commands/context.py
+++ b/emdx/commands/context.py
@@ -124,9 +124,9 @@ def traverse_graph(
             continue
         scored = ScoredDocument(
             doc_id=sid,
-            title=doc["title"],
-            content=doc["content"],
-            tokens=estimate_tokens(doc["content"]),
+            title=doc.title,
+            content=doc.content,
+            tokens=estimate_tokens(doc.content),
             hops=0,
             score=1.0,
             path=[sid],
@@ -161,9 +161,9 @@ def traverse_graph(
                     reason = f"{depth}-hop {method} from #{source_id}"
                     visited[target_id] = ScoredDocument(
                         doc_id=target_id,
-                        title=doc["title"],
-                        content=doc["content"],
-                        tokens=estimate_tokens(doc["content"]),
+                        title=doc.title,
+                        content=doc.content,
+                        tokens=estimate_tokens(doc.content),
                         hops=depth,
                         score=hop_score,
                         path=source.path + [target_id],

--- a/emdx/commands/context.py
+++ b/emdx/commands/context.py
@@ -10,14 +10,15 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import typer
 from rich.console import Console
 
 from ..database import db
 from ..database.document_links import get_links_for_document
-from ..database.types import DocumentLinkDetail, DocumentRow
+from ..database.types import DocumentLinkDetail
+from ..models.document import Document
 
 if TYPE_CHECKING:
     from ..services.hybrid_search import HybridSearchResult
@@ -89,7 +90,7 @@ def compute_link_score(
 # ── Document fetching (no access tracking) ───────────────────────────
 
 
-def _fetch_document(doc_id: int) -> DocumentRow | None:
+def _fetch_document(doc_id: int) -> Document | None:
     """Fetch a document by ID without updating access tracking."""
     with db.get_connection() as conn:
         cursor = conn.execute(
@@ -98,7 +99,7 @@ def _fetch_document(doc_id: int) -> DocumentRow | None:
         )
         row = cursor.fetchone()
         if row:
-            return cast(DocumentRow, dict(row))
+            return Document.from_row(row)
         return None
 
 

--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -9,7 +9,6 @@ import json
 import os
 import subprocess
 import tempfile
-from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -26,6 +25,7 @@ from emdx.database.documents import (
     find_supersede_candidate,
     set_parent,
 )
+from emdx.models.document import Document
 from emdx.models.documents import (
     delete_document,
     get_document,
@@ -170,12 +170,12 @@ def display_save_result(
     doc_id: int,
     metadata: DocumentMetadata,
     applied_tags: list[str],
-    supersede_target: Mapping[str, Any] | None = None,
+    supersede_target: Document | None = None,
 ) -> None:
     """Display save result to user"""
     console.print(f"[green]✅ Saved as #{doc_id}:[/green] [cyan]{metadata.title}[/cyan]")
     if supersede_target:
-        console.print(f"   [dim]↳ Superseded #{supersede_target['id']}[/dim]")
+        console.print(f"   [dim]↳ Superseded #{supersede_target.id}[/dim]")
     if metadata.project:
         console.print(f"   [dim]Project:[/dim] {metadata.project}")
     if applied_tags:
@@ -255,7 +255,7 @@ def save(
 
     # Step 5.5: If superseding, link the old doc as a child of the new doc
     if supersede_target:
-        set_parent(supersede_target["id"], doc_id, relationship="supersedes")
+        set_parent(supersede_target.id, doc_id, relationship="supersedes")
 
     # Step 6: Apply tags
     applied_tags = apply_tags(doc_id, tags)
@@ -831,13 +831,13 @@ def _find_list_all(
     table.add_column("Views", justify="right", style="blue")
 
     for doc in docs:
-        created = doc["created_at"].strftime("%Y-%m-%d") if doc["created_at"] else ""
+        created = doc.created_at.strftime("%Y-%m-%d") if doc.created_at else ""
         table.add_row(
-            str(doc["id"]),
-            truncate_title(doc["title"]),
-            doc["project"] or "None",
+            str(doc.id),
+            truncate_title(doc.title),
+            doc.project or "None",
             created,
-            str(doc["access_count"]),
+            str(doc.access_count),
         )
 
     console.print(table)
@@ -856,7 +856,7 @@ def _find_recent(
 
     docs = get_recent_documents(limit=limit, doc_type=doc_type)
     if project:
-        docs = [d for d in docs if d.get("project") == project]
+        docs = [d for d in docs if d.project == project]
 
     if not docs:
         console.print("[yellow]No recently accessed documents found[/yellow]")
@@ -885,14 +885,14 @@ def _find_recent(
 
     for doc in docs:
         accessed_str = "Never"
-        if doc["accessed_at"]:
-            accessed_str = doc["accessed_at"].strftime("%Y-%m-%d %H:%M")
+        if doc.accessed_at:
+            accessed_str = doc.accessed_at.strftime("%Y-%m-%d %H:%M")
         table.add_row(
-            str(doc["id"]),
-            truncate_title(doc["title"]),
-            doc["project"] or "None",
+            str(doc.id),
+            truncate_title(doc.title),
+            doc.project or "None",
             accessed_str,
-            str(doc["access_count"]),
+            str(doc.access_count),
         )
 
     console.print(table)
@@ -1631,24 +1631,24 @@ def view(
         # Record view event (non-critical, best-effort)
         from emdx.models.events import record_event
 
-        record_event("view", doc_id=doc["id"])
+        record_event("view", doc_id=doc.id)
 
-        doc_tags = get_document_tags(doc["id"])
+        doc_tags = get_document_tags(doc.id)
 
         # Fetch linked documents
         try:
             from emdx.database.document_links import get_links_for_document
 
-            doc_links = get_links_for_document(doc["id"])
+            doc_links = get_links_for_document(doc.id)
         except Exception:
             doc_links = []
 
         # JSON output
         if json_output:
-            content = doc["content"]
+            content = doc.content
             linked_docs = []
             for link in doc_links:
-                if link["source_doc_id"] == doc["id"]:
+                if link["source_doc_id"] == doc.id:
                     linked_docs.append(
                         {
                             "id": link["target_doc_id"],
@@ -1667,15 +1667,15 @@ def view(
                         }
                     )
             output = {
-                "id": doc["id"],
-                "title": doc["title"],
+                "id": doc.id,
+                "title": doc.title,
                 "content": content,
-                "project": doc["project"],
-                "created_at": str(doc.get("created_at") or ""),
-                "updated_at": str(doc.get("updated_at") or ""),
-                "accessed_at": str(doc.get("accessed_at") or ""),
-                "access_count": doc["access_count"],
-                "parent_id": doc.get("parent_id"),
+                "project": doc.project,
+                "created_at": str(doc.created_at or ""),
+                "updated_at": str(doc.updated_at or ""),
+                "accessed_at": str(doc.accessed_at or ""),
+                "access_count": doc.access_count,
+                "parent_id": doc.parent_id,
                 "tags": doc_tags,
                 "linked_docs": linked_docs,
                 "word_count": len(content.split()),
@@ -1688,10 +1688,10 @@ def view(
         # Handle --links: show detailed link information
         if links:
             if not doc_links:
-                console.print(f"[yellow]No links found for document #{doc['id']}[/yellow]")
+                console.print(f"[yellow]No links found for document #{doc.id}[/yellow]")
                 return
 
-            console.print(f"[bold]Links for #{doc['id']} '{doc['title']}':[/bold]\n")
+            console.print(f"[bold]Links for #{doc.id} '{doc.title}':[/bold]\n")
             from rich.table import Table as LinksTable
 
             table = LinksTable()
@@ -1701,7 +1701,7 @@ def view(
             table.add_column("Method", style="dim", width=8)
 
             for link in doc_links:
-                if link["source_doc_id"] == doc["id"]:
+                if link["source_doc_id"] == doc.id:
                     other_id = link["target_doc_id"]
                     other_title = link["target_title"]
                 else:
@@ -1720,17 +1720,17 @@ def view(
                 else:
                     _print_view_header_plain(doc, doc_tags)
                 if doc_links:
-                    _print_related_docs(doc["id"], doc_links, rich_mode)
+                    _print_related_docs(doc.id, doc_links, rich_mode)
                 print()
 
             if raw:
-                print(doc["content"])
+                print(doc.content)
             elif rich_mode:
                 from emdx.ui.markdown_config import MarkdownConfig
 
-                console.print(MarkdownConfig.create_markdown(doc["content"]))
+                console.print(MarkdownConfig.create_markdown(doc.content))
             else:
-                print(doc["content"])
+                print(doc.content)
 
         if no_pager:
             _render_output()
@@ -1749,7 +1749,7 @@ def view(
         raise typer.Exit(1) from e
 
 
-def _view_review(doc: Mapping[str, Any]) -> None:
+def _view_review(doc: Document) -> None:
     """Run an adversarial review of a document using an LLM.
 
     Finds similar documents via embeddings (if available) and prompts
@@ -1767,9 +1767,9 @@ def _view_review(doc: Mapping[str, Any]) -> None:
         )
         raise typer.Exit(1)
 
-    doc_id: int = doc["id"]
-    title: str = doc["title"]
-    content: str = doc["content"]
+    doc_id: int = doc.id
+    title: str = doc.title
+    content: str = doc.content
 
     console.print(f"[dim]Reviewing #{doc_id} '{escape(title)}'...[/dim]")
 
@@ -1851,17 +1851,17 @@ def _view_review(doc: Mapping[str, Any]) -> None:
         console.print(f"\n[dim]Similar docs referenced: {id_list}[/dim]")
 
 
-def _print_view_header_plain(doc: Mapping[str, Any], doc_tags: list[str]) -> None:
+def _print_view_header_plain(doc: Document, doc_tags: list[str]) -> None:
     """Print a plain text header for machine-friendly output."""
-    print(f"#{doc['id']}  {doc['title']}")
+    print(f"#{doc.id}  {doc.title}")
 
     meta = []
-    if doc.get("project"):
-        meta.append(f"Project: {doc['project']}")
-    created = str(doc.get("created_at") or "")[:16]
+    if doc.project:
+        meta.append(f"Project: {doc.project}")
+    created = str(doc.created_at or "")[:16]
     if created:
         meta.append(f"Created: {created}")
-    updated = str(doc.get("updated_at") or "")[:16]
+    updated = str(doc.updated_at or "")[:16]
     if updated and updated != created:
         meta.append(f"Updated: {updated}")
     if doc_tags:
@@ -1871,26 +1871,26 @@ def _print_view_header_plain(doc: Mapping[str, Any], doc_tags: list[str]) -> Non
     print("---")
 
 
-def _print_view_header_rich(doc: Mapping[str, Any], doc_tags: list[str]) -> None:
+def _print_view_header_rich(doc: Document, doc_tags: list[str]) -> None:
     """Print a rich panel header for document view, matching the TUI."""
-    content = doc.get("content", "")
+    content = doc.content
     word_count = len(content.split())
     char_count = len(content)
     line_count = content.count("\n") + 1 if content else 0
 
     lines = []
-    lines.append(f"[bold cyan]#{doc['id']}[/bold cyan]  [bold]{doc['title']}[/bold]")
+    lines.append(f"[bold cyan]#{doc.id}[/bold cyan]  [bold]{doc.title}[/bold]")
     lines.append("")
 
-    if doc.get("project"):
-        lines.append(f"  [dim]Project:[/dim]   {doc['project']}")
+    if doc.project:
+        lines.append(f"  [dim]Project:[/dim]   {doc.project}")
 
     if doc_tags:
         lines.append(f"  [dim]Tags:[/dim]      {format_tags(doc_tags)}")
 
-    created = str(doc.get("created_at") or "")[:16]
-    updated = str(doc.get("updated_at") or "")[:16]
-    accessed = str(doc.get("accessed_at") or "")[:16]
+    created = str(doc.created_at or "")[:16]
+    updated = str(doc.updated_at or "")[:16]
+    accessed = str(doc.accessed_at or "")[:16]
 
     if created:
         lines.append(f"  [dim]Created:[/dim]   {created}")
@@ -1900,14 +1900,14 @@ def _print_view_header_rich(doc: Mapping[str, Any], doc_tags: list[str]) -> None
         lines.append(f"  [dim]Accessed:[/dim]  {accessed}")
 
     lines.append(
-        f"  [dim]Views:[/dim]     {doc.get('access_count', 0)}   "
+        f"  [dim]Views:[/dim]     {doc.access_count}   "
         f"[dim]Words:[/dim] {word_count}   "
         f"[dim]Lines:[/dim] {line_count}   "
         f"[dim]Chars:[/dim] {char_count}"
     )
 
-    if doc.get("parent_id"):
-        lines.append(f"  [dim]Parent:[/dim]    #{doc['parent_id']}")
+    if doc.parent_id:
+        lines.append(f"  [dim]Parent:[/dim]    #{doc.parent_id}")
 
     panel = Panel(
         "\n".join(lines),
@@ -1976,10 +1976,10 @@ def edit(
 
         # Quick title update without editing content
         if title:
-            success = update_document(doc["id"], title, doc["content"])
+            success = update_document(doc.id, title, doc.content)
             if success:
                 console.print(
-                    f"[green]✅ Updated title of #{doc['id']} to:[/green] [cyan]{title}[/cyan]"
+                    f"[green]✅ Updated title of #{doc.id} to:[/green] [cyan]{title}[/cyan]"
                 )
                 # Flag wiki articles sourced from this doc as stale
                 try:
@@ -1987,7 +1987,7 @@ def edit(
                         check_doc_staleness,
                     )
 
-                    check_doc_staleness(doc["id"])
+                    check_doc_staleness(doc.id)
                 except Exception:
                     pass  # Wiki tables may not exist; non-critical
             else:
@@ -2002,9 +2002,9 @@ def edit(
         # Create temporary file with current content
         with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp_file:
             # Write header comment
-            tmp_file.write(f"# Editing: {doc['title']} (ID: {doc['id']})\n")
-            tmp_file.write(f"# Project: {doc['project'] or 'None'}\n")
-            tmp_file.write(f"# Created: {str(doc['created_at'] or '')[:16]}\n")
+            tmp_file.write(f"# Editing: {doc.title} (ID: {doc.id})\n")
+            tmp_file.write(f"# Project: {doc.project or 'None'}\n")
+            tmp_file.write(f"# Created: {str(doc.created_at or '')[:16]}\n")
             tmp_file.write("# Lines starting with '#' will be removed\n")
             tmp_file.write("#\n")
             tmp_file.write("# First line (after comments) will be used as the title\n")
@@ -2012,8 +2012,8 @@ def edit(
             tmp_file.write("#\n")
 
             # Write title and content
-            tmp_file.write(f"{doc['title']}\n\n")
-            tmp_file.write(doc["content"])
+            tmp_file.write(f"{doc.title}\n\n")
+            tmp_file.write(doc.content)
             tmp_file_path = tmp_file.name
 
         try:
@@ -2054,17 +2054,17 @@ def edit(
             new_content = "".join(lines[content_start:]).strip()
 
             # Check if anything changed
-            if new_title == doc["title"] and new_content == doc["content"].strip():
+            if new_title == doc.title and new_content == doc.content.strip():
                 console.print("[yellow]No changes made[/yellow]")
                 return
 
             # Update document
-            success = update_document(doc["id"], new_title, new_content)
+            success = update_document(doc.id, new_title, new_content)
 
             if success:
-                console.print(f"[green]✅ Updated #{doc['id']}:[/green] [cyan]{new_title}[/cyan]")
-                if new_title != doc["title"]:
-                    console.print(f"   [dim]Title changed from:[/dim] {doc['title']}")
+                console.print(f"[green]✅ Updated #{doc.id}:[/green] [cyan]{new_title}[/cyan]")
+                if new_title != doc.title:
+                    console.print(f"   [dim]Title changed from:[/dim] {doc.title}")
                 console.print("   [dim]Content updated[/dim]")
 
                 # Flag wiki articles sourced from this doc as stale
@@ -2073,7 +2073,7 @@ def edit(
                         check_doc_staleness,
                     )
 
-                    check_doc_staleness(doc["id"])
+                    check_doc_staleness(doc.id)
                 except Exception:
                     pass  # Wiki tables may not exist; non-critical
             else:
@@ -2137,10 +2137,10 @@ def delete(
 
         for doc in docs_to_delete:
             table.add_row(
-                str(doc["id"]),
-                doc["title"][:50] + "..." if len(doc["title"]) > 50 else doc["title"],
-                doc["project"] or "[dim]None[/dim]",
-                str(doc["created_at"] or "")[:10],
+                str(doc.id),
+                doc.title[:50] + "..." if len(doc.title) > 50 else doc.title,
+                doc.project or "[dim]None[/dim]",
+                str(doc.created_at or "")[:10],
                 "[red]PERMANENT[/red]" if hard else "[yellow]Soft delete[/yellow]",
             )
 
@@ -2174,7 +2174,7 @@ def delete(
         failed = []
 
         for doc in docs_to_delete:
-            success = delete_document(str(doc["id"]), hard_delete=hard)
+            success = delete_document(str(doc.id), hard_delete=hard)
             if success:
                 deleted_count += 1
             else:

--- a/emdx/commands/gist.py
+++ b/emdx/commands/gist.py
@@ -203,14 +203,14 @@ def create(
         raise typer.Exit(1)
 
     # Prepare gist content
-    filename = sanitize_filename(doc["title"])
-    content = doc["content"]
+    filename = sanitize_filename(doc.title)
+    content = doc.content
 
     # Use document title and metadata in description if not provided
     if not description:
-        description = f"{doc['title']} - emdx knowledge base"
-        if doc.get("project"):
-            description += f" (Project: {doc['project']})"
+        description = f"{doc.title} - emdx knowledge base"
+        if doc.project:
+            description += f" (Project: {doc.project})"
 
     # Create or update gist
     if update:
@@ -229,7 +229,7 @@ def create(
                     SET updated_at = CURRENT_TIMESTAMP
                     WHERE gist_id = ? AND document_id = ?
                 """,
-                    (update, doc["id"]),
+                    (update, doc.id),
                 )
                 conn.commit()
         else:
@@ -253,7 +253,7 @@ def create(
                     INSERT INTO gists (document_id, gist_id, gist_url, is_public)
                     VALUES (?, ?, ?, ?)
                 """,
-                    (doc["id"], gist_id, gist_url, public),
+                    (doc.id, gist_id, gist_url, public),
                 )
                 conn.commit()
 

--- a/emdx/commands/history.py
+++ b/emdx/commands/history.py
@@ -65,7 +65,7 @@ def history(
             json.dumps(
                 {
                     "doc_id": doc_id,
-                    "title": doc["title"],
+                    "title": doc.title,
                     "versions": versions,
                 },
                 indent=2,
@@ -73,7 +73,7 @@ def history(
         )
         return
 
-    table = Table(title=f"Version history for #{doc_id}: {doc['title']}")
+    table = Table(title=f"Version history for #{doc_id}: {doc.title}")
     table.add_column("Ver", justify="right", style="cyan")
     table.add_column("Date", style="dim")
     table.add_column("Delta", justify="right")
@@ -167,7 +167,7 @@ def diff(
 
     old_version: int = row[0]
     old_content: str = row[2]
-    current_content: str = doc["content"]
+    current_content: str = doc.content
 
     old_lines = old_content.splitlines(keepends=True)
     new_lines = current_content.splitlines(keepends=True)

--- a/emdx/commands/tags.py
+++ b/emdx/commands/tags.py
@@ -62,7 +62,7 @@ def _add_tags_impl(
             suggestions = tagger.suggest_tags(doc_id)
 
             if suggestions:
-                console.print(f"\n[bold]Tag suggestions for #{doc_id}: {doc['title']}[/bold]\n")
+                console.print(f"\n[bold]Tag suggestions for #{doc_id}: {doc.title}[/bold]\n")
 
                 table = Table(show_header=True, header_style="bold cyan")
                 table.add_column("Tag", style="cyan")
@@ -91,10 +91,10 @@ def _add_tags_impl(
         if not tags:
             current_tags = get_document_tags(doc_id)
             if current_tags:
-                console.print(f"\n[bold]Tags for #{doc_id}: {doc['title']}[/bold]")
+                console.print(f"\n[bold]Tags for #{doc_id}: {doc.title}[/bold]")
                 console.print(f"[cyan]{format_tags(current_tags)}[/cyan]")
             else:
-                console.print(f"[yellow]No tags for #{doc_id}: {doc['title']}[/yellow]")
+                console.print(f"[yellow]No tags for #{doc_id}: {doc.title}[/yellow]")
             return
 
         # Add tags manually
@@ -375,7 +375,7 @@ def batch(
                 doc = get_document(str(doc_id))
                 if not doc:
                     continue
-                title = truncate_title(doc["title"])
+                title = truncate_title(doc.title)
 
                 console.print(f"  [dim]#{doc_id}[/dim] {title}")
                 for tag_name, conf in tag_list:

--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -417,13 +417,13 @@ def view(
     if source_id:
         source_doc = get_document(source_id)
         if source_doc:
-            console.print(f"  [dim]Source:[/dim] #{source_id} [cyan]{source_doc['title']}[/cyan]")
+            console.print(f"  [dim]Source:[/dim] #{source_id} [cyan]{source_doc.title}[/cyan]")
         else:
             console.print(f"  [dim]Source:[/dim] #{source_id} [dim](deleted)[/dim]")
     if output_id:
         output_doc = get_document(output_id)
         if output_doc:
-            console.print(f"  [dim]Output:[/dim] #{output_id} [cyan]{output_doc['title']}[/cyan]")
+            console.print(f"  [dim]Output:[/dim] #{output_id} [cyan]{output_doc.title}[/cyan]")
         else:
             console.print(f"  [dim]Output:[/dim] #{output_id} [dim](deleted)[/dim]")
 
@@ -676,7 +676,7 @@ def _assemble_brief(
         related_docs.append(
             {
                 "id": source_id,
-                "title": source_doc["title"] if source_doc else "(deleted)",
+                "title": source_doc.title if source_doc else "(deleted)",
                 "relation": "source",
             }
         )
@@ -691,7 +691,7 @@ def _assemble_brief(
         related_docs.append(
             {
                 "id": output_id,
-                "title": output_doc["title"] if output_doc else "(deleted)",
+                "title": output_doc.title if output_doc else "(deleted)",
                 "relation": "output",
             }
         )

--- a/emdx/commands/trash.py
+++ b/emdx/commands/trash.py
@@ -69,11 +69,11 @@ def _list_trash(days: int | None = None, limit: int = 50) -> None:
 
         for doc in deleted_docs:
             table.add_row(
-                str(doc["id"]),
-                doc["title"][:50] + "..." if len(doc["title"]) > 50 else doc["title"],
-                doc["project"] or "[dim]None[/dim]",
-                doc["deleted_at"].strftime("%Y-%m-%d %H:%M") if doc["deleted_at"] else "Unknown",
-                str(doc["access_count"]),
+                str(doc.id),
+                doc.title[:50] + "..." if len(doc.title) > 50 else doc.title,
+                doc.project or "[dim]None[/dim]",
+                doc.deleted_at.strftime("%Y-%m-%d %H:%M") if doc.deleted_at else "Unknown",
+                str(doc.access_count),
             )
 
         console.print(table)
@@ -110,7 +110,7 @@ def restore(
 
             restored_count = 0
             for doc in deleted_docs:
-                if restore_document(str(doc["id"])):
+                if restore_document(str(doc.id)):
                     restored_count += 1
 
             console.print(f"\n[green]✅ Restored {restored_count} document(s)[/green]")
@@ -157,7 +157,7 @@ def purge(
 
             cutoff = datetime.now() - timedelta(days=older_than)
             docs_to_purge = [
-                d for d in deleted_docs if d["deleted_at"] is not None and d["deleted_at"] < cutoff
+                d for d in deleted_docs if d.deleted_at is not None and d.deleted_at < cutoff
             ]
             count = len(docs_to_purge)
         else:

--- a/emdx/commands/wiki.py
+++ b/emdx/commands/wiki.py
@@ -184,9 +184,9 @@ def wiki_view(
             json.dumps(
                 {
                     "topic_id": topic_id,
-                    "doc_id": doc["id"],
-                    "title": doc["title"],
-                    "content": doc["content"],
+                    "doc_id": doc.id,
+                    "title": doc.title,
+                    "content": doc.content,
                 },
                 indent=2,
             )
@@ -194,16 +194,15 @@ def wiki_view(
         return
 
     if raw:
-        print(doc["content"])
+        print(doc.content)
         return
 
     from rich.markdown import Markdown
 
     console.print(
-        f"\n[bold cyan]Wiki: {doc['title']}[/bold cyan]"
-        f" [dim](topic {topic_id}, doc #{doc['id']})[/dim]\n"
+        f"\n[bold cyan]Wiki: {doc.title}[/bold cyan] [dim](topic {topic_id}, doc #{doc.id})[/dim]\n"
     )
-    console.print(Markdown(doc["content"]))
+    console.print(Markdown(doc.content))
 
 
 @wiki_app.command(name="search")

--- a/emdx/database/__init__.py
+++ b/emdx/database/__init__.py
@@ -16,6 +16,8 @@ from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any, Union, cast
 
+from ..models.document import Document
+from ..models.search import SearchHit
 from .connection import DatabaseConnection, db_connection
 from .documents import (
     delete_document,
@@ -32,11 +34,6 @@ from .documents import (
 from .search import search_documents
 from .types import (
     DatabaseStats,
-    DeletedDocumentItem,
-    DocumentListItem,
-    DocumentRow,
-    RecentDocumentItem,
-    SearchResult,
 )
 
 
@@ -136,7 +133,7 @@ class SQLiteDatabase:
 
             return doc_id
 
-    def get_document(self, identifier: Union[str, int]) -> DocumentRow | None:
+    def get_document(self, identifier: Union[str, int]) -> Document | None:
         """Get a document by ID or title."""
         if not self._uses_custom_path:
             return get_document(identifier)
@@ -167,9 +164,9 @@ class SQLiteDatabase:
                 )
             conn.commit()
             row = cursor.fetchone()
-            return cast(DocumentRow, dict(row)) if row else None
+            return Document.from_row(row) if row else None
 
-    def list_documents(self, project: str | None = None, limit: int = 50) -> list[DocumentListItem]:
+    def list_documents(self, project: str | None = None, limit: int = 50) -> list[Document]:
         """List documents with optional filters."""
         if not self._uses_custom_path:
             return list_documents(project, limit)
@@ -189,7 +186,7 @@ class SQLiteDatabase:
                 f"FROM documents WHERE {where_clause} ORDER BY id DESC LIMIT ?",
                 params,
             )
-            return [cast(DocumentListItem, dict(row)) for row in cursor.fetchall()]
+            return [Document.from_partial_row(row) for row in cursor.fetchall()]
 
     def update_document(self, doc_id: int, title: str, content: str) -> bool:
         """Update a document."""
@@ -240,7 +237,7 @@ class SQLiteDatabase:
             conn.commit()
             return bool(cursor.rowcount > 0)
 
-    def get_recent_documents(self, limit: int = 10) -> list[RecentDocumentItem]:
+    def get_recent_documents(self, limit: int = 10) -> list[Document]:
         """Get recently accessed documents."""
         if not self._uses_custom_path:
             return get_recent_documents(limit)
@@ -252,7 +249,7 @@ class SQLiteDatabase:
                 "FROM documents WHERE is_deleted = FALSE ORDER BY accessed_at DESC LIMIT ?",
                 (limit,),
             )
-            return [cast(RecentDocumentItem, dict(row)) for row in cursor.fetchall()]
+            return [Document.from_partial_row(row) for row in cursor.fetchall()]
 
     def get_stats(self, project: str | None = None) -> DatabaseStats:
         """Get database statistics."""
@@ -280,7 +277,7 @@ class SQLiteDatabase:
         self,
         days: int | None = None,
         limit: int = 50,
-    ) -> list[DeletedDocumentItem]:
+    ) -> list[Document]:
         """List soft-deleted documents."""
         if not self._uses_custom_path:
             return list_deleted_documents(days, limit)
@@ -300,7 +297,7 @@ class SQLiteDatabase:
                     "WHERE is_deleted = TRUE ORDER BY deleted_at DESC LIMIT ?",
                     (limit,),
                 )
-            return [cast(DeletedDocumentItem, dict(row)) for row in cursor.fetchall()]
+            return [Document.from_partial_row(row) for row in cursor.fetchall()]
 
     def restore_document(self, identifier: Union[str, int]) -> bool:
         """Restore a soft-deleted document."""
@@ -353,7 +350,7 @@ class SQLiteDatabase:
         created_before: str | None = None,
         modified_after: str | None = None,
         modified_before: str | None = None,
-    ) -> list[SearchResult]:
+    ) -> list[SearchHit]:
         """Search documents using FTS."""
         if not self._uses_custom_path:
             return search_documents(
@@ -384,7 +381,7 @@ class SQLiteDatabase:
                     f"FROM documents d WHERE {where_clause} ORDER BY d.id DESC LIMIT ?",
                     params,
                 )
-                return [cast(SearchResult, dict(row)) for row in cursor.fetchall()]
+                return [SearchHit.from_row(row) for row in cursor.fetchall()]
 
             conditions = ["d.is_deleted = FALSE"]
             params = []
@@ -405,7 +402,7 @@ class SQLiteDatabase:
                 f"WHERE fts.documents_fts MATCH ? AND {where_clause} ORDER BY rank LIMIT ?",
                 [safe_query] + params + [limit],
             )
-            return [cast(SearchResult, dict(row)) for row in cursor.fetchall()]
+            return [SearchHit.from_row(row) for row in cursor.fetchall()]
 
 
 # Create global instance for backward compatibility

--- a/emdx/database/documents.py
+++ b/emdx/database/documents.py
@@ -5,40 +5,16 @@ Document CRUD operations for emdx knowledge base
 from __future__ import annotations
 
 import logging
-from typing import Any, Union, cast
+from typing import Union, cast
 
-from ..utils.datetime_utils import parse_datetime
+from ..models.document import Document
 from .connection import db_connection
 from .types import (
-    ChildDocumentItem,
     DatabaseStats,
-    DeletedDocumentItem,
-    DocumentListItem,
-    DocumentRow,
     MostViewedDoc,
-    RecentDocumentItem,
-    SupersedeCandidate,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _parse_doc_datetimes(
-    doc: dict[str, Any],
-    fields: list[str] | None = None,
-) -> dict[str, Any]:
-    """Parse datetime string fields in a document dictionary, in place.
-
-    Returns the same dict for call-chaining convenience.  Callers should
-    ``cast()`` to the concrete TypedDict *before* calling this so that
-    their local variable already carries the right type.
-    """
-    if fields is None:
-        fields = ["created_at", "updated_at", "accessed_at", "deleted_at"]
-    for field in fields:
-        if field in doc and isinstance(doc[field], str):
-            doc[field] = parse_datetime(doc[field])
-    return doc
 
 
 def save_document(
@@ -92,7 +68,7 @@ def save_document(
     return doc_id
 
 
-def get_document(identifier: Union[str, int]) -> DocumentRow | None:
+def get_document(identifier: Union[str, int]) -> Document | None:
     """Get a document by ID or title"""
     with db_connection.get_connection() as conn:
         # Convert to string for consistent handling
@@ -138,9 +114,7 @@ def get_document(identifier: Union[str, int]) -> DocumentRow | None:
         row = cursor.fetchone()
 
         if row:
-            raw = dict(row)
-            _parse_doc_datetimes(raw)
-            return cast(DocumentRow, raw)
+            return Document.from_row(row)
         return None
 
 
@@ -150,7 +124,7 @@ def list_documents(
     parent_id: int | None = None,
     offset: int = 0,
     doc_type: str | None = "user",
-) -> list[DocumentListItem]:
+) -> list[Document]:
     """List documents with optional project and hierarchy filters.
 
     Args:
@@ -164,7 +138,7 @@ def list_documents(
         doc_type: Filter by document type. 'user' (default), 'wiki', or None for all types.
 
     Returns:
-        List of document dictionaries
+        List of Document objects
 
     Raises:
         ValueError: If limit or offset is negative
@@ -212,13 +186,7 @@ def list_documents(
             params,
         )
 
-        # Convert rows and parse datetime strings
-        docs: list[DocumentListItem] = []
-        for row in cursor.fetchall():
-            raw = dict(row)
-            _parse_doc_datetimes(raw, ["created_at", "accessed_at", "archived_at"])
-            docs.append(cast(DocumentListItem, raw))
-        return docs
+        return [Document.from_partial_row(row) for row in cursor.fetchall()]
 
 
 def count_documents(
@@ -437,7 +405,7 @@ def delete_document(identifier: Union[str, int], hard_delete: bool = False) -> b
 def get_recent_documents(
     limit: int = 10,
     doc_type: str | None = "user",
-) -> list[RecentDocumentItem]:
+) -> list[Document]:
     """Get recently accessed documents.
 
     Args:
@@ -466,13 +434,7 @@ def get_recent_documents(
             params,
         )
 
-        # Convert rows and parse datetime strings
-        docs: list[RecentDocumentItem] = []
-        for row in cursor.fetchall():
-            raw = dict(row)
-            _parse_doc_datetimes(raw)
-            docs.append(cast(RecentDocumentItem, raw))
-        return docs
+        return [Document.from_partial_row(row) for row in cursor.fetchall()]
 
 
 def get_stats(project: str | None = None) -> DatabaseStats:
@@ -545,7 +507,7 @@ def get_stats(project: str | None = None) -> DatabaseStats:
         return stats
 
 
-def list_deleted_documents(days: int | None = None, limit: int = 50) -> list[DeletedDocumentItem]:
+def list_deleted_documents(days: int | None = None, limit: int = 50) -> list[Document]:
     """List soft-deleted documents"""
     with db_connection.get_connection() as conn:
         if days:
@@ -572,13 +534,7 @@ def list_deleted_documents(days: int | None = None, limit: int = 50) -> list[Del
                 (limit,),
             )
 
-        # Convert rows and parse datetime strings
-        docs: list[DeletedDocumentItem] = []
-        for row in cursor.fetchall():
-            raw = dict(row)
-            _parse_doc_datetimes(raw)
-            docs.append(cast(DeletedDocumentItem, raw))
-        return docs
+        return [Document.from_partial_row(row) for row in cursor.fetchall()]
 
 
 def restore_document(identifier: Union[str, int]) -> bool:
@@ -661,7 +617,7 @@ def find_supersede_candidate(
     title_threshold: float = 0.85,
     content: str | None = None,
     content_threshold: float = 0.5,
-) -> SupersedeCandidate | None:
+) -> Document | None:
     """Find a document that should be superseded by a new document with the given title.
 
     Uses title normalization and optional content similarity to find the best candidate.
@@ -710,10 +666,10 @@ def find_supersede_candidate(
                 """,
             )
 
-        candidates = []
+        candidates: list[tuple[Document, float, str]] = []
         for row in cursor.fetchall():
-            doc = dict(row)
-            normalized_existing = normalize_title(doc["title"])
+            doc = Document.from_partial_row(row)
+            normalized_existing = normalize_title(doc.title)
 
             # Exact normalized match - always a candidate
             if normalized_existing == normalized_new:
@@ -721,7 +677,7 @@ def find_supersede_candidate(
                 continue
 
             # Fuzzy title match - needs content check
-            sim = title_similarity(title, doc["title"])
+            sim = title_similarity(title, doc.title)
             if sim >= title_threshold:
                 candidates.append((doc, sim, "fuzzy"))
 
@@ -731,19 +687,16 @@ def find_supersede_candidate(
         # For exact matches, return the most recent one
         exact_matches = [c for c in candidates if c[2] == "exact"]
         if exact_matches:
-            raw = exact_matches[0][0]
-            _parse_doc_datetimes(raw)
-            return cast(SupersedeCandidate, raw)
+            return exact_matches[0][0]
 
         # For fuzzy matches, we need content similarity check
         if content and candidates:
             from ..services.similarity import compute_content_similarity
 
             for doc, _title_sim, _match_type in candidates:
-                content_sim = compute_content_similarity(content, doc["content"])
+                content_sim = compute_content_similarity(content, doc.content)
                 if content_sim >= content_threshold:
-                    _parse_doc_datetimes(doc)
-                    return cast(SupersedeCandidate, doc)
+                    return doc
 
         return None
 
@@ -772,7 +725,7 @@ def set_parent(doc_id: int, parent_id: int, relationship: str = "supersedes") ->
         return cursor.rowcount > 0
 
 
-def get_children(doc_id: int) -> list[ChildDocumentItem]:
+def get_children(doc_id: int) -> list[Document]:
     """Get all child documents of a parent.
 
     Args:
@@ -792,18 +745,13 @@ def get_children(doc_id: int) -> list[ChildDocumentItem]:
             (doc_id,),
         )
 
-        docs: list[ChildDocumentItem] = []
-        for row in cursor.fetchall():
-            raw = dict(row)
-            _parse_doc_datetimes(raw)
-            docs.append(cast(ChildDocumentItem, raw))
-        return docs
+        return [Document.from_partial_row(row) for row in cursor.fetchall()]
 
 
 def list_recent_documents(
     limit: int = 100,
     days: int = 7,
-) -> list[DocumentRow]:
+) -> list[Document]:
     """Get recent direct-save documents.
 
     Args:
@@ -811,7 +759,7 @@ def list_recent_documents(
         days: Only include documents from the last N days
 
     Returns:
-        List of document dicts
+        List of Document objects
     """
     from datetime import datetime, timedelta
 
@@ -828,15 +776,10 @@ def list_recent_documents(
         """
 
         cursor = conn.execute(query, (cutoff.isoformat(), limit))
-        docs: list[DocumentRow] = []
-        for row in cursor.fetchall():
-            raw = dict(row)
-            _parse_doc_datetimes(raw)
-            docs.append(cast(DocumentRow, raw))
-        return docs
+        return [Document.from_row(row) for row in cursor.fetchall()]
 
 
-def get_docs_in_window(hours: int, limit: int = 100) -> list[DocumentListItem]:
+def get_docs_in_window(hours: int, limit: int = 100) -> list[Document]:
     """Get documents created within a time window.
 
     Args:
@@ -859,9 +802,4 @@ def get_docs_in_window(hours: int, limit: int = 100) -> list[DocumentListItem]:
             """,
             (f"-{hours}", limit),
         )
-        docs: list[DocumentListItem] = []
-        for row in cursor.fetchall():
-            raw = dict(row)
-            _parse_doc_datetimes(raw, ["created_at", "accessed_at", "archived_at"])
-            docs.append(cast(DocumentListItem, raw))
-        return docs
+        return [Document.from_partial_row(row) for row in cursor.fetchall()]

--- a/emdx/database/search.py
+++ b/emdx/database/search.py
@@ -2,11 +2,10 @@
 Search functionality for emdx documents using FTS5
 """
 
-from typing import Any, cast
+from __future__ import annotations
 
-from ..utils.datetime_utils import parse_datetime
+from ..models.search import SearchHit
 from .connection import db_connection
-from .types import SearchResult
 
 
 def escape_fts5_query(query: str) -> str:
@@ -48,7 +47,7 @@ def search_documents(
     modified_after: str | None = None,
     modified_before: str | None = None,
     doc_type: str | None = "user",
-) -> list[SearchResult]:
+) -> list[SearchHit]:
     """Search documents using FTS5
 
     Args:
@@ -59,7 +58,7 @@ def search_documents(
         doc_type: Filter by document type. 'user' (default), 'wiki', or None for all types.
 
     Returns:
-        List of document dictionaries with search results including snippets and ranking
+        List of SearchHit objects with document data, snippets, and ranking
     """
     with db_connection.get_connection() as conn:
         # Build dynamic query with date filters
@@ -130,12 +129,4 @@ def search_documents(
 
         cursor = conn.execute(base_query, params)
 
-        # Convert rows and parse datetime strings
-        docs: list[SearchResult] = []
-        for row in cursor.fetchall():
-            raw: dict[str, Any] = dict(row)
-            for field in ["created_at", "updated_at", "last_accessed"]:
-                if field in raw and isinstance(raw[field], str):
-                    raw[field] = parse_datetime(raw[field])
-            docs.append(cast(SearchResult, raw))
-        return docs
+        return [SearchHit.from_row(row) for row in cursor.fetchall()]

--- a/emdx/models/document.py
+++ b/emdx/models/document.py
@@ -1,0 +1,160 @@
+"""Document domain model for emdx.
+
+Single source of truth for the Document type. Replaces the scattered
+TypedDict projections (DocumentRow, DocumentListItem, RecentDocumentItem,
+etc.) with a proper dataclass that supports:
+
+- Factory construction from sqlite3.Row with datetime parsing
+- Backward-compatible bracket access (doc["title"]) for incremental migration
+- Serialization to dict for JSON output
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from dataclasses import asdict, dataclass, fields
+from datetime import datetime
+from typing import Any
+
+from ..utils.datetime_utils import parse_datetime
+
+# Fields that store datetime values and should be parsed from SQLite strings.
+_DATETIME_FIELDS: frozenset[str] = frozenset(
+    {"created_at", "updated_at", "accessed_at", "deleted_at", "archived_at"}
+)
+
+
+@dataclass(slots=True)
+class Document:
+    """Core document domain object.
+
+    Constructed via ``Document.from_row()`` at the database boundary.
+    Supports ``doc["field"]`` and ``doc.get("field")`` for backward
+    compatibility with code that previously used TypedDict dicts.
+    """
+
+    id: int
+    title: str
+    content: str = ""
+    project: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    accessed_at: datetime | None = None
+    access_count: int = 0
+    deleted_at: datetime | None = None
+    is_deleted: bool = False
+    parent_id: int | None = None
+    relationship: str | None = None
+    archived_at: datetime | None = None
+    stage: str | None = None
+    doc_type: str = "user"
+
+    # ── Dict-compatibility layer ──────────────────────────────────────
+
+    def __getitem__(self, key: str) -> Any:
+        """Allow ``doc["title"]`` access for backward compatibility."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key) from None
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Allow ``doc.get("title", "Untitled")`` for backward compatibility."""
+        return getattr(self, key, default)
+
+    def __contains__(self, key: object) -> bool:
+        """Allow ``"title" in doc`` checks."""
+        if not isinstance(key, str):
+            return False
+        return key in self._field_names()
+
+    def keys(self) -> list[str]:
+        """Return field names, for code that iterates dict keys."""
+        return list(self._field_names())
+
+    def items(self) -> Iterator[tuple[str, Any]]:
+        """Yield (field_name, value) pairs, for dict-like iteration."""
+        for name in self._field_names():
+            yield name, getattr(self, name)
+
+    def values(self) -> Iterator[Any]:
+        """Yield field values, for dict-like iteration."""
+        for name in self._field_names():
+            yield getattr(self, name)
+
+    @classmethod
+    def _field_names(cls) -> frozenset[str]:
+        """Cached set of field names for this dataclass."""
+        # Use the class-level cache if available.
+        cache_attr = "_cached_field_names"
+        cached: frozenset[str] | None = cls.__dict__.get(cache_attr)
+        if cached is not None:
+            return cached
+        names = frozenset(f.name for f in fields(cls))
+        # slots=True means we can't set arbitrary class attrs, so we
+        # store on the class __dict__ via type.__setattr__.
+        type.__setattr__(cls, cache_attr, names)
+        return names
+
+    # ── Factory methods ───────────────────────────────────────────────
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row | dict[str, Any]) -> Document:
+        """Construct a Document from a full database row.
+
+        Parses datetime string fields into ``datetime`` objects using
+        the centralized ``parse_datetime`` utility. Unknown columns in
+        the row are silently ignored (safe for SELECT * with extra cols).
+
+        The ``is_deleted`` field is normalized to ``bool`` (SQLite stores
+        it as 0/1 integer).
+        """
+        if isinstance(row, sqlite3.Row):
+            raw = dict(row)
+        else:
+            raw = dict(row)  # defensive copy
+
+        return cls._from_dict(raw)
+
+    @classmethod
+    def from_partial_row(cls, row: sqlite3.Row | dict[str, Any]) -> Document:
+        """Construct a Document from a partial SELECT.
+
+        Missing fields get their dataclass defaults (empty string for
+        content, None for optional fields, 0 for counts, etc.).
+        Functionally identical to ``from_row`` — both tolerate missing
+        columns — but the separate name signals intent to callers.
+        """
+        return cls.from_row(row)
+
+    @classmethod
+    def _from_dict(cls, raw: dict[str, Any]) -> Document:
+        """Internal: build a Document from a raw dict, parsing datetimes."""
+        known = cls._field_names()
+        kwargs: dict[str, Any] = {}
+        for key, value in raw.items():
+            if key not in known:
+                continue
+            if key in _DATETIME_FIELDS and isinstance(value, str):
+                kwargs[key] = parse_datetime(value)
+            elif key == "is_deleted":
+                # SQLite stores boolean as 0/1 int
+                kwargs[key] = bool(value)
+            else:
+                kwargs[key] = value
+        return cls(**kwargs)
+
+    # ── Serialization ─────────────────────────────────────────────────
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a plain dict for JSON serialization.
+
+        Datetime fields are formatted as ISO 8601 strings.
+        """
+        result = asdict(self)
+        for key in _DATETIME_FIELDS:
+            val = result.get(key)
+            if isinstance(val, datetime):
+                result[key] = val.isoformat()
+        return result

--- a/emdx/models/search.py
+++ b/emdx/models/search.py
@@ -1,0 +1,92 @@
+"""Search result domain model for emdx.
+
+Wraps a Document with search-specific metadata (snippet, rank).
+Supports the same dict-compat interface as Document.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+from .document import Document
+
+
+@dataclass(slots=True)
+class SearchHit:
+    """A search result: a Document plus search metadata.
+
+    Supports ``hit["title"]`` bracket access for backward compatibility
+    with code that consumed SearchResult TypedDicts.
+    """
+
+    doc: Document
+    snippet: str | None = None
+    rank: float = 0.0
+
+    # ── Dict-compatibility layer ──────────────────────────────────────
+
+    def __getitem__(self, key: str) -> Any:
+        """Access document fields or search metadata via bracket notation."""
+        if key == "snippet":
+            return self.snippet
+        if key == "rank":
+            return self.rank
+        return self.doc[key]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Dict-compat .get() that checks search fields then document fields."""
+        if key == "snippet":
+            return self.snippet
+        if key == "rank":
+            return self.rank
+        return self.doc.get(key, default)
+
+    def __contains__(self, key: object) -> bool:
+        if key in ("snippet", "rank"):
+            return True
+        return key in self.doc
+
+    def keys(self) -> list[str]:
+        return self.doc.keys() + ["snippet", "rank"]
+
+    def items(self) -> Iterator[tuple[str, Any]]:
+        yield from self.doc.items()
+        yield "snippet", self.snippet
+        yield "rank", self.rank
+
+    def values(self) -> Iterator[Any]:
+        yield from self.doc.values()
+        yield self.snippet
+        yield self.rank
+
+    # ── Factory ───────────────────────────────────────────────────────
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row | dict[str, Any]) -> SearchHit:
+        """Construct from a search query row.
+
+        Expects document fields plus ``snippet`` and ``rank`` columns.
+        """
+        if isinstance(row, sqlite3.Row):
+            raw = dict(row)
+        else:
+            raw = dict(row)
+
+        snippet = raw.pop("snippet", None)
+        rank_val = raw.pop("rank", 0.0)
+        rank = float(rank_val) if rank_val is not None else 0.0
+
+        doc = Document.from_row(raw)
+        return cls(doc=doc, snippet=snippet, rank=rank)
+
+    # ── Serialization ─────────────────────────────────────────────────
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to plain dict for JSON serialization."""
+        result = self.doc.to_dict()
+        result["snippet"] = self.snippet
+        result["rank"] = self.rank
+        return result

--- a/emdx/ui/activity/activity_data.py
+++ b/emdx/ui/activity/activity_data.py
@@ -67,7 +67,7 @@ class ActivityDataLoader:
             from emdx.models.tags import get_document_tags
 
             for doc in docs:
-                doc_id = doc["id"]
+                doc_id = doc.id
                 doc_tags[doc_id] = get_document_tags(doc_id)
         except ImportError:
             pass
@@ -76,7 +76,7 @@ class ActivityDataLoader:
 
         for doc in docs:
             try:
-                doc_id = doc["id"]
+                doc_id = doc.id
                 created = doc.get("created_at")
                 title = doc.get("title", "")
                 doc_type = doc.get("doc_type", "user") or "user"

--- a/tests/test_activity_doc_type.py
+++ b/tests/test_activity_doc_type.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from datetime import datetime
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 from textual.app import App, ComposeResult
 
+from emdx.models.document import Document
 from emdx.ui.activity.activity_data import ActivityDataLoader
 from emdx.ui.activity.activity_items import DocumentItem
 from emdx.ui.activity.activity_table import ActivityTable
@@ -25,25 +25,27 @@ def make_doc_row(
     title: str = "Test doc",
     doc_type: str = "user",
     created_at: str = "2025-01-20T12:00:00",
-) -> dict[str, Any]:
-    """Create a fake document row matching DocumentRow shape."""
-    return {
-        "id": id,
-        "title": title,
-        "content": "some content",
-        "project": None,
-        "created_at": created_at,
-        "updated_at": None,
-        "accessed_at": None,
-        "access_count": 1,
-        "deleted_at": None,
-        "is_deleted": 0,
-        "parent_id": None,
-        "relationship": None,
-        "archived_at": None,
-        "stage": None,
-        "doc_type": doc_type,
-    }
+) -> Document:
+    """Create a fake Document matching the Document dataclass shape."""
+    return Document.from_row(
+        {
+            "id": id,
+            "title": title,
+            "content": "some content",
+            "project": None,
+            "created_at": created_at,
+            "updated_at": None,
+            "accessed_at": None,
+            "access_count": 1,
+            "deleted_at": None,
+            "is_deleted": 0,
+            "parent_id": None,
+            "relationship": None,
+            "archived_at": None,
+            "stage": None,
+            "doc_type": doc_type,
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -150,7 +152,7 @@ class TestDataLoaderDocTypeFilter:
     async def test_doc_type_defaults_to_user(self) -> None:
         """Documents without doc_type field default to 'user'."""
         docs = [make_doc_row(id=1, title="Old doc")]
-        docs[0]["doc_type"] = None  # Simulate missing doc_type
+        docs[0].doc_type = None  # Simulate missing doc_type  # type: ignore[assignment]
         with (
             patch(f"{_DATA_LOADER_BASE}.doc_svc") as mock_svc,
             patch(f"{_DATA_LOADER_BASE}.HAS_DOCS", True),

--- a/tests/test_activity_view.py
+++ b/tests/test_activity_view.py
@@ -10,6 +10,7 @@ import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import RichLog, Static
 
+from emdx.models.document import Document
 from emdx.ui.activity.activity_items import DocumentItem
 from emdx.ui.activity.activity_view import ActivityView
 
@@ -143,14 +144,16 @@ class TestStreamingRemoval:
         """Document preview rendering still works after streaming removal."""
         doc_item = make_doc_item(item_id=100, title="My Document")
         mock_activity_deps["loader"].load_all.return_value = [doc_item]
-        mock_activity_deps["doc_db"].get_document.return_value = {
-            "id": 100,
-            "title": "My Document",
-            "content": "# My Document\n\nHello world",
-            "project": "test",
-            "created_at": "2025-01-01T12:00:00",
-            "access_count": 5,
-        }
+        mock_activity_deps["doc_db"].get_document.return_value = Document.from_row(
+            {
+                "id": 100,
+                "title": "My Document",
+                "content": "# My Document\n\nHello world",
+                "project": "test",
+                "created_at": "2025-01-01T12:00:00",
+                "access_count": 5,
+            }
+        )
 
         app = ActivityTestApp()
         async with app.run_test() as pilot:
@@ -164,14 +167,16 @@ class TestStreamingRemoval:
         """Copy mode toggle still works after streaming removal."""
         doc_item = make_doc_item(item_id=100, title="My Document")
         mock_activity_deps["loader"].load_all.return_value = [doc_item]
-        mock_activity_deps["doc_db"].get_document.return_value = {
-            "id": 100,
-            "title": "My Document",
-            "content": "# My Document\n\nHello world",
-            "project": "test",
-            "created_at": "2025-01-01T12:00:00",
-            "access_count": 1,
-        }
+        mock_activity_deps["doc_db"].get_document.return_value = Document.from_row(
+            {
+                "id": 100,
+                "title": "My Document",
+                "content": "# My Document\n\nHello world",
+                "project": "test",
+                "created_at": "2025-01-01T12:00:00",
+                "access_count": 1,
+            }
+        )
 
         app = ActivityTestApp()
         async with app.run_test() as pilot:

--- a/tests/test_commands_core.py
+++ b/tests/test_commands_core.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from emdx.commands.core import InputContent, app, generate_title, get_input_content
+from emdx.models.document import Document
 
 runner = CliRunner()
 
@@ -291,14 +292,16 @@ class TestViewCommand:
     @patch("emdx.commands.core.get_document")
     def test_view_by_id(self, mock_get_doc, mock_get_tags):
         """View a document by numeric ID."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "My Doc",
-            "content": "Hello world",
-            "project": "test",
-            "created_at": datetime(2024, 1, 1),
-            "access_count": 5,
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "My Doc",
+                "content": "Hello world",
+                "project": "test",
+                "created_at": datetime(2024, 1, 1),
+                "access_count": 5,
+            }
+        )
         mock_get_tags.return_value = ["python"]
 
         result = runner.invoke(app, ["view", "1", "--no-pager"])
@@ -318,14 +321,16 @@ class TestViewCommand:
     @patch("emdx.commands.core.get_document")
     def test_view_raw(self, mock_get_doc, mock_get_tags):
         """View with --raw shows raw content."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "Raw Doc",
-            "content": "# Raw markdown",
-            "project": None,
-            "created_at": datetime(2024, 1, 1),
-            "access_count": 0,
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "Raw Doc",
+                "content": "# Raw markdown",
+                "project": None,
+                "created_at": datetime(2024, 1, 1),
+                "access_count": 0,
+            }
+        )
         mock_get_tags.return_value = []
 
         result = runner.invoke(app, ["view", "1", "--raw", "--no-pager"])
@@ -336,14 +341,16 @@ class TestViewCommand:
     @patch("emdx.commands.core.get_document")
     def test_view_no_header(self, mock_get_doc, mock_get_tags):
         """View with --no-header hides header."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "No Header",
-            "content": "Just content",
-            "project": None,
-            "created_at": datetime(2024, 1, 1),
-            "access_count": 0,
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "No Header",
+                "content": "Just content",
+                "project": None,
+                "created_at": datetime(2024, 1, 1),
+                "access_count": 0,
+            }
+        )
         mock_get_tags.return_value = []
 
         result = runner.invoke(app, ["view", "1", "--no-header", "--no-pager"])
@@ -356,16 +363,18 @@ class TestViewCommand:
     @patch("emdx.commands.core.get_document")
     def test_view_json(self, mock_get_doc, mock_get_tags):
         """View with --json outputs valid JSON."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "JSON Doc",
-            "content": "Hello world",
-            "project": "test",
-            "created_at": datetime(2024, 1, 1),
-            "updated_at": datetime(2024, 1, 2),
-            "accessed_at": datetime(2024, 1, 3),
-            "access_count": 5,
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "JSON Doc",
+                "content": "Hello world",
+                "project": "test",
+                "created_at": datetime(2024, 1, 1),
+                "updated_at": datetime(2024, 1, 2),
+                "accessed_at": datetime(2024, 1, 3),
+                "access_count": 5,
+            }
+        )
         mock_get_tags.return_value = ["python"]
 
         result = runner.invoke(app, ["view", "1", "--json"])
@@ -394,13 +403,15 @@ class TestEditCommand:
     @patch("emdx.commands.core.get_document")
     def test_edit_title_only(self, mock_get_doc, mock_update):
         """Edit with --title updates title without opening editor."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "Old Title",
-            "content": "content",
-            "project": "p",
-            "created_at": datetime(2024, 1, 1),
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "Old Title",
+                "content": "content",
+                "project": "p",
+                "created_at": datetime(2024, 1, 1),
+            }
+        )
         mock_update.return_value = True
 
         result = runner.invoke(app, ["edit", "1", "--title", "New Title"])
@@ -421,13 +432,15 @@ class TestEditCommand:
     @patch("emdx.commands.core.get_document")
     def test_edit_title_failure(self, mock_get_doc, mock_update):
         """Edit that fails to update shows error."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "Title",
-            "content": "c",
-            "project": None,
-            "created_at": datetime(2024, 1, 1),
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "Title",
+                "content": "c",
+                "project": None,
+                "created_at": datetime(2024, 1, 1),
+            }
+        )
         mock_update.return_value = False
 
         result = runner.invoke(app, ["edit", "1", "--title", "New"])
@@ -450,13 +463,15 @@ class TestDeleteCommand:
     @patch("emdx.commands.core.get_document")
     def test_delete_soft(self, mock_get_doc, mock_delete):
         """Soft delete with --force skips confirmation."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "To Delete",
-            "project": "p",
-            "created_at": datetime(2024, 1, 1),
-            "access_count": 0,
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "To Delete",
+                "project": "p",
+                "created_at": datetime(2024, 1, 1),
+                "access_count": 0,
+            }
+        )
         mock_delete.return_value = True
 
         result = runner.invoke(app, ["delete", "1", "--force"])
@@ -469,13 +484,15 @@ class TestDeleteCommand:
     @patch("emdx.commands.core.get_document")
     def test_delete_hard_force(self, mock_get_doc, mock_delete):
         """Hard delete with --force --hard."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "Perm Delete",
-            "project": None,
-            "created_at": datetime(2024, 1, 1),
-            "access_count": 0,
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "Perm Delete",
+                "project": None,
+                "created_at": datetime(2024, 1, 1),
+                "access_count": 0,
+            }
+        )
         mock_delete.return_value = True
 
         result = runner.invoke(app, ["delete", "1", "--force", "--hard"])
@@ -496,13 +513,15 @@ class TestDeleteCommand:
     @patch("emdx.commands.core.get_document")
     def test_delete_dry_run(self, mock_get_doc):
         """--dry-run shows what would be deleted without deleting."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "Dry Run Doc",
-            "project": "p",
-            "created_at": datetime(2024, 1, 1),
-            "access_count": 0,
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "Dry Run Doc",
+                "project": "p",
+                "created_at": datetime(2024, 1, 1),
+                "access_count": 0,
+            }
+        )
 
         result = runner.invoke(app, ["delete", "1", "--dry-run"])
         assert result.exit_code == 0
@@ -515,20 +534,24 @@ class TestDeleteCommand:
 
         def side_effect(identifier):
             docs = {
-                "1": {
-                    "id": 1,
-                    "title": "Doc 1",
-                    "project": None,
-                    "created_at": datetime(2024, 1, 1),
-                    "access_count": 0,
-                },  # noqa: E501
-                "2": {
-                    "id": 2,
-                    "title": "Doc 2",
-                    "project": None,
-                    "created_at": datetime(2024, 1, 2),
-                    "access_count": 0,
-                },  # noqa: E501
+                "1": Document.from_row(
+                    {
+                        "id": 1,
+                        "title": "Doc 1",
+                        "project": None,
+                        "created_at": datetime(2024, 1, 1),
+                        "access_count": 0,
+                    }
+                ),
+                "2": Document.from_row(
+                    {
+                        "id": 2,
+                        "title": "Doc 2",
+                        "project": None,
+                        "created_at": datetime(2024, 1, 2),
+                        "access_count": 0,
+                    }
+                ),
             }
             return docs.get(identifier)
 
@@ -549,13 +572,15 @@ class TestDeleteCommand:
     @patch("emdx.commands.core.is_non_interactive", return_value=True)
     def test_delete_auto_confirms_when_non_tty(self, mock_isatty, mock_get_doc, mock_delete):
         """Delete skips confirmation when stdin is not a TTY (agent mode)."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "Agent Delete",
-            "project": "p",
-            "created_at": datetime(2024, 1, 1),
-            "access_count": 0,
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "Agent Delete",
+                "project": "p",
+                "created_at": datetime(2024, 1, 1),
+                "access_count": 0,
+            }
+        )
         mock_delete.return_value = True
 
         # No --force flag, but should still proceed without prompting
@@ -570,13 +595,15 @@ class TestDeleteCommand:
     @patch("emdx.commands.core.is_non_interactive", return_value=True)
     def test_delete_hard_auto_confirms_when_non_tty(self, mock_isatty, mock_get_doc, mock_delete):
         """Hard delete skips confirmation when stdin is not a TTY (agent mode)."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "Agent Hard Delete",
-            "project": None,
-            "created_at": datetime(2024, 1, 1),
-            "access_count": 0,
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "Agent Hard Delete",
+                "project": None,
+                "created_at": datetime(2024, 1, 1),
+                "access_count": 0,
+            }
+        )
         mock_delete.return_value = True
 
         # No --force flag, --hard, should still proceed without prompting
@@ -610,13 +637,15 @@ class TestTrashCommand:
     def test_trash_with_items(self, mock_list_deleted):
         """Trash with items shows table."""
         mock_list_deleted.return_value = [
-            {
-                "id": 1,
-                "title": "Deleted Doc",
-                "project": "proj",
-                "deleted_at": datetime(2024, 6, 1, 10, 0),
-                "access_count": 3,
-            }
+            Document.from_row(
+                {
+                    "id": 1,
+                    "title": "Deleted Doc",
+                    "project": "proj",
+                    "deleted_at": datetime(2024, 6, 1, 10, 0),
+                    "access_count": 3,
+                }
+            )
         ]
 
         result = runner.invoke(main_app, ["trash"])
@@ -668,8 +697,8 @@ class TestRestoreCommand:
     def test_restore_all(self, mock_restore, mock_list_deleted):
         """Restore --all restores all deleted documents."""
         mock_list_deleted.return_value = [
-            {"id": 1, "title": "D1"},
-            {"id": 2, "title": "D2"},
+            Document.from_row({"id": 1, "title": "D1"}),
+            Document.from_row({"id": 2, "title": "D2"}),
         ]
         mock_restore.return_value = True
 
@@ -699,8 +728,8 @@ class TestPurgeCommand:
     def test_purge_with_force(self, mock_list_deleted, mock_purge):
         """Purge --force skips confirmation."""
         mock_list_deleted.return_value = [
-            {"id": 1, "title": "D", "deleted_at": datetime(2024, 1, 1)}
-        ]  # noqa: E501
+            Document.from_row({"id": 1, "title": "D", "deleted_at": datetime(2024, 1, 1)})
+        ]
         mock_purge.return_value = 1
 
         result = runner.invoke(main_app, ["trash", "purge", "--force"])

--- a/tests/test_commands_tags.py
+++ b/tests/test_commands_tags.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from emdx.commands.tags import app
+from emdx.models.document import Document
 
 runner = CliRunner()
 
@@ -30,7 +31,7 @@ class TestTagAddCommand:
     @patch("emdx.commands.tags.get_document")
     def test_add_tags_explicit(self, mock_get_doc, mock_add_tags, mock_get_tags):
         """Add tags via explicit 'add' subcommand."""
-        mock_get_doc.return_value = {"id": 1, "title": "Doc"}
+        mock_get_doc.return_value = Document.from_row({"id": 1, "title": "Doc"})
         mock_add_tags.return_value = ["python", "testing"]
         mock_get_tags.return_value = ["python", "testing"]
 
@@ -73,7 +74,7 @@ class TestTagAddCommand:
     @patch("emdx.commands.tags.get_document")
     def test_tag_show_current(self, mock_get_doc, mock_get_tags):
         """Tag with no tag arguments shows current tags."""
-        mock_get_doc.return_value = {"id": 1, "title": "Doc"}
+        mock_get_doc.return_value = Document.from_row({"id": 1, "title": "Doc"})
         mock_get_tags.return_value = ["python"]
 
         result = runner.invoke(app, ["add", "1"])
@@ -95,7 +96,7 @@ class TestTagAddCommand:
     @patch("emdx.commands.tags.get_document")
     def test_tag_already_exists(self, mock_get_doc, mock_add_tags, mock_get_tags):
         """Adding a tag that already exists shows message."""
-        mock_get_doc.return_value = {"id": 1, "title": "Doc"}
+        mock_get_doc.return_value = Document.from_row({"id": 1, "title": "Doc"})
         mock_add_tags.return_value = []  # no new tags added
         mock_get_tags.return_value = ["python"]
 
@@ -115,7 +116,7 @@ class TestTagRemoveCommand:
     @patch("emdx.commands.tags.get_document")
     def test_remove(self, mock_get_doc, mock_remove_tags, mock_get_tags):
         """Remove tags from a document."""
-        mock_get_doc.return_value = {"id": 1, "title": "Doc"}
+        mock_get_doc.return_value = Document.from_row({"id": 1, "title": "Doc"})
         mock_remove_tags.return_value = ["python"]
         mock_get_tags.return_value = []
 
@@ -128,7 +129,7 @@ class TestTagRemoveCommand:
     @patch("emdx.commands.tags.get_document")
     def test_remove_not_on_doc(self, mock_get_doc, mock_remove_tags, mock_get_tags):
         """Removing a tag that doesn't exist shows message."""
-        mock_get_doc.return_value = {"id": 1, "title": "Doc"}
+        mock_get_doc.return_value = Document.from_row({"id": 1, "title": "Doc"})
         mock_remove_tags.return_value = []
         mock_get_tags.return_value = []
 

--- a/tests/test_commands_trash.py
+++ b/tests/test_commands_trash.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from emdx.commands.trash import app
+from emdx.models.document import Document
 
 runner = CliRunner()
 
@@ -39,13 +40,15 @@ class TestTrashList:
     @patch("emdx.commands.trash.list_deleted_documents")
     def test_list_shows_documents(self, mock_list):
         mock_list.return_value = [
-            {
-                "id": 42,
-                "title": "Test Document",
-                "project": "test-project",
-                "deleted_at": datetime(2026, 1, 15, 10, 30),
-                "access_count": 5,
-            }
+            Document.from_row(
+                {
+                    "id": 42,
+                    "title": "Test Document",
+                    "project": "test-project",
+                    "deleted_at": datetime(2026, 1, 15, 10, 30),
+                    "access_count": 5,
+                }
+            )
         ]
         result = runner.invoke(app, ["list"])
         assert result.exit_code == 0
@@ -57,13 +60,15 @@ class TestTrashList:
     @patch("emdx.commands.trash.list_deleted_documents")
     def test_list_truncates_long_titles(self, mock_list):
         mock_list.return_value = [
-            {
-                "id": 1,
-                "title": "A" * 60,
-                "project": None,
-                "deleted_at": datetime(2026, 1, 15),
-                "access_count": 0,
-            }
+            Document.from_row(
+                {
+                    "id": 1,
+                    "title": "A" * 60,
+                    "project": None,
+                    "deleted_at": datetime(2026, 1, 15),
+                    "access_count": 0,
+                }
+            )
         ]
         result = runner.invoke(app, ["list"])
         assert result.exit_code == 0
@@ -134,7 +139,9 @@ class TestTrashPurge:
     @patch("emdx.commands.trash.list_deleted_documents")
     @patch("emdx.commands.trash.purge_deleted_documents")
     def test_purge_with_force(self, mock_purge, mock_list):
-        mock_list.return_value = [{"id": 1, "deleted_at": datetime(2026, 1, 1)}]
+        mock_list.return_value = [
+            Document.from_row({"id": 1, "title": "", "deleted_at": datetime(2026, 1, 1)})
+        ]
         mock_purge.return_value = 1
         result = runner.invoke(app, ["purge", "--force"])
         assert result.exit_code == 0
@@ -143,7 +150,9 @@ class TestTrashPurge:
     @patch("emdx.commands.trash.list_deleted_documents")
     @patch("emdx.commands.trash.is_non_interactive", return_value=False)
     def test_purge_cancelled(self, mock_interactive, mock_list):
-        mock_list.return_value = [{"id": 1, "deleted_at": datetime(2026, 1, 1)}]
+        mock_list.return_value = [
+            Document.from_row({"id": 1, "title": "", "deleted_at": datetime(2026, 1, 1)})
+        ]
         result = runner.invoke(app, ["purge"], input="n\n")
         assert result.exit_code == 0
         assert "cancelled" in _out(result).lower()
@@ -155,7 +164,9 @@ class TestTrashPurge:
         self, mock_ni: Any, mock_list: Any, mock_purge: Any
     ) -> None:
         """Purge skips confirmation when stdin is not a TTY (agent mode)."""
-        mock_list.return_value = [{"id": 1, "deleted_at": datetime(2026, 1, 1)}]
+        mock_list.return_value = [
+            Document.from_row({"id": 1, "title": "", "deleted_at": datetime(2026, 1, 1)})
+        ]
         mock_purge.return_value = 1
         result = runner.invoke(app, ["purge"])
         assert result.exit_code == 0
@@ -174,8 +185,8 @@ class TestTrashRestoreNonInteractive:
     ) -> None:
         """Restore --all skips confirmation when stdin is not a TTY."""
         mock_list.return_value = [
-            {"id": 1, "title": "Doc 1", "deleted_at": datetime(2026, 1, 1)},
-            {"id": 2, "title": "Doc 2", "deleted_at": datetime(2026, 1, 2)},
+            Document.from_row({"id": 1, "title": "Doc 1", "deleted_at": datetime(2026, 1, 1)}),
+            Document.from_row({"id": 2, "title": "Doc 2", "deleted_at": datetime(2026, 1, 2)}),
         ]
         mock_restore.return_value = True
         result = runner.invoke(app, ["restore", "--all"])

--- a/tests/test_document_model.py
+++ b/tests/test_document_model.py
@@ -1,0 +1,325 @@
+"""Tests for the Document dataclass domain model."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from emdx.models.document import _DATETIME_FIELDS, Document
+from emdx.models.search import SearchHit
+
+# ── Construction ──────────────────────────────────────────────────────
+
+
+class TestDocumentConstruction:
+    def test_minimal_construction(self) -> None:
+        doc = Document(id=1, title="Hello")
+        assert doc.id == 1
+        assert doc.title == "Hello"
+        assert doc.content == ""
+        assert doc.project is None
+        assert doc.access_count == 0
+        assert doc.is_deleted is False
+        assert doc.doc_type == "user"
+
+    def test_full_construction(self) -> None:
+        now = datetime.now()
+        doc = Document(
+            id=42,
+            title="Full doc",
+            content="body",
+            project="emdx",
+            created_at=now,
+            updated_at=now,
+            accessed_at=now,
+            access_count=5,
+            deleted_at=None,
+            is_deleted=False,
+            parent_id=10,
+            relationship="supersedes",
+            archived_at=None,
+            stage="draft",
+            doc_type="wiki",
+        )
+        assert doc.id == 42
+        assert doc.project == "emdx"
+        assert doc.parent_id == 10
+        assert doc.stage == "draft"
+        assert doc.doc_type == "wiki"
+
+
+# ── from_row / from_partial_row ───────────────────────────────────────
+
+
+class TestFromRow:
+    def test_from_dict_full_row(self) -> None:
+        raw = {
+            "id": 1,
+            "title": "Test",
+            "content": "body",
+            "project": "proj",
+            "created_at": "2025-01-15 10:30:00",
+            "updated_at": "2025-01-16T12:00:00",
+            "accessed_at": None,
+            "access_count": 3,
+            "deleted_at": None,
+            "is_deleted": 0,
+            "parent_id": None,
+            "relationship": None,
+            "archived_at": None,
+            "stage": None,
+            "doc_type": "user",
+        }
+        doc = Document.from_row(raw)
+        assert doc.id == 1
+        assert doc.title == "Test"
+        assert isinstance(doc.created_at, datetime)
+        assert doc.created_at.year == 2025
+        assert doc.created_at.month == 1
+        assert doc.created_at.day == 15
+        assert isinstance(doc.updated_at, datetime)
+        assert doc.is_deleted is False
+
+    def test_from_dict_parses_sqlite_datetime(self) -> None:
+        raw = {"id": 1, "title": "T", "created_at": "2025-03-07 14:30:00"}
+        doc = Document.from_row(raw)
+        assert isinstance(doc.created_at, datetime)
+        assert doc.created_at.hour == 14
+
+    def test_from_dict_parses_iso_datetime(self) -> None:
+        raw = {"id": 1, "title": "T", "created_at": "2025-03-07T14:30:00Z"}
+        doc = Document.from_row(raw)
+        assert isinstance(doc.created_at, datetime)
+        assert doc.created_at.tzinfo == timezone.utc
+
+    def test_from_dict_is_deleted_bool_coercion(self) -> None:
+        doc_false = Document.from_row({"id": 1, "title": "T", "is_deleted": 0})
+        assert doc_false.is_deleted is False
+
+        doc_true = Document.from_row({"id": 1, "title": "T", "is_deleted": 1})
+        assert doc_true.is_deleted is True
+
+    def test_from_dict_ignores_unknown_columns(self) -> None:
+        raw = {"id": 1, "title": "T", "some_extra_column": "ignored"}
+        doc = Document.from_row(raw)
+        assert doc.id == 1
+        assert doc.title == "T"
+
+    def test_from_partial_row_fills_defaults(self) -> None:
+        raw = {"id": 1, "title": "T"}
+        doc = Document.from_partial_row(raw)
+        assert doc.content == ""
+        assert doc.project is None
+        assert doc.access_count == 0
+        assert doc.is_deleted is False
+        assert doc.doc_type == "user"
+
+    def test_from_row_defensive_copy(self) -> None:
+        """from_row should not mutate the input dict."""
+        raw = {"id": 1, "title": "T", "created_at": "2025-01-01 00:00:00"}
+        original_val = raw["created_at"]
+        Document.from_row(raw)
+        assert raw["created_at"] == original_val
+
+    def test_from_dict_datetime_already_parsed(self) -> None:
+        """If a datetime field is already a datetime object, pass through."""
+        now = datetime.now()
+        raw = {"id": 1, "title": "T", "created_at": now}
+        doc = Document.from_row(raw)
+        assert doc.created_at is now
+
+
+# ── Dict compatibility ────────────────────────────────────────────────
+
+
+class TestDictCompat:
+    @pytest.fixture()
+    def doc(self) -> Document:
+        return Document(
+            id=42,
+            title="My Doc",
+            content="body",
+            project="emdx",
+            access_count=5,
+        )
+
+    def test_getitem(self, doc: Document) -> None:
+        assert doc["id"] == 42
+        assert doc["title"] == "My Doc"
+        assert doc["content"] == "body"
+        assert doc["project"] == "emdx"
+
+    def test_getitem_raises_keyerror(self, doc: Document) -> None:
+        with pytest.raises(KeyError, match="nonexistent"):
+            doc["nonexistent"]
+
+    def test_get_with_default(self, doc: Document) -> None:
+        assert doc.get("title") == "My Doc"
+        assert doc.get("nonexistent") is None
+        assert doc.get("nonexistent", "fallback") == "fallback"
+
+    def test_contains(self, doc: Document) -> None:
+        assert "title" in doc
+        assert "id" in doc
+        assert "nonexistent" not in doc
+        assert 42 not in doc  # type: ignore[operator]  # non-string
+
+    def test_keys(self, doc: Document) -> None:
+        k = doc.keys()
+        assert "id" in k
+        assert "title" in k
+        assert "content" in k
+        assert "doc_type" in k
+        assert len(k) == 15  # all fields
+
+    def test_items(self, doc: Document) -> None:
+        pairs = dict(doc.items())
+        assert pairs["id"] == 42
+        assert pairs["title"] == "My Doc"
+        assert pairs["project"] == "emdx"
+        assert pairs["access_count"] == 5
+
+    def test_values(self, doc: Document) -> None:
+        vals = list(doc.values())
+        assert 42 in vals
+        assert "My Doc" in vals
+
+
+# ── Serialization ─────────────────────────────────────────────────────
+
+
+class TestSerialization:
+    def test_to_dict_basic(self) -> None:
+        doc = Document(id=1, title="T", content="body", project="p")
+        d = doc.to_dict()
+        assert isinstance(d, dict)
+        assert d["id"] == 1
+        assert d["title"] == "T"
+        assert d["project"] == "p"
+
+    def test_to_dict_serializes_datetimes(self) -> None:
+        now = datetime(2025, 3, 7, 14, 30, 0)
+        doc = Document(id=1, title="T", created_at=now, updated_at=now)
+        d = doc.to_dict()
+        assert d["created_at"] == "2025-03-07T14:30:00"
+        assert d["updated_at"] == "2025-03-07T14:30:00"
+
+    def test_to_dict_none_datetimes(self) -> None:
+        doc = Document(id=1, title="T")
+        d = doc.to_dict()
+        assert d["created_at"] is None
+        assert d["updated_at"] is None
+
+    def test_roundtrip_dict(self) -> None:
+        """from_row(to_dict()) should produce an equivalent Document."""
+        now = datetime(2025, 3, 7, 14, 30, 0)
+        original = Document(
+            id=1,
+            title="Roundtrip",
+            content="body",
+            project="p",
+            created_at=now,
+            access_count=5,
+            doc_type="wiki",
+        )
+        rebuilt = Document.from_row(original.to_dict())
+        assert rebuilt.id == original.id
+        assert rebuilt.title == original.title
+        assert rebuilt.created_at == original.created_at
+        assert rebuilt.access_count == original.access_count
+        assert rebuilt.doc_type == original.doc_type
+
+
+# ── SearchHit ─────────────────────────────────────────────────────────
+
+
+class TestSearchHit:
+    def test_from_row(self) -> None:
+        raw = {
+            "id": 1,
+            "title": "Found",
+            "project": "p",
+            "created_at": "2025-01-01 00:00:00",
+            "updated_at": None,
+            "snippet": "...match...",
+            "rank": -2.5,
+            "doc_type": "user",
+        }
+        hit = SearchHit.from_row(raw)
+        assert hit.doc.id == 1
+        assert hit.doc.title == "Found"
+        assert hit.snippet == "...match..."
+        assert hit.rank == -2.5
+
+    def test_bracket_access_document_fields(self) -> None:
+        doc = Document(id=1, title="T")
+        hit = SearchHit(doc=doc, snippet="snip", rank=-1.0)
+        assert hit["id"] == 1
+        assert hit["title"] == "T"
+        assert hit["snippet"] == "snip"
+        assert hit["rank"] == -1.0
+
+    def test_get_fallthrough(self) -> None:
+        doc = Document(id=1, title="T", project="p")
+        hit = SearchHit(doc=doc)
+        assert hit.get("project") == "p"
+        assert hit.get("snippet") is None
+        assert hit.get("nonexistent", "fb") == "fb"
+
+    def test_contains(self) -> None:
+        doc = Document(id=1, title="T")
+        hit = SearchHit(doc=doc)
+        assert "title" in hit
+        assert "snippet" in hit
+        assert "rank" in hit
+        assert "nonexistent" not in hit
+
+    def test_keys_includes_search_fields(self) -> None:
+        doc = Document(id=1, title="T")
+        hit = SearchHit(doc=doc)
+        k = hit.keys()
+        assert "snippet" in k
+        assert "rank" in k
+        assert "id" in k
+
+    def test_to_dict(self) -> None:
+        doc = Document(id=1, title="T", project="p")
+        hit = SearchHit(doc=doc, snippet="snip", rank=-1.5)
+        d = hit.to_dict()
+        assert d["id"] == 1
+        assert d["title"] == "T"
+        assert d["snippet"] == "snip"
+        assert d["rank"] == -1.5
+
+    def test_from_row_null_rank(self) -> None:
+        raw = {"id": 1, "title": "T", "snippet": None, "rank": None}
+        hit = SearchHit.from_row(raw)
+        assert hit.rank == 0.0
+        assert hit.snippet is None
+
+
+# ── Edge cases ────────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_datetime_fields_constant(self) -> None:
+        """Verify _DATETIME_FIELDS covers the expected fields."""
+        assert _DATETIME_FIELDS == {
+            "created_at",
+            "updated_at",
+            "accessed_at",
+            "deleted_at",
+            "archived_at",
+        }
+
+    def test_field_names_cached(self) -> None:
+        """_field_names should be cached after first call."""
+        names1 = Document._field_names()
+        names2 = Document._field_names()
+        assert names1 is names2
+
+    def test_slots_prevent_arbitrary_attrs(self) -> None:
+        doc = Document(id=1, title="T")
+        with pytest.raises(AttributeError):
+            doc.arbitrary_thing = "nope"  # type: ignore[attr-defined]

--- a/tests/test_gist.py
+++ b/tests/test_gist.py
@@ -10,6 +10,7 @@ from typer.testing import CliRunner
 
 from emdx.commands.gist import sanitize_filename
 from emdx.main import app as main_app
+from emdx.models.document import Document
 
 runner = CliRunner()
 
@@ -111,12 +112,14 @@ class TestGistCommand:
     @patch("emdx.commands.gist.get_document")
     def test_gist_no_auth(self, mock_get_doc: Any, mock_auth: Any) -> None:
         """Gist without GitHub auth shows authentication error."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "Test Doc",
-            "content": "Hello world",
-            "project": "test",
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "Test Doc",
+                "content": "Hello world",
+                "project": "test",
+            }
+        )
         mock_auth.return_value = None
 
         result = runner.invoke(main_app, ["gist", "1"])
@@ -132,12 +135,14 @@ class TestGistCommand:
         self, mock_get_doc: Any, mock_auth: Any, mock_create: Any, mock_db: Any
     ) -> None:
         """Successful gist creation shows URL."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "Test Doc",
-            "content": "Hello world",
-            "project": "test",
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "Test Doc",
+                "content": "Hello world",
+                "project": "test",
+            }
+        )
         mock_auth.return_value = "ghp_test_token"
         mock_create.return_value = {
             "id": "abc123",
@@ -158,12 +163,14 @@ class TestGistCommand:
     @patch("emdx.commands.gist.get_document")
     def test_gist_create_failure(self, mock_get_doc: Any, mock_auth: Any, mock_create: Any) -> None:
         """Failed gist creation shows error."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "Test Doc",
-            "content": "Hello world",
-            "project": None,
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "Test Doc",
+                "content": "Hello world",
+                "project": None,
+            }
+        )
         mock_auth.return_value = "ghp_test_token"
         mock_create.return_value = None
 
@@ -187,12 +194,14 @@ class TestGistCommand:
         self, mock_get_doc: Any, mock_auth: Any, mock_update: Any, mock_db: Any
     ) -> None:
         """Updating an existing gist succeeds."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "Test Doc",
-            "content": "Updated content",
-            "project": None,
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "Test Doc",
+                "content": "Updated content",
+                "project": None,
+            }
+        )
         mock_auth.return_value = "ghp_test_token"
         mock_update.return_value = True
         # Mock the database connection so UPDATE gists doesn't fail
@@ -210,12 +219,14 @@ class TestGistCommand:
     @patch("emdx.commands.gist.get_document")
     def test_gist_update_failure(self, mock_get_doc: Any, mock_auth: Any, mock_update: Any) -> None:
         """Failed gist update shows error."""
-        mock_get_doc.return_value = {
-            "id": 1,
-            "title": "Test Doc",
-            "content": "Content",
-            "project": None,
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 1,
+                "title": "Test Doc",
+                "content": "Content",
+                "project": None,
+            }
+        )
         mock_auth.return_value = "ghp_test_token"
         mock_update.return_value = False
 

--- a/tests/test_task_commands.py
+++ b/tests/test_task_commands.py
@@ -10,6 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 from emdx.commands.tasks import app
+from emdx.models.document import Document
 
 runner = CliRunner()
 
@@ -735,7 +736,7 @@ class TestTaskView:
         mock_tasks.get_dependencies.return_value = []
         mock_tasks.get_dependents.return_value = []
         mock_tasks.get_task_log.return_value = []
-        mock_get_doc.return_value = {"id": 99, "title": "Security audit report"}
+        mock_get_doc.return_value = Document.from_row({"id": 99, "title": "Security audit report"})
 
         result = runner.invoke(app, ["view", "10"])
         out = _out(result)

--- a/tests/test_v028_regressions.py
+++ b/tests/test_v028_regressions.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 from emdx.main import app
+from emdx.models.document import Document
 
 runner = CliRunner()
 
@@ -238,7 +239,9 @@ class TestHistoryJsonOutput:
         mock_db: MagicMock,
     ) -> None:
         """history --json should produce parseable JSON with version info."""
-        mock_get_doc.return_value = {"id": 42, "title": "Test Document", "content": "body"}
+        mock_get_doc.return_value = Document.from_row(
+            {"id": 42, "title": "Test Document", "content": "body"}
+        )
 
         # Simulate version rows from the database
         mock_conn = MagicMock()
@@ -267,7 +270,9 @@ class TestHistoryJsonOutput:
         mock_db: MagicMock,
     ) -> None:
         """history --json with no versions should output a JSON error message."""
-        mock_get_doc.return_value = {"id": 42, "title": "Test", "content": "body"}
+        mock_get_doc.return_value = Document.from_row(
+            {"id": 42, "title": "Test", "content": "body"}
+        )
 
         mock_conn = MagicMock()
         mock_db.get_connection.return_value.__enter__ = MagicMock(return_value=mock_conn)
@@ -346,11 +351,13 @@ class TestWikiViewNoCrash:
         mock_row.__getitem__ = MagicMock(return_value=99)
         mock_conn.execute.return_value.fetchone.return_value = mock_row
 
-        mock_get_doc.return_value = {
-            "id": 99,
-            "title": "Wiki Article Title",
-            "content": "# Article\n\nSome content here.",
-        }
+        mock_get_doc.return_value = Document.from_row(
+            {
+                "id": 99,
+                "title": "Wiki Article Title",
+                "content": "# Article\n\nSome content here.",
+            }
+        )
 
         result = runner.invoke(app, ["wiki", "view", "5", "--raw"])
         assert result.exit_code == 0

--- a/tests/test_view_review.py
+++ b/tests/test_view_review.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 from emdx.commands.core import app
+from emdx.models.document import Document
 
 runner = CliRunner()
 
@@ -18,14 +19,16 @@ def _out(result) -> str:  # type: ignore[no-untyped-def]
     return re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
 
 
-_DOC = {
-    "id": 42,
-    "title": "Architecture Plan",
-    "content": "We currently use REST. Today the API handles 1000 rps.",
-    "project": "acme",
-    "created_at": datetime(2024, 6, 1),
-    "access_count": 3,
-}
+_DOC = Document.from_row(
+    {
+        "id": 42,
+        "title": "Architecture Plan",
+        "content": "We currently use REST. Today the API handles 1000 rps.",
+        "project": "acme",
+        "created_at": datetime(2024, 6, 1),
+        "access_count": 3,
+    }
+)
 
 
 class TestViewReviewFlag:


### PR DESCRIPTION
## Summary

- Introduces `Document` dataclass (`emdx/models/document.py`) as the single domain object for documents, replacing ~8 scattered TypedDicts (`DocumentRow`, `DocumentListItem`, `RecentDocumentItem`, `DeletedDocumentItem`, `ChildDocumentItem`, `SupersedeCandidate`, etc.)
- Introduces `SearchHit` dataclass (`emdx/models/search.py`) wrapping `Document` + search metadata (`snippet`, `rank`)
- Both support `doc["field"]` bracket access via `__getitem__` for zero-breakage backward compatibility with 158 existing call sites
- Wires new types into `database/documents.py`, `database/search.py`, `database/__init__.py` — eliminating 25 `cast()` calls and the `_parse_doc_datetimes()` mutate-dict-in-place hack
- 31 new unit tests for the Document model; 2068 total tests passing

## What changed

| File | Change |
|------|--------|
| `emdx/models/document.py` | **NEW** — `Document` dataclass with `from_row()`, `from_partial_row()`, dict compat, `to_dict()` |
| `emdx/models/search.py` | **NEW** — `SearchHit` dataclass wrapping Document + snippet/rank |
| `emdx/database/documents.py` | All functions return `Document`. Removed `_parse_doc_datetimes()` and all `cast()` calls |
| `emdx/database/search.py` | Returns `list[SearchHit]`. Removed manual datetime parsing |
| `emdx/database/__init__.py` | `SQLiteDatabase` methods return `Document`/`SearchHit`. Removed TypedDict imports |
| `emdx/commands/context.py` | Switched `DocumentRow` → `Document` |
| `tests/test_document_model.py` | **NEW** — 31 tests for construction, parsing, dict compat, serialization, SearchHit |

## Context

This is Phases 1-2 of the data model refactor (epic ARCH-24, gameplan doc #7431). Future phases will migrate consumers to attribute access (`doc.title` instead of `doc["title"]`), remove the obsolete TypedDicts, and apply the same pattern to Tasks.

## Test plan

- [x] 31 new Document model tests passing
- [x] 158 existing document + search tests passing (via `__getitem__` compat)
- [x] Full suite: 2068 passed, 8 skipped (pre-existing)
- [x] ruff lint clean
- [x] ruff format clean
- [x] mypy clean
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)