### PR TITLE
refactor: rename --epic to --parent, epic_key/seq to cat_key/seq

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ emdx status   # Quick overview
    ```
    This gives the user real-time visibility into progress, especially for longer tasks.
 3. **Save significant outputs** to emdx: `echo "findings" | emdx save --title "Title" --tags "analysis,active"`
-4. **Create tasks** for discovered work: `emdx task add "Title" -D "Details" --epic <id> --cat FEAT`
+4. **Create tasks** for discovered work: `emdx task add "Title" -D "Details" --parent <id> --cat FEAT`
 5. **Update task status as you work** — mark tasks done when complete, create new tasks for discovered work
 
 #### For Agent/Subagent Sessions
@@ -205,9 +205,15 @@ emdx status   # Quick overview
 **Status:** `active` (working), `done` (completed), `blocked` (stuck)
 **Outcome:** `success`, `failed`, `partial`
 
-**Tasks** use categories and epics (NOT tags):
-- `--cat FEAT` / `--cat FIX` / `--cat ARCH` etc. — assigns a category
-- `--epic <id>` — groups task under a parent epic
+**Tasks** use two orthogonal mechanisms for organization (NOT tags):
+
+| Flag | Purpose | Example |
+|------|---------|---------|
+| `--cat CAT` | Namespace: assigns category prefix (SEC-1, PROP-2) | `--cat SEC` |
+| `--parent 42` | Hierarchy: sets parent task for subtask relationship | `--parent 42` |
+
+- `--cat FEAT` / `--cat FIX` / `--cat ARCH` etc. — assigns a category key that generates numbered IDs
+- `--parent <id>` — sets the parent task, creating a subtask hierarchy
 - Use `emdx task cat list` to see available categories
 - Use `emdx task epic list` to see active epics
 
@@ -235,8 +241,8 @@ emdx view 42                           # View document content
 emdx view 42 --links                   # Show document's link graph
 emdx view 42 --review                  # Adversarial review of the document
 
-# Tasks (use --epic and --cat, NOT --tags)
-emdx task add "Title" -D "Details" --epic 898 --cat FEAT
+# Tasks (use --parent and --cat, NOT --tags)
+emdx task add "Title" -D "Details" --parent 898 --cat FEAT
 emdx task plan <parent> "Step 1" "Step 2" "Step 3"  # Batch create subtasks
 emdx task brief <id>                   # Agent-ready task context
 emdx task brief <id> --json            # Structured for programmatic use

--- a/emdx/commands/_drift.py
+++ b/emdx/commands/_drift.py
@@ -23,7 +23,7 @@ class StaleEpicDict(TypedDict):
 
     id: int
     title: str
-    epic_key: str | None
+    cat_key: str | None
     status: str
     open_tasks: int
     last_activity: str | None
@@ -36,7 +36,7 @@ class OrphanedTaskDict(TypedDict):
     id: int
     title: str
     status: str
-    epic_key: str | None
+    cat_key: str | None
     parent_task_id: int | None
     updated_at: str | None
     days_idle: int
@@ -58,7 +58,7 @@ class BurstEpicDict(TypedDict):
 
     id: int
     title: str
-    epic_key: str | None
+    cat_key: str | None
     total_tasks: int
     burst_days: int
     silent_days: int
@@ -81,7 +81,7 @@ def _find_stale_epics(days: int) -> list[StaleEpicDict]:
             SELECT
                 e.id,
                 e.title,
-                e.epic_key,
+                e.cat_key,
                 e.status,
                 COUNT(c.id) AS open_tasks,
                 MAX(
@@ -118,7 +118,7 @@ def _find_orphaned_active_tasks(days: int) -> list[OrphanedTaskDict]:
                 t.id,
                 t.title,
                 t.status,
-                t.epic_key,
+                t.cat_key,
                 t.parent_task_id,
                 t.updated_at,
                 CAST(
@@ -202,7 +202,7 @@ def _find_burst_epics(days: int) -> list[BurstEpicDict]:
             SELECT
                 e.id,
                 e.title,
-                e.epic_key,
+                e.cat_key,
                 COUNT(c.id) AS total_tasks,
                 CAST(
                     julianday(MAX(c.created_at))
@@ -264,7 +264,7 @@ def _format_plain(report: DriftReport, days: int) -> str:
         lines.append(f"Stale Epics ({len(report['stale_epics'])})")
         lines.append("-" * 30)
         for epic in report["stale_epics"]:
-            key = epic.get("epic_key") or "?"
+            key = epic.get("cat_key") or "?"
             lines.append(
                 f"  #{epic['id']} {epic['title']} "
                 f"[{key}] -- went silent "
@@ -278,7 +278,7 @@ def _format_plain(report: DriftReport, days: int) -> str:
         lines.append(f"Orphaned Active Tasks ({len(report['orphaned_tasks'])})")
         lines.append("-" * 30)
         for task in report["orphaned_tasks"]:
-            key = task.get("epic_key") or ""
+            key = task.get("cat_key") or ""
             prefix = f"[{key}] " if key else ""
             lines.append(
                 f"  #{task['id']} {prefix}{task['title']} -- idle {task['days_idle']} days"
@@ -305,7 +305,7 @@ def _format_plain(report: DriftReport, days: int) -> str:
         lines.append(f"Burst-Then-Stop Epics ({len(report['burst_epics'])})")
         lines.append("-" * 30)
         for burst in report["burst_epics"]:
-            key = burst.get("epic_key") or "?"
+            key = burst.get("cat_key") or "?"
             lines.append(
                 f"  #{burst['id']} {burst['title']} "
                 f"[{key}] -- "

--- a/emdx/commands/categories.py
+++ b/emdx/commands/categories.py
@@ -79,7 +79,7 @@ def delete(
 ) -> None:
     """Delete a category and unlink associated tasks.
 
-    Tasks are NOT deleted — their epic_key/epic_seq are cleared.
+    Tasks are NOT deleted — their cat_key/cat_seq are cleared.
     Refuses to delete if open/active tasks exist unless --force is used.
 
     Examples:
@@ -105,7 +105,7 @@ def adopt(
 ) -> None:
     """Backfill existing tasks with KEY-N: titles into the category system.
 
-    Scans tasks matching the KEY-N: pattern and sets their epic_key/epic_seq.
+    Scans tasks matching the KEY-N: pattern and sets their cat_key/cat_seq.
     Also detects parent EPIC tasks and marks them.
 
     Examples:

--- a/emdx/commands/epics.py
+++ b/emdx/commands/epics.py
@@ -46,7 +46,7 @@ def create(
     try:
         epic_id = tasks.create_epic(name, cat, description or "")
         epic = tasks.get_task(epic_id)
-        seq = epic.epic_seq if epic else None
+        seq = epic.cat_seq if epic else None
         key_label = f"{cat.upper()}-{seq}" if seq else f"#{epic_id}"
         id_suffix = f" (#{epic_id})" if seq else ""
         console.print(f"[green]Created epic {key_label}{id_suffix}: {name}[/green]")
@@ -83,9 +83,9 @@ def list_cmd(
     table.add_column("Total", justify="right", width=6)
 
     for e in epics:
-        epic_key = e.epic_key or ""
-        epic_seq = e.epic_seq
-        key_label = f"{epic_key}-{epic_seq}" if epic_key and epic_seq else str(e.id)
+        cat_key = e.cat_key or ""
+        cat_seq = e.cat_seq
+        key_label = f"{cat_key}-{cat_seq}" if cat_key and cat_seq else str(e.id)
         table.add_row(
             key_label,
             e.title[:40],
@@ -114,7 +114,7 @@ def view(
         console.print(f"[red]Epic #{epic_id} not found[/red]")
         raise typer.Exit(1)
 
-    cat_label = f" ({epic.epic_key})" if epic.epic_key else ""
+    cat_label = f" ({epic.cat_key})" if epic.cat_key else ""
     console.print(f"\n[bold]Epic #{epic.id}: {epic.title}{cat_label}[/bold] — {epic.status}")
     if epic.description:
         console.print(f"[dim]{epic.description}[/dim]")
@@ -126,7 +126,7 @@ def view(
         done_count = 0
         for c in children:
             icon = ICONS.get(c.status, "?")
-            seq_label = f"{c.epic_key}-{c.epic_seq}" if c.epic_seq else f"#{c.id}"
+            seq_label = f"{c.cat_key}-{c.cat_seq}" if c.cat_seq else f"#{c.id}"
             console.print(f"  {icon}  {seq_label}  {c.title}")
             if c.status == "done":
                 done_count += 1
@@ -237,7 +237,7 @@ def attach(
 
     epic_task = tasks.get_task(epic_id)
     epic_label = f"#{epic_id}"
-    if epic_task and epic_task.epic_key and epic_task.epic_seq:
-        epic_label = f"{epic_task.epic_key}-{epic_task.epic_seq}"
+    if epic_task and epic_task.cat_key and epic_task.cat_seq:
+        epic_label = f"{epic_task.cat_key}-{epic_task.cat_seq}"
 
     console.print(f"[green]✅ Attached {count} task(s) to epic {epic_label}[/green]")

--- a/emdx/commands/prime.py
+++ b/emdx/commands/prime.py
@@ -284,10 +284,10 @@ def _output_text(
 
 def _task_label(task: ReadyTask | InProgressTask) -> str:
     """Format a task label: use epic key (e.g. DEBT-10) if available, else #id."""
-    epic_key = task.get("epic_key")
-    epic_seq = task.get("epic_seq")
-    if epic_key and epic_seq:
-        label = f"{epic_key}-{epic_seq}"
+    cat_key = task.get("cat_key")
+    cat_seq = task.get("cat_seq")
+    if cat_key and cat_seq:
+        label = f"{cat_key}-{cat_seq}"
     else:
         label = f"#{task['id']}"
     # Pad to 13 chars for alignment (supports 8-char keys like SECURITY-999)
@@ -298,7 +298,7 @@ def _format_epic_line(epic: EpicInfo) -> str:
     """Format an epic line with progress bar."""
     done = epic["children_done"]
     total = epic["child_count"]
-    cat = epic.get("epic_key") or ""
+    cat = epic.get("cat_key") or ""
 
     # Progress bar: 5 chars wide
     if total > 0:
@@ -318,7 +318,7 @@ def _format_epic_brief(epic: EpicInfo) -> str:
     """Format an epic as a compact one-liner for brief mode."""
     done = epic["children_done"]
     total = epic["child_count"]
-    cat = epic.get("epic_key") or ""
+    cat = epic.get("cat_key") or ""
     prefix = f"{cat}: " if cat else ""
     return f"  {prefix}{epic['title']} — {done}/{total} done"
 
@@ -333,7 +333,7 @@ def _get_active_epics() -> list[EpicInfo]:
     with db.get_connection() as conn:
         cursor = conn.cursor()
         cursor.execute("""
-            SELECT t.id, t.title, t.status, t.epic_key,
+            SELECT t.id, t.title, t.status, t.cat_key,
                 COUNT(c.id) as child_count,
                 COUNT(CASE WHEN c.status IN ('done', 'duplicate')
                     THEN 1 END) as children_done
@@ -349,7 +349,7 @@ def _get_active_epics() -> list[EpicInfo]:
                 id=r[0],
                 title=r[1],
                 status=r[2],
-                epic_key=r[3],
+                cat_key=r[3],
                 child_count=r[4],
                 children_done=r[5],
             )
@@ -363,7 +363,7 @@ def _get_ready_tasks() -> list[ReadyTask]:
         cursor = conn.cursor()
         cursor.execute("""
             SELECT t.id, t.title, t.description, t.priority, t.status,
-                   t.source_doc_id, t.epic_key, t.epic_seq
+                   t.source_doc_id, t.cat_key, t.cat_seq
             FROM tasks t
             WHERE t.status = 'open'
             AND NOT EXISTS (
@@ -384,8 +384,8 @@ def _get_ready_tasks() -> list[ReadyTask]:
                 priority=r[3],
                 status=r[4],
                 source_doc_id=r[5],
-                epic_key=r[6],
-                epic_seq=r[7],
+                cat_key=r[6],
+                cat_seq=r[7],
             )
             for r in rows
         ]
@@ -396,7 +396,7 @@ def _get_in_progress_tasks() -> list[InProgressTask]:
     with db.get_connection() as conn:
         cursor = conn.cursor()
         cursor.execute("""
-            SELECT id, title, description, priority, epic_key, epic_seq
+            SELECT id, title, description, priority, cat_key, cat_seq
             FROM tasks
             WHERE status = 'active'
             ORDER BY updated_at DESC
@@ -409,8 +409,8 @@ def _get_in_progress_tasks() -> list[InProgressTask]:
                 title=r[1],
                 description=r[2],
                 priority=r[3],
-                epic_key=r[4],
-                epic_seq=r[5],
+                cat_key=r[4],
+                cat_seq=r[5],
             )
             for r in rows
         ]

--- a/emdx/commands/serve.py
+++ b/emdx/commands/serve.py
@@ -123,10 +123,10 @@ def _tag_list(params: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _task_list(params: dict[str, Any]) -> list[dict[str, Any]]:
     status = params.get("status")
-    epic_key = params.get("epic_key")
+    cat_key = params.get("cat_key")
     limit = params.get("limit", 200)
     status_list = [status] if status else None
-    rows = list_tasks(status=status_list, epic_key=epic_key, limit=limit)
+    rows = list_tasks(status=status_list, cat_key=cat_key, limit=limit)
     return [r.to_dict() for r in rows]
 
 

--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -61,8 +61,8 @@ def _blocker_summary(task_id: int) -> str:
 
 def _display_id(task: Task) -> str:
     """Return KEY-N display ID if available, otherwise #id."""
-    if task.epic_key and task.epic_seq:
-        return f"{task.epic_key}-{task.epic_seq}"
+    if task.cat_key and task.cat_seq:
+        return f"{task.cat_key}-{task.cat_seq}"
     return f"#{task.id}"
 
 
@@ -91,7 +91,15 @@ def add(
     title: str = typer.Argument(..., help="Task title"),
     doc: int | None = typer.Option(None, "-d", "--doc", help="Link to document ID"),
     description: str | None = typer.Option(None, "-D", "--description", help="Task description"),
-    epic: TaskRef | None = typer.Option(None, "-e", "--epic", help="Epic ID (e.g. 510 or SEC-1)"),
+    parent: TaskRef | None = typer.Option(
+        None, "-p", "--parent", help="Parent task ID (e.g. 510 or SEC-1)"
+    ),
+    epic: TaskRef | None = typer.Option(
+        None,
+        "--epic",
+        hidden=True,
+        help="Deprecated: use --parent",
+    ),
     cat: str | None = typer.Option(None, "-c", "--cat", help="Category key (e.g. SEC)"),
     after: list[int] | None = typer.Option(
         None, "--after", help="Task IDs this depends on (repeatable)"
@@ -103,8 +111,8 @@ def add(
         emdx task add "Fix the auth bug"
         emdx task add "Implement this" --doc 42
         emdx task add "Refactor tests" -D "Split into unit and integration"
-        emdx task add "Test task" --epic 510
-        emdx task add "Test task" --epic SEC-1
+        emdx task add "Test task" --parent 510
+        emdx task add "Test task" --parent SEC-1
         emdx task add "Another task" --cat SEC
         emdx task add "Deploy" --after 10 --after 11
     """
@@ -112,19 +120,22 @@ def add(
         console.print("[red]Error: Task title cannot be empty[/red]")
         raise typer.Exit(1)
 
-    parent_task_id = None
-    epic_key = cat.upper() if cat else None
+    # --epic is a deprecated alias for --parent
+    parent_ref = parent or epic
 
-    if epic:
-        epic_id = _resolve_id(epic, label="Epic")
+    parent_task_id = None
+    cat_key = cat.upper() if cat else None
+
+    if parent_ref:
+        epic_id = _resolve_id(parent_ref, label="Parent")
         parent_task = tasks.get_task(epic_id)
         if not parent_task:
-            console.print(f"[red]Epic {epic} not found[/red]")
+            console.print(f"[red]Parent task {parent_ref} not found[/red]")
             raise typer.Exit(1)
         parent_task_id = epic_id
-        # Inherit epic_key from the parent epic if not explicitly set
-        if not epic_key and parent_task.epic_key:
-            epic_key = parent_task.epic_key
+        # Inherit cat_key from the parent task if not explicitly set
+        if not cat_key and parent_task.cat_key:
+            cat_key = parent_task.cat_key
 
     depends_on = after if after else None
 
@@ -133,7 +144,7 @@ def add(
         description=description or "",
         source_doc_id=doc,
         parent_task_id=parent_task_id,
-        epic_key=epic_key,
+        cat_key=cat_key,
         depends_on=depends_on,
     )
 
@@ -154,7 +165,7 @@ def add(
 
 @app.command()
 def plan(
-    parent: str = typer.Argument(..., help="Parent task epic_key (e.g. FEAT-25)"),
+    parent: str = typer.Argument(..., help="Parent task ID (e.g. FEAT-25 or 42)"),
     titles: list[str] = typer.Argument(..., help="Subtask titles (at least one)"),
     cat: str | None = typer.Option(None, "-c", "--cat", help="Category for all subtasks"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
@@ -185,9 +196,9 @@ def plan(
             console.print(f"[red]{msg}[/red]")
         raise typer.Exit(1)
 
-    epic_key = cat.upper() if cat else None
-    if not epic_key and parent_task.epic_key:
-        epic_key = parent_task.epic_key
+    cat_key = cat.upper() if cat else None
+    if not cat_key and parent_task.cat_key:
+        cat_key = parent_task.cat_key
 
     created: list[dict[str, str | int]] = []
     prev_id: int | None = None
@@ -198,12 +209,12 @@ def plan(
             title,
             description="",
             parent_task_id=parent_id,
-            epic_key=epic_key,
+            cat_key=cat_key,
             depends_on=depends_on,
         )
         task_data = tasks.get_task(task_id)
         display = _display_id(task_data) if task_data else f"#{task_id}"
-        created.append({"id": task_id, "epic_key": display, "title": title})
+        created.append({"id": task_id, "cat_key": display, "title": title})
         prev_id = task_id
 
     parent_display = _display_id(parent_task)
@@ -213,7 +224,7 @@ def plan(
     else:
         print(f"Created {len(created)} subtasks under {parent_display}:")
         for sub in created:
-            print(f"  {sub['epic_key']}  {sub['title']}")
+            print(f"  {sub['cat_key']}  {sub['title']}")
 
 
 @app.command()
@@ -237,12 +248,20 @@ def ready(
         console.print("[yellow]No ready tasks[/yellow]")
         return
 
+    # Build parent ID set for quick lookup
+    ready_ids = {t.id for t in ready_tasks}
+
     table = Table(title=f"Ready ({len(ready_tasks)})")
     table.add_column("ID", style="cyan", no_wrap=True)
     table.add_column("Title")
 
     for t in ready_tasks:
-        table.add_row(_task_label(t), _display_title(t))
+        label = _task_label(t)
+        title = _display_title(t)
+        # Indent subtasks whose parent is also in the ready list
+        if t.parent_task_id is not None and t.parent_task_id in ready_ids:
+            title = f"  [dim]↳[/dim] {title}"
+        table.add_row(label, title)
 
     console.print(table)
 
@@ -394,12 +413,12 @@ def view(
 
     # Metadata line
     meta = [f"Status: {task.status}"]
-    if task.epic_key:
-        meta.append(f"Category: {task.epic_key}")
+    if task.cat_key:
+        meta.append(f"Category: {task.cat_key}")
     parent_task_id: int | None = task.parent_task_id
     if parent_task_id:
         parent = tasks.get_task(parent_task_id)
-        epic_label = _display_id(parent) if parent else (task.epic_key or "?")
+        epic_label = _display_id(parent) if parent else (task.cat_key or "?")
         meta.append(f"Epic: {epic_label}")
     if task.priority and task.priority != 3:
         meta.append(f"Priority: {task.priority}")
@@ -612,7 +631,7 @@ def _assemble_brief(
         "title": _display_title(task),
         "status": task.status,
         "priority": task.priority,
-        "category": task.epic_key,
+        "category": task.cat_key,
         "description": task.description or "",
     }
 
@@ -887,7 +906,7 @@ def list_cmd(
     task_list = tasks.list_tasks(
         status=status_list,
         limit=limit,
-        epic_key=cat,
+        cat_key=cat,
         parent_task_id=resolved_epic,
         since=since_date,
     )
@@ -919,20 +938,20 @@ def list_cmd(
 
 def _task_label(task: Task) -> str:
     """Format task label: DEBT-13 if epic, else #id."""
-    epic_key = task.epic_key
-    epic_seq = task.epic_seq
-    if epic_key and epic_seq:
-        return f"{epic_key}-{epic_seq}"
+    cat_key = task.cat_key
+    cat_seq = task.cat_seq
+    if cat_key and cat_seq:
+        return f"{cat_key}-{cat_seq}"
     return f"#{task.id}"
 
 
 def _display_title(task: Task) -> str:
     """Strip redundant KEY-N: prefix from title since the ID column has it."""
     title: str = task.title
-    epic_key = task.epic_key
-    epic_seq = task.epic_seq
-    if epic_key and epic_seq:
-        prefix = f"{epic_key}-{epic_seq}: "
+    cat_key = task.cat_key
+    cat_seq = task.cat_seq
+    if cat_key and cat_seq:
+        prefix = f"{cat_key}-{cat_seq}: "
         if title.startswith(prefix):
             return title[len(prefix) :]
     return title

--- a/emdx/commands/types.py
+++ b/emdx/commands/types.py
@@ -16,7 +16,7 @@ class EpicInfo(TypedDict):
     id: int
     title: str
     status: str
-    epic_key: str | None
+    cat_key: str | None
     child_count: int
     children_done: int
 
@@ -30,8 +30,8 @@ class ReadyTask(TypedDict):
     priority: int
     status: str
     source_doc_id: int | None
-    epic_key: str | None
-    epic_seq: int | None
+    cat_key: str | None
+    cat_seq: int | None
 
 
 class InProgressTask(TypedDict):
@@ -41,8 +41,8 @@ class InProgressTask(TypedDict):
     title: str
     description: str | None
     priority: int
-    epic_key: str | None
-    epic_seq: int | None
+    cat_key: str | None
+    cat_seq: int | None
 
 
 class RecentDoc(TypedDict):

--- a/emdx/database/migrations.py
+++ b/emdx/database/migrations.py
@@ -3121,6 +3121,23 @@ def migration_20260302_160000_add_wiki_quality_index(
     conn.commit()
 
 
+def migration_20260413_000000_rename_epic_key_to_cat_key(
+    conn: sqlite3.Connection,
+) -> None:
+    """Rename epic_key/epic_seq columns to cat_key/cat_seq in tasks table.
+
+    These columns represent category namespacing (e.g. SEC-1), not epic hierarchy.
+    The rename aligns the column names with their actual purpose.
+    """
+    conn.execute("ALTER TABLE tasks RENAME COLUMN epic_key TO cat_key")
+    conn.execute("ALTER TABLE tasks RENAME COLUMN epic_seq TO cat_seq")
+    conn.execute("DROP INDEX IF EXISTS idx_tasks_epic_key")
+    conn.execute("DROP INDEX IF EXISTS idx_tasks_epic_seq")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_cat_key ON tasks(cat_key)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_cat_seq ON tasks(cat_seq)")
+    conn.commit()
+
+
 # List of all migrations in order
 MIGRATIONS: list[tuple[str, str, Callable]] = [
     ("0", "Create documents table", migration_000_create_documents_table),
@@ -3206,6 +3223,11 @@ MIGRATIONS: list[tuple[str, str, Callable]] = [
         "20260302_160000",
         "Add index on wiki_articles.quality_score",
         migration_20260302_160000_add_wiki_quality_index,
+    ),
+    (
+        "20260413_000000",
+        "Rename epic_key/epic_seq to cat_key/cat_seq",
+        migration_20260413_000000_rename_epic_key_to_cat_key,
     ),
 ]
 

--- a/emdx/models/categories.py
+++ b/emdx/models/categories.py
@@ -40,15 +40,15 @@ def list_categories() -> list[Category]:
         cursor = conn.execute("""
             SELECT
                 c.key, c.name, c.description, c.created_at,
-                COUNT(CASE WHEN t.epic_seq IS NOT NULL
+                COUNT(CASE WHEN t.cat_seq IS NOT NULL
                     AND t.status IN ('open', 'active', 'blocked')
                     THEN 1 END) as open_count,
-                COUNT(CASE WHEN t.epic_seq IS NOT NULL
+                COUNT(CASE WHEN t.cat_seq IS NOT NULL
                     AND t.status = 'done' THEN 1 END) as done_count,
                 COUNT(CASE WHEN t.type = 'epic' THEN 1 END) as epic_count,
-                COUNT(CASE WHEN t.epic_seq IS NOT NULL THEN 1 END) as total_count
+                COUNT(CASE WHEN t.cat_seq IS NOT NULL THEN 1 END) as total_count
             FROM categories c
-            LEFT JOIN tasks t ON t.epic_key = c.key
+            LEFT JOIN tasks t ON t.cat_key = c.key
             GROUP BY c.key
             ORDER BY c.key
         """)
@@ -77,7 +77,7 @@ def delete_category(key: str, force: bool = False) -> dict[str, int]:
     """Delete a category and handle orphaned tasks.
 
     If force=False (default), refuses to delete if open/active tasks exist.
-    If force=True, clears epic_key/epic_seq on all associated tasks, then deletes.
+    If force=True, clears cat_key/cat_seq on all associated tasks, then deletes.
 
     Returns dict with counts: tasks_cleared, epics_cleared.
     Raises ValueError if category not found or has open tasks (when not forced).
@@ -90,7 +90,7 @@ def delete_category(key: str, force: bool = False) -> dict[str, int]:
     with db.get_connection() as conn:
         # Count open/active tasks in this category
         cursor = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE epic_key = ? AND status IN ('open', 'active')",
+            "SELECT COUNT(*) FROM tasks WHERE cat_key = ? AND status IN ('open', 'active')",
             (key,),
         )
         open_count = cursor.fetchone()[0]
@@ -103,20 +103,20 @@ def delete_category(key: str, force: bool = False) -> dict[str, int]:
 
         # Count tasks and epics that will be affected
         cursor = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE epic_key = ? AND type != 'epic'",
+            "SELECT COUNT(*) FROM tasks WHERE cat_key = ? AND type != 'epic'",
             (key,),
         )
         tasks_cleared = cursor.fetchone()[0]
 
         cursor = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE epic_key = ? AND type = 'epic'",
+            "SELECT COUNT(*) FROM tasks WHERE cat_key = ? AND type = 'epic'",
             (key,),
         )
         epics_cleared = cursor.fetchone()[0]
 
-        # Clear epic_key/epic_seq on all associated tasks (don't delete the tasks)
+        # Clear cat_key/cat_seq on all associated tasks (don't delete the tasks)
         conn.execute(
-            "UPDATE tasks SET epic_key = NULL, epic_seq = NULL WHERE epic_key = ?",
+            "UPDATE tasks SET cat_key = NULL, cat_seq = NULL WHERE cat_key = ?",
             (key,),
         )
 
@@ -130,8 +130,8 @@ def delete_category(key: str, force: bool = False) -> dict[str, int]:
 def adopt_category(key: str, name: str | None = None) -> dict[str, int]:
     """Backfill existing tasks with KEY-N: titles into the category system.
 
-    Scans tasks where title matches '{KEY}-N:' pattern and sets epic_key/epic_seq.
-    Also detects parent epic tasks titled 'EPIC: ...' and sets their type/epic_key.
+    Scans tasks where title matches '{KEY}-N:' pattern and sets cat_key/cat_seq.
+    Also detects parent epic tasks titled 'EPIC: ...' and sets their type/cat_key.
 
     Returns dict with counts: adopted, skipped, epics_found.
     """
@@ -156,7 +156,7 @@ def adopt_category(key: str, name: str | None = None) -> dict[str, int]:
 
     with db.get_connection() as conn:
         # Find tasks matching KEY-N: pattern that aren't already adopted
-        cursor = conn.execute("SELECT id, title, parent_task_id FROM tasks WHERE epic_key IS NULL")
+        cursor = conn.execute("SELECT id, title, parent_task_id FROM tasks WHERE cat_key IS NULL")
         rows = cursor.fetchall()
 
         for row in rows:
@@ -165,14 +165,14 @@ def adopt_category(key: str, name: str | None = None) -> dict[str, int]:
                 seq = int(m.group(1))
                 # Check for conflicts
                 conflict = conn.execute(
-                    "SELECT id FROM tasks WHERE epic_key = ? AND epic_seq = ?",
+                    "SELECT id FROM tasks WHERE cat_key = ? AND cat_seq = ?",
                     (key, seq),
                 ).fetchone()
                 if conflict:
                     skipped += 1
                     continue
                 conn.execute(
-                    "UPDATE tasks SET epic_key = ?, epic_seq = ? WHERE id = ?",
+                    "UPDATE tasks SET cat_key = ?, cat_seq = ? WHERE id = ?",
                     (key, seq, row["id"]),
                 )
                 adopted += 1
@@ -180,18 +180,18 @@ def adopt_category(key: str, name: str | None = None) -> dict[str, int]:
         # Find parent epic tasks (title starts with "EPIC:")
         epic_cursor = conn.execute(
             "SELECT DISTINCT parent_task_id FROM tasks "
-            "WHERE epic_key = ? AND parent_task_id IS NOT NULL",
+            "WHERE cat_key = ? AND parent_task_id IS NOT NULL",
             (key,),
         )
         parent_ids = [r["parent_task_id"] for r in epic_cursor.fetchall()]
 
         for pid in parent_ids:
             parent = conn.execute(
-                "SELECT id, type, epic_key FROM tasks WHERE id = ?", (pid,)
+                "SELECT id, type, cat_key FROM tasks WHERE id = ?", (pid,)
             ).fetchone()
-            if parent and parent["epic_key"] is None:
+            if parent and parent["cat_key"] is None:
                 conn.execute(
-                    "UPDATE tasks SET type = 'epic', epic_key = ? WHERE id = ?",
+                    "UPDATE tasks SET type = 'epic', cat_key = ? WHERE id = ?",
                     (key, pid),
                 )
                 epics_found += 1
@@ -239,16 +239,16 @@ def rename_category(
     title_pattern = re.compile(rf"^{re.escape(old_key)}-(\d+):\s*")
 
     with db.get_connection() as conn:
-        # Find the max existing epic_seq in the target category
+        # Find the max existing cat_seq in the target category
         cursor = conn.execute(
-            "SELECT COALESCE(MAX(epic_seq), 0) FROM tasks WHERE epic_key = ?",
+            "SELECT COALESCE(MAX(cat_seq), 0) FROM tasks WHERE cat_key = ?",
             (new_key,),
         )
         next_seq = cursor.fetchone()[0] + 1
 
         # Get all tasks in the old category (epics and regular tasks)
         cursor = conn.execute(
-            "SELECT id, title, type FROM tasks WHERE epic_key = ? ORDER BY epic_seq",
+            "SELECT id, title, type FROM tasks WHERE cat_key = ? ORDER BY cat_seq",
             (old_key,),
         )
         rows = cursor.fetchall()
@@ -267,7 +267,7 @@ def rename_category(
                 new_title = f"{new_key}-{seq}: {new_title[m.end() :]}"
 
             conn.execute(
-                "UPDATE tasks SET epic_key = ?, epic_seq = ?, title = ? WHERE id = ?",
+                "UPDATE tasks SET cat_key = ?, cat_seq = ?, title = ? WHERE id = ?",
                 (new_key, seq, new_title, row["id"]),
             )
 

--- a/emdx/models/task.py
+++ b/emdx/models/task.py
@@ -45,8 +45,8 @@ class Task:
     source_doc_id: int | None = None
     output_doc_id: int | None = None
     parent_task_id: int | None = None
-    epic_key: str | None = None
-    epic_seq: int | None = None
+    cat_key: str | None = None
+    cat_seq: int | None = None
 
     # Epic-specific fields (populated by epic queries, default to 0)
     child_count: int = 0

--- a/emdx/models/tasks.py
+++ b/emdx/models/tasks.py
@@ -29,36 +29,36 @@ def create_task(
     parent_task_id: int | None = None,
     task_type: str = "single",
     status: str = "open",
-    epic_key: str | None = None,
+    cat_key: str | None = None,
 ) -> int:
     """Create task and return its ID.
 
-    When epic_key is set:
+    When cat_key is set:
       - Auto-creates category if needed
-      - Assigns next epic_seq (epics and tasks share one sequence)
+      - Assigns next cat_seq (epics and tasks share one sequence)
       - Prepends "KEY-N: " to title for non-epic tasks only
     """
-    epic_seq_val = None
+    cat_seq_val = None
 
-    if epic_key:
+    if cat_key:
         from emdx.models.categories import ensure_category
 
-        epic_key = ensure_category(epic_key.upper())
+        cat_key = ensure_category(cat_key.upper())
 
     with db.get_connection() as conn:
         cursor = conn.cursor()
 
         # Auto-number tasks within a category (epics and regular tasks share one sequence)
-        if epic_key:
+        if cat_key:
             cursor.execute(
-                "SELECT COALESCE(MAX(epic_seq), 0) + 1 FROM tasks WHERE epic_key = ?",
-                (epic_key,),
+                "SELECT COALESCE(MAX(cat_seq), 0) + 1 FROM tasks WHERE cat_key = ?",
+                (cat_key,),
             )
             seq_result = cursor.fetchone()
-            epic_seq_val = seq_result[0] if seq_result else 1
+            cat_seq_val = seq_result[0] if seq_result else 1
             # Prepend KEY-N: prefix to non-epic tasks only (epics use their title as-is)
             if task_type != "epic":
-                prefix = f"{epic_key}-{epic_seq_val}: "
+                prefix = f"{cat_key}-{cat_seq_val}: "
                 if not title.startswith(prefix):
                     title = f"{prefix}{title}"
 
@@ -67,7 +67,7 @@ def create_task(
             INSERT INTO tasks (
                 title, description, priority, gameplan_id, project, status,
                 type, source_doc_id, output_doc_id, parent_task_id,
-                epic_key, epic_seq
+                cat_key, cat_seq
             )
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
@@ -82,8 +82,8 @@ def create_task(
                 source_doc_id,
                 output_doc_id,
                 parent_task_id,
-                epic_key,
-                epic_seq_val,
+                cat_key,
+                cat_seq_val,
             ),
         )
         task_id = cursor.lastrowid
@@ -105,7 +105,7 @@ def create_epic(name: str, category_key: str, description: str = "") -> int:
         title=name,
         description=description,
         task_type="epic",
-        epic_key=category_key.upper(),
+        cat_key=category_key.upper(),
     )
 
 
@@ -175,12 +175,12 @@ def resolve_task_id(identifier: TaskRef) -> int | None:
     """Resolve a task identifier to a database ID.
 
     Accepts:
-      - Category-prefixed IDs like "TOOL-12" (looks up by epic_key + epic_seq)
+      - Category-prefixed IDs like "TOOL-12" (looks up by cat_key + cat_seq)
       - Raw integer IDs like "42" or "#42"
 
     For bare integers, first checks if a task with that database ID exists.
-    If not, falls back to searching by epic_seq (e.g. "49" might match TOOL-49).
-    When the epic_seq fallback finds exactly one match, returns it.
+    If not, falls back to searching by cat_seq (e.g. "49" might match TOOL-49).
+    When the cat_seq fallback finds exactly one match, returns it.
 
     Returns the database ID, or None if the format is invalid or task not found.
     """
@@ -194,8 +194,8 @@ def resolve_task_id(identifier: TaskRef) -> int | None:
             cursor = conn.execute("SELECT id FROM tasks WHERE id = ?", (int_id,))
             if cursor.fetchone():
                 return int_id
-            # Fall back: look for a task with this epic_seq number
-            cursor = conn.execute("SELECT id FROM tasks WHERE epic_seq = ?", (int_id,))
+            # Fall back: look for a task with this cat_seq number
+            cursor = conn.execute("SELECT id FROM tasks WHERE cat_seq = ?", (int_id,))
             rows = cursor.fetchall()
             if len(rows) == 1:
                 return int(rows[0][0])
@@ -204,12 +204,12 @@ def resolve_task_id(identifier: TaskRef) -> int | None:
     # Try category-prefixed format (e.g. TOOL-12)
     match = _PREFIXED_ID_RE.match(identifier)
     if match:
-        epic_key = match.group(1).upper()
-        epic_seq = int(match.group(2))
+        cat_key = match.group(1).upper()
+        cat_seq = int(match.group(2))
         with db.get_connection() as conn:
             cursor = conn.execute(
-                "SELECT id FROM tasks WHERE epic_key = ? AND epic_seq = ?",
-                (epic_key, epic_seq),
+                "SELECT id FROM tasks WHERE cat_key = ? AND cat_seq = ?",
+                (cat_key, cat_seq),
             )
             row = cursor.fetchone()
             if row:
@@ -230,14 +230,14 @@ def list_tasks(
     gameplan_id: int | None = None,
     project: str | None = None,
     limit: int = DEFAULT_BROWSE_LIMIT,
-    epic_key: str | None = None,
+    cat_key: str | None = None,
     parent_task_id: int | None = None,
     since: str | None = None,
 ) -> list[Task]:
     """List tasks with filters.
 
     Args:
-        epic_key: Filter by category key.
+        cat_key: Filter by category key.
         parent_task_id: Filter by parent task (epic) ID.
         since: ISO date string (YYYY-MM-DD). Filter to tasks completed on or after this date.
     """
@@ -253,9 +253,9 @@ def list_tasks(
     if project:
         conditions.append("project = ?")
         params.append(project)
-    if epic_key:
-        conditions.append("epic_key = ?")
-        params.append(epic_key.upper())
+    if cat_key:
+        conditions.append("cat_key = ?")
+        params.append(cat_key.upper())
     if parent_task_id is not None:
         conditions.append("parent_task_id = ?")
         params.append(parent_task_id)
@@ -304,8 +304,8 @@ ALLOWED_UPDATE_COLUMNS = frozenset(
         "source_doc_id",
         "output_doc_id",
         "parent_task_id",
-        "epic_key",
-        "epic_seq",
+        "cat_key",
+        "cat_seq",
     }
 )
 
@@ -395,12 +395,12 @@ def get_dependents(task_id: int) -> list[Task]:
 
 def get_ready_tasks(
     gameplan_id: int | None = None,
-    epic_key: str | None = None,
+    cat_key: str | None = None,
 ) -> list[Task]:
     """Get tasks ready to work (open + all deps done).
 
     Args:
-        epic_key: Filter by category key.
+        cat_key: Filter by category key.
     """
     conditions = ["t.status = 'open'"]
     params: list[str | int | None] = []
@@ -408,9 +408,9 @@ def get_ready_tasks(
     if gameplan_id:
         conditions.append("t.gameplan_id = ?")
         params.append(gameplan_id)
-    if epic_key:
-        conditions.append("t.epic_key = ?")
-        params.append(epic_key.upper())
+    if cat_key:
+        conditions.append("t.cat_key = ?")
+        params.append(cat_key.upper())
 
     with db.get_connection() as conn:
         cursor = conn.execute(
@@ -529,7 +529,7 @@ def list_epics(
     params = []
 
     if category_key:
-        conditions.append("t.epic_key = ?")
+        conditions.append("t.cat_key = ?")
         params.append(category_key.upper())
     if status:
         conditions.append(f"t.status IN ({','.join('?' * len(status))})")
@@ -572,7 +572,7 @@ def get_epic_view(epic_id: int) -> Task | None:
             """
             SELECT * FROM tasks
             WHERE parent_task_id = ?
-            ORDER BY epic_seq, id
+            ORDER BY cat_seq, id
         """,
             (epic_id,),
         )
@@ -585,7 +585,7 @@ def attach_to_epic(task_ids: list[int], epic_id: int) -> int:
     """Attach existing tasks to an epic.
 
     Sets parent_task_id and inherits the epic's category key.
-    Assigns next epic_seq for tasks that don't already have one in this category.
+    Assigns next cat_seq for tasks that don't already have one in this category.
 
     Returns the number of tasks attached.
     Raises ValueError if the epic doesn't exist or isn't an epic.
@@ -599,7 +599,7 @@ def attach_to_epic(task_ids: list[int], epic_id: int) -> int:
         if not epic_row:
             raise ValueError(f"Epic #{epic_id} not found or is not an epic")
 
-        epic_key = epic_row["epic_key"]
+        cat_key = epic_row["cat_key"]
         attached = 0
 
         for tid in task_ids:
@@ -614,15 +614,15 @@ def attach_to_epic(task_ids: list[int], epic_id: int) -> int:
 
             updates = {"parent_task_id": epic_id}
 
-            # Assign epic_key and next epic_seq if needed
-            if epic_key and task_row["epic_key"] != epic_key:
+            # Assign cat_key and next cat_seq if needed
+            if cat_key and task_row["cat_key"] != cat_key:
                 seq_cursor = conn.execute(
-                    "SELECT COALESCE(MAX(epic_seq), 0) + 1 FROM tasks WHERE epic_key = ?",
-                    (epic_key,),
+                    "SELECT COALESCE(MAX(cat_seq), 0) + 1 FROM tasks WHERE cat_key = ?",
+                    (cat_key,),
                 )
                 next_seq = seq_cursor.fetchone()[0]
-                updates["epic_key"] = epic_key
-                updates["epic_seq"] = next_seq
+                updates["cat_key"] = cat_key
+                updates["cat_seq"] = next_seq
 
             set_clause = ", ".join(f"{k} = ?" for k in updates)
             params = list(updates.values()) + [tid]

--- a/emdx/onboarding.py
+++ b/emdx/onboarding.py
@@ -181,7 +181,7 @@ def maybe_seed_onboarding() -> None:
             title=title,
             description=description,
             parent_task_id=epic_id,
-            epic_key="START",
+            cat_key="START",
         )
 
     _set_seeded()

--- a/emdx/ui/task_view.py
+++ b/emdx/ui/task_view.py
@@ -143,10 +143,10 @@ def _priority_style(priority: int) -> str:
     return "dim"
 
 
-def _strip_epic_prefix(title: str, epic_key: str | None, epic_seq: int | None) -> str:
+def _strip_epic_prefix(title: str, cat_key: str | None, cat_seq: int | None) -> str:
     """Strip the 'KEY-N: ' prefix from a title if it matches the epic."""
-    if epic_key and epic_seq:
-        prefix = f"{epic_key}-{epic_seq}: "
+    if cat_key and cat_seq:
+        prefix = f"{cat_key}-{cat_seq}: "
         if title.startswith(prefix):
             return title[len(prefix) :]
     return title
@@ -154,12 +154,12 @@ def _strip_epic_prefix(title: str, epic_key: str | None, epic_seq: int | None) -
 
 def _task_badge(task: Task) -> str:
     """Return the KEY-N badge for a task, or empty string if unavailable."""
-    epic_key = task.epic_key
-    epic_seq = task.epic_seq
-    if epic_key and epic_seq:
-        return f"{epic_key}-{epic_seq}"
-    if epic_key:
-        return str(epic_key)
+    cat_key = task.cat_key
+    cat_seq = task.cat_seq
+    if cat_key and cat_seq:
+        return f"{cat_key}-{cat_seq}"
+    if cat_key:
+        return str(cat_key)
     return ""
 
 
@@ -167,7 +167,7 @@ def _task_label(task: Task) -> str:
     """Build a plain text label for tests and fallback display."""
     icon = STATUS_ICONS.get(task.status, "?")
     title = task.title
-    title = _strip_epic_prefix(title, task.epic_key, task.epic_seq)
+    title = _strip_epic_prefix(title, task.cat_key, task.cat_seq)
     if len(title) > 50:
         title = title[:47] + "..."
     return f"{icon} {title}"
@@ -607,24 +607,24 @@ class TaskView(Widget):
         icon = "📋" if is_parent else STATUS_ICONS.get(task.status, "?")
         title = _strip_epic_prefix(
             task.title,
-            task.epic_key,
-            task.epic_seq,
+            task.cat_key,
+            task.cat_seq,
         )
         # Epic badge: parents and children show "KEY-N" colored by status
-        epic_key = task.epic_key
-        epic_seq = task.epic_seq
+        cat_key = task.cat_key
+        cat_seq = task.cat_seq
         badge_color = color or "cyan"
         bold_badge = f"bold {badge_color}" if badge_color else "bold"
-        if is_parent and epic_key and epic_seq:
-            epic_text = Text(f"{epic_key}-{epic_seq}", style=bold_badge)
-        elif is_parent and epic_key:
-            epic_text = Text(epic_key, style=bold_badge)
+        if is_parent and cat_key and cat_seq:
+            epic_text = Text(f"{cat_key}-{cat_seq}", style=bold_badge)
+        elif is_parent and cat_key:
+            epic_text = Text(cat_key, style=bold_badge)
         elif is_parent:
             epic_text = Text("")
-        elif epic_key and epic_seq:
-            epic_text = Text(f"{epic_key}-{epic_seq}", style=badge_color)
-        elif epic_key:
-            epic_text = Text(epic_key, style=badge_color)
+        elif cat_key and cat_seq:
+            epic_text = Text(f"{cat_key}-{cat_seq}", style=badge_color)
+        elif cat_key:
+            epic_text = Text(cat_key, style=badge_color)
         else:
             epic_text = Text("")
 
@@ -719,7 +719,7 @@ class TaskView(Widget):
             for parent_id, children in cross_group_by_parent.items():
                 epic_data = self._epics.get(parent_id)
                 if epic_data:
-                    ek = epic_data.epic_key or ""
+                    ek = epic_data.cat_key or ""
                     done = epic_data.children_done
                     total = epic_data.child_count
                     ref_text = f"{ek} ({done}/{total} done)"
@@ -1152,7 +1152,7 @@ class TaskView(Widget):
         q = query.lower()
         fields = [
             task.title or "",
-            task.epic_key or "",
+            task.cat_key or "",
             task.description or "",
         ]
         return any(q in f.lower() for f in fields)
@@ -1161,7 +1161,7 @@ class TaskView(Widget):
         """Check if a task passes text, status, and epic filters."""
         if task.status in self._hidden_statuses:
             return False
-        if self._epic_filter and task.epic_key != self._epic_filter:
+        if self._epic_filter and task.cat_key != self._epic_filter:
             return False
         if self._filter_text and not self._task_matches_filter(task, self._filter_text):
             return False
@@ -1281,9 +1281,9 @@ class TaskView(Widget):
     def action_filter_epic(self) -> None:
         """Toggle epic filter to the current task's epic."""
         task = self._get_selected_task()
-        epic_key = task.epic_key if task else None
-        if epic_key and self._epic_filter != epic_key:
-            self._epic_filter = epic_key
+        cat_key = task.cat_key if task else None
+        if cat_key and self._epic_filter != cat_key:
+            self._epic_filter = cat_key
         else:
             self._epic_filter = None
         self._apply_filter()
@@ -1465,7 +1465,7 @@ class TaskView(Widget):
         header.update(header_label)
 
         # Title (strip KEY-N prefix since badge already shows it)
-        title = _strip_epic_prefix(task.title, task.epic_key, task.epic_seq)
+        title = _strip_epic_prefix(task.title, task.cat_key, task.cat_seq)
         detail_log.write(f"[bold]{title}[/bold]")
         detail_log.write("")
 
@@ -1503,15 +1503,15 @@ class TaskView(Widget):
             meta_parts.append(f"Priority: [yellow]{pri} !![/yellow]")
         else:
             meta_parts.append(f"Priority: {pri}")
-        if task.epic_key:
+        if task.cat_key:
             parent_id = task.parent_task_id
             epic = self._epics.get(parent_id) if parent_id else None
             if epic:
                 done = epic.children_done
                 total = epic.child_count
-                meta_parts.append(f"Epic: [cyan]{task.epic_key}[/cyan] ({done}/{total} done)")
+                meta_parts.append(f"Epic: [cyan]{task.cat_key}[/cyan] ({done}/{total} done)")
             else:
-                meta_parts.append(f"Epic: [cyan]{task.epic_key}[/cyan]")
+                meta_parts.append(f"Epic: [cyan]{task.cat_key}[/cyan]")
         target.write("  ".join(meta_parts))
 
         # Timestamps
@@ -1603,12 +1603,12 @@ class TaskView(Widget):
         header.update(epic_header)
 
         # Title (strip KEY-N prefix since badge already shows it)
-        title = _strip_epic_prefix(task.title, task.epic_key, task.epic_seq)
+        title = _strip_epic_prefix(task.title, task.cat_key, task.cat_seq)
         detail_log.write(f"[bold]{title}[/bold]")
         detail_log.write("")
 
         # Progress summary from cached epic data
-        epic_key = task.epic_key
+        cat_key = task.cat_key
         epic_data = self._epics.get(task.id)
         if epic_data:
             done = epic_data.children_done
@@ -1642,9 +1642,9 @@ class TaskView(Widget):
                 for child in epic_view.children:
                     c_icon = STATUS_ICONS.get(child.status, "?")
                     c_color = STATUS_COLORS.get(child.status, "")
-                    c_title = _strip_epic_prefix(child.title, child.epic_key, child.epic_seq)[:55]
-                    seq = child.epic_seq
-                    prefix = f"{epic_key}-{seq}" if epic_key and seq else ""
+                    c_title = _strip_epic_prefix(child.title, child.cat_key, child.cat_seq)[:55]
+                    seq = child.cat_seq
+                    prefix = f"{cat_key}-{seq}" if cat_key and seq else ""
                     if c_color:
                         detail_log.write(
                             f"  [{c_color}]{c_icon}[/{c_color}] "

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -74,8 +74,8 @@ class TestListCategories:
     def test_list_categories_with_counts(self):
         categories.ensure_category("LCNT")
         # Create some tasks in this category
-        tasks.create_task("LCNT-1: First task", epic_key="LCNT")
-        tasks.create_task("LCNT-2: Second task", epic_key="LCNT", status="done")
+        tasks.create_task("LCNT-1: First task", cat_key="LCNT")
+        tasks.create_task("LCNT-2: Second task", cat_key="LCNT", status="done")
 
         cats = categories.list_categories()
         lcnt = next((c for c in cats if c.key == "LCNT"), None)
@@ -97,29 +97,29 @@ class TestDeleteCategory:
 
     def test_delete_category_with_done_tasks(self):
         categories.create_category("DDNE", "Done Tasks")
-        t1 = tasks.create_task("Task 1", epic_key="DDNE", status="done")
+        t1 = tasks.create_task("Task 1", cat_key="DDNE", status="done")
         result = categories.delete_category("DDNE")
         assert result["tasks_cleared"] == 1
-        # Task still exists but epic_key is cleared
+        # Task still exists but cat_key is cleared
         task = tasks.get_task(t1)
         assert task is not None
-        assert task.epic_key is None
-        assert task.epic_seq is None
+        assert task.cat_key is None
+        assert task.cat_seq is None
 
     def test_delete_category_refuses_open_tasks(self):
         categories.create_category("DREF", "Has Open Tasks")
-        tasks.create_task("Open task", epic_key="DREF")
+        tasks.create_task("Open task", cat_key="DREF")
         with pytest.raises(ValueError, match="open/active task"):
             categories.delete_category("DREF")
 
     def test_delete_category_force_with_open_tasks(self):
         categories.create_category("DFRC", "Force Delete")
-        t1 = tasks.create_task("Open task", epic_key="DFRC")
+        t1 = tasks.create_task("Open task", cat_key="DFRC")
         result = categories.delete_category("DFRC", force=True)
         assert result["tasks_cleared"] == 1
         assert categories.get_category("DFRC") is None
         task = tasks.get_task(t1)
-        assert task.epic_key is None
+        assert task.cat_key is None
 
     def test_delete_category_clears_epics(self):
         categories.create_category("DEPC", "With Epics")
@@ -129,7 +129,7 @@ class TestDeleteCategory:
         assert result["epics_cleared"] == 1
         epic = tasks.get_task(epic_id)
         assert epic is not None
-        assert epic.epic_key is None
+        assert epic.cat_key is None
 
     def test_delete_category_not_found(self):
         with pytest.raises(ValueError, match="not found"):
@@ -146,7 +146,7 @@ class TestAdoptCategory:
     """Tests for adopt_category."""
 
     def test_adopt_backfills(self):
-        # Create tasks with KEY-N: pattern in their title (no epic_key set)
+        # Create tasks with KEY-N: pattern in their title (no cat_key set)
         t1 = tasks.create_task("ADPT-1: First adopted task")
         t2 = tasks.create_task("ADPT-2: Second adopted task")
 
@@ -154,18 +154,18 @@ class TestAdoptCategory:
         assert result["adopted"] == 2
         assert result["skipped"] == 0
 
-        # Verify tasks now have epic_key/epic_seq
+        # Verify tasks now have cat_key/cat_seq
         task1 = tasks.get_task(t1)
-        assert task1.epic_key == "ADPT"
-        assert task1.epic_seq == 1
+        assert task1.cat_key == "ADPT"
+        assert task1.cat_seq == 1
 
         task2 = tasks.get_task(t2)
-        assert task2.epic_key == "ADPT"
-        assert task2.epic_seq == 2
+        assert task2.cat_key == "ADPT"
+        assert task2.cat_seq == 2
 
     def test_adopt_skips_already_adopted(self):
-        # Create a task that already has epic_key
-        tasks.create_task("SKIP-1: Already adopted", epic_key="SKIP")
+        # Create a task that already has cat_key
+        tasks.create_task("SKIP-1: Already adopted", cat_key="SKIP")
 
         # Adopt should not try to re-adopt
         result = categories.adopt_category("SKIP")
@@ -184,8 +184,8 @@ class TestRenameCategory:
     def test_rename_simple(self):
         """Rename with no target existing — creates target, moves tasks, deletes source."""
         categories.create_category("RNOLD", "Old Name")
-        t1 = tasks.create_task("Task 1", epic_key="RNOLD")
-        t2 = tasks.create_task("Task 2", epic_key="RNOLD")
+        t1 = tasks.create_task("Task 1", cat_key="RNOLD")
+        t2 = tasks.create_task("Task 2", cat_key="RNOLD")
 
         result = categories.rename_category("RNOLD", "RNNEW")
         assert result["tasks_moved"] == 2
@@ -199,37 +199,37 @@ class TestRenameCategory:
 
         # Tasks moved and retitled
         task1 = tasks.get_task(t1)
-        assert task1.epic_key == "RNNEW"
+        assert task1.cat_key == "RNNEW"
         assert "RNNEW-" in task1.title
 
         task2 = tasks.get_task(t2)
-        assert task2.epic_key == "RNNEW"
+        assert task2.cat_key == "RNNEW"
         assert "RNNEW-" in task2.title
 
     def test_rename_merge_renumbers(self):
         """Merge into existing category — renumbers to avoid seq conflicts."""
         categories.create_category("MROLD", "Old")
         categories.create_category("MRNEW", "New")
-        t_old = tasks.create_task("Task A", epic_key="MROLD")
-        t_new = tasks.create_task("Task B", epic_key="MRNEW")
+        t_old = tasks.create_task("Task A", cat_key="MROLD")
+        t_new = tasks.create_task("Task B", cat_key="MRNEW")
 
         # t_new should have seq 1, t_old should get seq 2 after merge
         result = categories.rename_category("MROLD", "MRNEW")
         assert result["tasks_moved"] == 1
 
         task_old = tasks.get_task(t_old)
-        assert task_old.epic_key == "MRNEW"
-        assert task_old.epic_seq == 2  # after existing seq 1
+        assert task_old.cat_key == "MRNEW"
+        assert task_old.cat_seq == 2  # after existing seq 1
 
         # Original target task unchanged
         task_new = tasks.get_task(t_new)
-        assert task_new.epic_key == "MRNEW"
-        assert task_new.epic_seq == 1
+        assert task_new.cat_key == "MRNEW"
+        assert task_new.cat_seq == 1
 
     def test_rename_with_name_override(self):
         """--name overrides the target category name."""
         categories.create_category("NMOLD", "Old Name")
-        tasks.create_task("Task", epic_key="NMOLD")
+        tasks.create_task("Task", cat_key="NMOLD")
 
         categories.rename_category("NMOLD", "NMNEW", name="Better Name")
         cat = categories.get_category("NMNEW")
@@ -239,14 +239,14 @@ class TestRenameCategory:
         """Epics are moved along with regular tasks."""
         categories.create_category("EPOLD", "Old")
         epic_id = tasks.create_epic("Test Epic", "EPOLD")
-        tasks.create_task("Task 1", epic_key="EPOLD")
+        tasks.create_task("Task 1", cat_key="EPOLD")
 
         result = categories.rename_category("EPOLD", "EPNEW")
         assert result["epics_moved"] == 1
         assert result["tasks_moved"] == 1
 
         epic = tasks.get_task(epic_id)
-        assert epic.epic_key == "EPNEW"
+        assert epic.cat_key == "EPNEW"
 
     def test_rename_same_key_raises(self):
         categories.create_category("SAME", "Same")
@@ -264,7 +264,7 @@ class TestRenameCategory:
 
     def test_rename_case_insensitive(self):
         categories.create_category("CSOLD", "Case Test")
-        tasks.create_task("Task", epic_key="CSOLD")
+        tasks.create_task("Task", cat_key="CSOLD")
         result = categories.rename_category("csold", "csnew")
         assert result["tasks_moved"] == 1
         assert categories.get_category("CSNEW") is not None
@@ -304,14 +304,14 @@ class TestCategoriesCLI:
 
     def test_delete_command_refuses_open(self):
         categories.create_category("CDRJ", "CLI Refuse")
-        tasks.create_task("Open task", epic_key="CDRJ")
+        tasks.create_task("Open task", cat_key="CDRJ")
         result = runner.invoke(app, ["delete", "CDRJ"])
         assert result.exit_code == 1
         assert "open/active" in _out(result)
 
     def test_delete_command_force(self):
         categories.create_category("CDFF", "CLI Force")
-        tasks.create_task("Open task", epic_key="CDFF")
+        tasks.create_task("Open task", cat_key="CDFF")
         result = runner.invoke(app, ["delete", "CDFF", "--force"])
         assert result.exit_code == 0
         assert "Deleted" in _out(result)
@@ -325,7 +325,7 @@ class TestCategoriesCLI:
 
     def test_rename_command(self):
         categories.create_category("CRNO", "CLI Rename Old")
-        tasks.create_task("Task", epic_key="CRNO")
+        tasks.create_task("Task", cat_key="CRNO")
         result = runner.invoke(app, ["rename", "CRNO", "CRNN"])
         assert result.exit_code == 0
         out = _out(result)

--- a/tests/test_commands_prime.py
+++ b/tests/test_commands_prime.py
@@ -31,8 +31,8 @@ def _make_task(
     priority=5,
     status="open",
     source_doc_id=None,
-    epic_key=None,
-    epic_seq=None,
+    cat_key=None,
+    cat_seq=None,
 ):
     return {
         "id": id,
@@ -41,19 +41,19 @@ def _make_task(
         "priority": priority,
         "status": status,
         "source_doc_id": source_doc_id,
-        "epic_key": epic_key,
-        "epic_seq": epic_seq,
+        "cat_key": cat_key,
+        "cat_seq": cat_seq,
     }
 
 
 def _make_epic(
-    id=100, title="My Epic", status="active", epic_key="SEC", child_count=5, children_done=2
+    id=100, title="My Epic", status="active", cat_key="SEC", child_count=5, children_done=2
 ):
     return {
         "id": id,
         "title": title,
         "status": status,
-        "epic_key": epic_key,
+        "cat_key": cat_key,
         "child_count": child_count,
         "children_done": children_done,
     }
@@ -70,11 +70,11 @@ class TestTaskLabel:
         assert label.strip() == "#42"
 
     def test_epic_task_shows_key_seq(self):
-        label = _task_label(_make_task(id=449, epic_key="DEBT", epic_seq=10))
+        label = _task_label(_make_task(id=449, cat_key="DEBT", cat_seq=10))
         assert label.strip() == "DEBT-10"
 
-    def test_epic_key_without_seq_falls_back_to_id(self):
-        label = _task_label(_make_task(id=500, epic_key="SEC", epic_seq=None))
+    def test_cat_key_without_seq_falls_back_to_id(self):
+        label = _task_label(_make_task(id=500, cat_key="SEC", cat_seq=None))
         assert label.strip() == "#500"
 
     def test_label_is_padded(self):
@@ -164,7 +164,7 @@ class TestPrimeDefault:
         mock_epics.return_value = []
         mock_ready.return_value = [
             _make_task(id=10, title="Fix the bug"),
-            _make_task(id=449, title="DEBT-10: Fix type safety", epic_key="DEBT", epic_seq=10),
+            _make_task(id=449, title="DEBT-10: Fix type safety", cat_key="DEBT", cat_seq=10),
         ]
         mock_ip.return_value = []
 
@@ -195,7 +195,7 @@ class TestPrimeDefault:
     @patch("emdx.commands.prime.get_git_project")
     def test_shows_active_epics(self, mock_project, mock_ip, mock_ready, mock_epics):
         mock_project.return_value = None
-        mock_epics.return_value = [_make_epic(epic_key="SEC", title="Security Hardening")]
+        mock_epics.return_value = [_make_epic(cat_key="SEC", title="Security Hardening")]
         mock_ready.return_value = []
         mock_ip.return_value = []
 
@@ -659,13 +659,13 @@ class TestPrimeWithKeyDocs:
 class TestFormatEpicBrief:
     def test_shows_key_and_progress(self):
         line = _format_epic_brief(
-            _make_epic(epic_key="FEAT", title="Next Intelligence", child_count=18, children_done=3)
+            _make_epic(cat_key="FEAT", title="Next Intelligence", child_count=18, children_done=3)
         )
         assert "FEAT: Next Intelligence" in line
         assert "3/18 done" in line
 
-    def test_no_epic_key(self):
-        epic = _make_epic(epic_key=None, title="Cleanup", child_count=5, children_done=2)
+    def test_no_cat_key(self):
+        epic = _make_epic(cat_key=None, title="Cleanup", child_count=5, children_done=2)
         line = _format_epic_brief(epic)
         assert "Cleanup" in line
         assert "2/5 done" in line
@@ -705,7 +705,7 @@ class TestPrimeBrief:
         mock_project.return_value = None
         mock_epics.return_value = [
             _make_epic(
-                epic_key="FEAT",
+                cat_key="FEAT",
                 title="Next Intelligence",
                 child_count=18,
                 children_done=3,

--- a/tests/test_epics.py
+++ b/tests/test_epics.py
@@ -27,8 +27,8 @@ class TestCreateEpic:
         epic = tasks.get_task(epic_id)
         assert epic is not None
         assert epic.type == "epic"
-        assert epic.epic_key == "TEPC"
-        assert epic.epic_seq == 1  # epics get KEY-N like regular tasks
+        assert epic.cat_key == "TEPC"
+        assert epic.cat_seq == 1  # epics get KEY-N like regular tasks
 
     def test_create_epic_auto_creates_category(self) -> None:
         tasks.create_epic("Auto Cat Epic", "ACAT")
@@ -54,27 +54,27 @@ class TestTaskInEpic:
         task_id = tasks.create_task(
             "Do something",
             parent_task_id=epic_id,
-            epic_key="TPIC",
+            cat_key="TPIC",
         )
         task = tasks.get_task(task_id)
         assert task is not None
         assert task.parent_task_id == epic_id
-        assert task.epic_key == "TPIC"
-        assert task.epic_seq == 2  # epic took seq 1
+        assert task.cat_key == "TPIC"
+        assert task.cat_seq == 2  # epic took seq 1
         assert task.title.startswith("TPIC-2: ")
 
     def test_epic_auto_numbers(self) -> None:
         categories.ensure_category("ENUM")
-        t1 = tasks.create_task("First", epic_key="ENUM")
-        t2 = tasks.create_task("Second", epic_key="ENUM")
-        t3 = tasks.create_task("Third", epic_key="ENUM")
+        t1 = tasks.create_task("First", cat_key="ENUM")
+        t2 = tasks.create_task("Second", cat_key="ENUM")
+        t3 = tasks.create_task("Third", cat_key="ENUM")
 
         task1, task2, task3 = tasks.get_task(t1), tasks.get_task(t2), tasks.get_task(t3)
         assert task1 is not None and task2 is not None and task3 is not None
 
-        assert task1.epic_seq == 1
-        assert task2.epic_seq == 2
-        assert task3.epic_seq == 3
+        assert task1.cat_seq == 1
+        assert task2.cat_seq == 2
+        assert task3.cat_seq == 3
 
         assert task1.title == "ENUM-1: First"
         assert task2.title == "ENUM-2: Second"
@@ -83,19 +83,19 @@ class TestTaskInEpic:
     def test_numbering_spans_epics(self) -> None:
         """Numbering is category-scoped, so it continues across epics."""
         epic_a = tasks.create_epic("Epic A", "SPAN")  # SPAN-1
-        tasks.create_task("Task in A", parent_task_id=epic_a, epic_key="SPAN")  # SPAN-2
-        tasks.create_task("Another in A", parent_task_id=epic_a, epic_key="SPAN")  # SPAN-3
+        tasks.create_task("Task in A", parent_task_id=epic_a, cat_key="SPAN")  # SPAN-2
+        tasks.create_task("Another in A", parent_task_id=epic_a, cat_key="SPAN")  # SPAN-3
 
         epic_b = tasks.create_epic("Epic B", "SPAN")  # SPAN-4
-        t5 = tasks.create_task("Task in B", parent_task_id=epic_b, epic_key="SPAN")  # SPAN-5
+        t5 = tasks.create_task("Task in B", parent_task_id=epic_b, cat_key="SPAN")  # SPAN-5
 
         epic_a_task = tasks.get_task(epic_a)
         epic_b_task = tasks.get_task(epic_b)
         task5 = tasks.get_task(t5)
         assert epic_a_task is not None and epic_b_task is not None and task5 is not None
-        assert epic_a_task.epic_seq == 1
-        assert epic_b_task.epic_seq == 4
-        assert task5.epic_seq == 5  # continues from epic_b's seq 4
+        assert epic_a_task.cat_seq == 1
+        assert epic_b_task.cat_seq == 4
+        assert task5.cat_seq == 5  # continues from epic_b's seq 4
         assert task5.title == "SPAN-5: Task in B"
 
 
@@ -121,7 +121,7 @@ class TestDeleteEpic:
 
     def test_delete_epic_with_done_children(self) -> None:
         epic_id = tasks.create_epic("Done Children Epic", "DDCH")
-        t1 = tasks.create_task("Done child", parent_task_id=epic_id, epic_key="DDCH", status="done")
+        t1 = tasks.create_task("Done child", parent_task_id=epic_id, cat_key="DDCH", status="done")
         result = tasks.delete_epic(epic_id)
         assert result["children_unlinked"] == 1
         # Child still exists but parent_task_id is cleared
@@ -131,13 +131,13 @@ class TestDeleteEpic:
 
     def test_delete_epic_refuses_open_children(self) -> None:
         epic_id = tasks.create_epic("Open Children Epic", "DOCH")
-        tasks.create_task("Open child", parent_task_id=epic_id, epic_key="DOCH")
+        tasks.create_task("Open child", parent_task_id=epic_id, cat_key="DOCH")
         with pytest.raises(ValueError, match="open/active child"):
             tasks.delete_epic(epic_id)
 
     def test_delete_epic_force_with_open_children(self) -> None:
         epic_id = tasks.create_epic("Force Delete Epic", "DFEP")
-        t1 = tasks.create_task("Open child", parent_task_id=epic_id, epic_key="DFEP")
+        t1 = tasks.create_task("Open child", parent_task_id=epic_id, cat_key="DFEP")
         result = tasks.delete_epic(epic_id, force=True)
         assert result["children_unlinked"] == 1
         assert tasks.get_task(epic_id) is None
@@ -163,7 +163,7 @@ class TestListEpics:
         tasks.create_epic("Other Epic", "OTHR")
 
         result = tasks.list_epics(category_key="FILT")
-        keys = [e.epic_key for e in result]
+        keys = [e.cat_key for e in result]
         assert "FILT" in keys
         assert "OTHR" not in keys
 
@@ -186,8 +186,8 @@ class TestEpicView:
 
     def test_epic_view_with_children(self) -> None:
         epic_id = tasks.create_epic("View Epic", "VIEW")
-        tasks.create_task("Child 1", parent_task_id=epic_id, epic_key="VIEW")
-        tasks.create_task("Child 2", parent_task_id=epic_id, epic_key="VIEW")
+        tasks.create_task("Child 1", parent_task_id=epic_id, cat_key="VIEW")
+        tasks.create_task("Child 2", parent_task_id=epic_id, cat_key="VIEW")
 
         view = tasks.get_epic_view(epic_id)
         assert view is not None
@@ -222,7 +222,7 @@ class TestEpicsCLI:
 
     def test_view_command(self) -> None:
         epic_id = tasks.create_epic("View CLI Epic", "EVEW")
-        tasks.create_task("View child", parent_task_id=epic_id, epic_key="EVEW")
+        tasks.create_task("View child", parent_task_id=epic_id, cat_key="EVEW")
         result = runner.invoke(epics_app, ["view", str(epic_id)])
         assert result.exit_code == 0
         out = _out(result)
@@ -266,14 +266,14 @@ class TestEpicsCLI:
 
     def test_delete_command_refuses_open(self) -> None:
         epic_id = tasks.create_epic("Refuse CLI Epic", "ERCL")
-        tasks.create_task("Open child", parent_task_id=epic_id, epic_key="ERCL")
+        tasks.create_task("Open child", parent_task_id=epic_id, cat_key="ERCL")
         result = runner.invoke(epics_app, ["delete", str(epic_id)])
         assert result.exit_code == 1
         assert "open/active" in _out(result)
 
     def test_delete_command_force(self) -> None:
         epic_id = tasks.create_epic("Force CLI Epic", "EFCL")
-        tasks.create_task("Open child", parent_task_id=epic_id, epic_key="EFCL")
+        tasks.create_task("Open child", parent_task_id=epic_id, cat_key="EFCL")
         result = runner.invoke(epics_app, ["delete", str(epic_id), "--force"])
         assert result.exit_code == 0
         assert "Deleted" in _out(result)
@@ -304,13 +304,13 @@ class TestTaskListWithFilters:
 
     def test_list_with_cat(self) -> None:
         categories.ensure_category("TLCT")
-        tasks.create_task("Cat filter test", epic_key="TLCT")
+        tasks.create_task("Cat filter test", cat_key="TLCT")
         result = runner.invoke(tasks_app, ["list", "--cat", "TLCT"])
         assert result.exit_code == 0
 
     def test_list_with_epic(self) -> None:
         epic_id = tasks.create_epic("List Epic", "TLEP")
-        tasks.create_task("Epic filter test", parent_task_id=epic_id, epic_key="TLEP")
+        tasks.create_task("Epic filter test", parent_task_id=epic_id, cat_key="TLEP")
         result = runner.invoke(tasks_app, ["list", "--epic", str(epic_id)])
         assert result.exit_code == 0
 
@@ -334,7 +334,7 @@ class TestEpicCommandsAcceptCategoryKeys:
         epic_id = tasks.create_epic("Key View Epic", "KVIW")
         epic = tasks.get_task(epic_id)
         assert epic is not None
-        key = f"KVIW-{epic.epic_seq}"
+        key = f"KVIW-{epic.cat_seq}"
         result = runner.invoke(epics_app, ["view", key])
         assert result.exit_code == 0
         assert "Key View Epic" in _out(result)
@@ -343,7 +343,7 @@ class TestEpicCommandsAcceptCategoryKeys:
         epic_id = tasks.create_epic("Key Done Epic", "KDNE")
         epic = tasks.get_task(epic_id)
         assert epic is not None
-        key = f"KDNE-{epic.epic_seq}"
+        key = f"KDNE-{epic.cat_seq}"
         result = runner.invoke(epics_app, ["done", key])
         assert result.exit_code == 0
         assert "Done" in _out(result)
@@ -352,7 +352,7 @@ class TestEpicCommandsAcceptCategoryKeys:
         epic_id = tasks.create_epic("Key Active Epic", "KACT")
         epic = tasks.get_task(epic_id)
         assert epic is not None
-        key = f"KACT-{epic.epic_seq}"
+        key = f"KACT-{epic.cat_seq}"
         result = runner.invoke(epics_app, ["active", key])
         assert result.exit_code == 0
         assert "Active" in _out(result)
@@ -362,7 +362,7 @@ class TestEpicCommandsAcceptCategoryKeys:
         tasks.update_task(epic_id, status="done")
         epic = tasks.get_task(epic_id)
         assert epic is not None
-        key = f"KDEL-{epic.epic_seq}"
+        key = f"KDEL-{epic.cat_seq}"
         result = runner.invoke(epics_app, ["delete", key])
         assert result.exit_code == 0
         assert "Deleted" in _out(result)
@@ -371,11 +371,11 @@ class TestEpicCommandsAcceptCategoryKeys:
 class TestTaskAddWithEpicKey:
     """Tests for #871: task add --epic accepts category keys."""
 
-    def test_add_with_epic_key(self) -> None:
+    def test_add_with_cat_key(self) -> None:
         epic_id = tasks.create_epic("Key Add Epic", "KADD")
         epic = tasks.get_task(epic_id)
         assert epic is not None
-        key = f"KADD-{epic.epic_seq}"
+        key = f"KADD-{epic.cat_seq}"
         result = runner.invoke(tasks_app, ["add", "Keyed task", "--epic", key])
         assert result.exit_code == 0
 
@@ -383,12 +383,12 @@ class TestTaskAddWithEpicKey:
 class TestTaskListWithEpicKey:
     """Tests for #871: task list --epic accepts category keys."""
 
-    def test_list_with_epic_key(self) -> None:
+    def test_list_with_cat_key(self) -> None:
         epic_id = tasks.create_epic("Key List Epic", "KLST")
-        tasks.create_task("Key list child", parent_task_id=epic_id, epic_key="KLST")
+        tasks.create_task("Key list child", parent_task_id=epic_id, cat_key="KLST")
         epic = tasks.get_task(epic_id)
         assert epic is not None
-        key = f"KLST-{epic.epic_seq}"
+        key = f"KLST-{epic.cat_seq}"
         result = runner.invoke(tasks_app, ["list", "--epic", key])
         assert result.exit_code == 0
 
@@ -409,14 +409,14 @@ class TestAttachToEpic:
         assert task1 is not None and task2 is not None
         assert task1.parent_task_id == epic_id
         assert task2.parent_task_id == epic_id
-        assert task1.epic_key == "ATCH"
-        assert task2.epic_key == "ATCH"
-        assert task1.epic_seq is not None
-        assert task2.epic_seq is not None
+        assert task1.cat_key == "ATCH"
+        assert task2.cat_key == "ATCH"
+        assert task1.cat_seq is not None
+        assert task2.cat_seq is not None
 
     def test_attach_skips_already_attached(self) -> None:
         epic_id = tasks.create_epic("Skip Epic", "SKIP")
-        t1 = tasks.create_task("Already child", parent_task_id=epic_id, epic_key="SKIP")
+        t1 = tasks.create_task("Already child", parent_task_id=epic_id, cat_key="SKIP")
 
         count = tasks.attach_to_epic([t1], epic_id)
         assert count == 0
@@ -440,29 +440,29 @@ class TestAttachToEpic:
 
     def test_attach_cli_with_keys(self) -> None:
         epic_id = tasks.create_epic("Key Attach Epic", "KCLA")
-        t1 = tasks.create_task("Key orphan", epic_key="KCLA")
+        t1 = tasks.create_task("Key orphan", cat_key="KCLA")
         task = tasks.get_task(t1)
         assert task is not None
-        key = f"KCLA-{task.epic_seq}"
+        key = f"KCLA-{task.cat_seq}"
         epic = tasks.get_task(epic_id)
         assert epic is not None
-        epic_key = f"KCLA-{epic.epic_seq}"
+        cat_key = f"KCLA-{epic.cat_seq}"
         result = runner.invoke(
             epics_app,
-            ["attach", key, "--epic", epic_key],
+            ["attach", key, "--epic", cat_key],
         )
         assert result.exit_code == 0
 
 
 class TestResolveTaskIdFallback:
-    """Tests for #872: resolve_task_id falls back to epic_seq for bare ints."""
+    """Tests for #872: resolve_task_id falls back to cat_seq for bare ints."""
 
-    def test_bare_int_falls_back_to_unique_epic_seq(self) -> None:
-        """When no task with that DB id exists, try epic_seq."""
-        task_id = tasks.create_task("Fallback test", epic_key="FLLB")
+    def test_bare_int_falls_back_to_unique_cat_seq(self) -> None:
+        """When no task with that DB id exists, try cat_seq."""
+        task_id = tasks.create_task("Fallback test", cat_key="FLLB")
         task = tasks.get_task(task_id)
         assert task is not None
-        seq = task.epic_seq
+        seq = task.cat_seq
         # Only works if no task with DB id == seq exists.
         # We can test this by using the category-key approach as verification.
         from emdx.models.tasks import resolve_task_id

--- a/tests/test_intelligence_integration.py
+++ b/tests/test_intelligence_integration.py
@@ -61,14 +61,14 @@ def _ensure_category(conn: sqlite3.Connection, key: str = "TEST") -> None:
 def _create_epic(
     conn: sqlite3.Connection,
     title: str,
-    epic_key: str = "TEST",
+    cat_key: str = "TEST",
     status: str = "open",
 ) -> int:
     """Create an epic task directly via SQL."""
-    _ensure_category(conn, epic_key)
+    _ensure_category(conn, cat_key)
     cursor = conn.execute(
-        "INSERT INTO tasks (title, type, epic_key, status) VALUES (?, 'epic', ?, ?)",
-        (title, epic_key, status),
+        "INSERT INTO tasks (title, type, cat_key, status) VALUES (?, 'epic', ?, ?)",
+        (title, cat_key, status),
     )
     conn.commit()
     assert cursor.lastrowid is not None
@@ -80,17 +80,17 @@ def _create_task(
     title: str,
     parent_task_id: int | None = None,
     status: str = "open",
-    epic_key: str | None = None,
+    cat_key: str | None = None,
     days_ago: int = 0,
     source_doc_id: int | None = None,
 ) -> int:
     """Create a task directly via SQL."""
-    if epic_key:
-        _ensure_category(conn, epic_key)
+    if cat_key:
+        _ensure_category(conn, cat_key)
     cursor = conn.execute(
         """
         INSERT INTO tasks (
-            title, parent_task_id, status, epic_key,
+            title, parent_task_id, status, cat_key,
             created_at, updated_at,
             source_doc_id
         )
@@ -105,7 +105,7 @@ def _create_task(
             title,
             parent_task_id,
             status,
-            epic_key,
+            cat_key,
             f"-{days_ago}",
             f"-{days_ago}",
             source_doc_id,
@@ -150,7 +150,7 @@ class TestIntelligenceLifecycle:
 
         # Step 2: Create stale epic with old task
         with db.get_connection() as conn:
-            epic_id = _create_epic(conn, "Lifecycle Epic", epic_key="LIFE")
+            epic_id = _create_epic(conn, "Lifecycle Epic", cat_key="LIFE")
             _create_task(
                 conn,
                 "Old task under lifecycle epic",
@@ -452,7 +452,7 @@ class TestBriefMode:
                 "id": 100,
                 "title": "My Epic",
                 "status": "active",
-                "epic_key": "FEAT",
+                "cat_key": "FEAT",
                 "child_count": 5,
                 "children_done": 2,
             }
@@ -465,8 +465,8 @@ class TestBriefMode:
                 "priority": 5,
                 "status": "open",
                 "source_doc_id": 42,
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
             }
         ]
         mock_ip.return_value = []
@@ -508,8 +508,8 @@ class TestBriefMode:
                 "priority": 5,
                 "status": "open",
                 "source_doc_id": 42,
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
             }
         ]
         mock_ip.return_value = []
@@ -543,8 +543,8 @@ class TestBriefMode:
                 "priority": 5,
                 "status": "open",
                 "source_doc_id": None,
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
             }
         ]
         mock_ip.return_value = []

--- a/tests/test_maintain_drift.py
+++ b/tests/test_maintain_drift.py
@@ -47,17 +47,17 @@ def _ensure_category(conn: sqlite3.Connection, key: str = "TEST") -> None:
 def _create_epic(
     conn: sqlite3.Connection,
     title: str,
-    epic_key: str = "TEST",
+    cat_key: str = "TEST",
     status: str = "open",
 ) -> int:
     """Helper to create an epic task directly via SQL."""
-    _ensure_category(conn, epic_key)
+    _ensure_category(conn, cat_key)
     cursor = conn.execute(
         """
-        INSERT INTO tasks (title, type, epic_key, status)
+        INSERT INTO tasks (title, type, cat_key, status)
         VALUES (?, 'epic', ?, ?)
         """,
-        (title, epic_key, status),
+        (title, cat_key, status),
     )
     conn.commit()
     assert cursor.lastrowid is not None
@@ -69,17 +69,17 @@ def _create_task(
     title: str,
     parent_task_id: int | None = None,
     status: str = "open",
-    epic_key: str | None = None,
+    cat_key: str | None = None,
     days_ago: int = 0,
     source_doc_id: int | None = None,
 ) -> int:
     """Helper to create a task directly via SQL."""
-    if epic_key:
-        _ensure_category(conn, epic_key)
+    if cat_key:
+        _ensure_category(conn, cat_key)
     cursor = conn.execute(
         """
         INSERT INTO tasks (
-            title, parent_task_id, status, epic_key,
+            title, parent_task_id, status, cat_key,
             created_at, updated_at,
             source_doc_id
         )
@@ -94,7 +94,7 @@ def _create_task(
             title,
             parent_task_id,
             status,
-            epic_key,
+            cat_key,
             f"-{days_ago}",
             f"-{days_ago}",
             source_doc_id,

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -80,8 +80,8 @@ def _make_test_db(db_path: Path) -> sqlite3.Connection:
             source_doc_id INTEGER REFERENCES documents(id),
             output_doc_id INTEGER REFERENCES documents(id),
             parent_task_id INTEGER REFERENCES tasks(id),
-            epic_key TEXT REFERENCES categories(key),
-            epic_seq INTEGER
+            cat_key TEXT REFERENCES categories(key),
+            cat_seq INTEGER
         )
     """)
     conn.execute("""

--- a/tests/test_smart_priming.py
+++ b/tests/test_smart_priming.py
@@ -29,8 +29,8 @@ def _make_task(
     priority=5,
     status="open",
     source_doc_id=None,
-    epic_key=None,
-    epic_seq=None,
+    cat_key=None,
+    cat_seq=None,
 ):
     return {
         "id": id,
@@ -39,8 +39,8 @@ def _make_task(
         "priority": priority,
         "status": status,
         "source_doc_id": source_doc_id,
-        "epic_key": epic_key,
-        "epic_seq": epic_seq,
+        "cat_key": cat_key,
+        "cat_seq": cat_seq,
     }
 
 

--- a/tests/test_task_browser.py
+++ b/tests/test_task_browser.py
@@ -26,13 +26,13 @@ def make_task(
     status: str = "open",
     priority: int = 5,
     description: str | None = None,
-    epic_key: str | None = None,
+    cat_key: str | None = None,
     created_at: str | None = "2025-01-01T12:00:00",
     updated_at: str | None = None,
     completed_at: str | None = None,
     parent_task_id: int | None = None,
     type: str = "manual",
-    epic_seq: int | None = None,
+    cat_seq: int | None = None,
     **kwargs: object,
 ) -> Task:
     return Task.from_row(
@@ -42,7 +42,7 @@ def make_task(
             "status": status,
             "priority": priority,
             "description": description,
-            "epic_key": epic_key,
+            "cat_key": cat_key,
             "created_at": created_at,
             "updated_at": updated_at,
             "completed_at": completed_at,
@@ -52,29 +52,29 @@ def make_task(
             "type": type,
             "source_doc_id": None,
             "parent_task_id": parent_task_id,
-            "epic_seq": epic_seq,
+            "cat_seq": cat_seq,
         }
     )
 
 
 def make_epic(
     id: int = 1,
-    epic_key: str = "AUTH",
+    cat_key: str = "AUTH",
     status: str = "open",
     child_count: int = 10,
     children_done: int = 7,
     children_open: int = 3,
-    epic_seq: int = 1,
+    cat_seq: int = 1,
     **kwargs: object,
 ) -> Task:
     return Task.from_row(
         {
             "id": id,
-            "title": f"Epic: {epic_key}",
+            "title": f"Epic: {cat_key}",
             "status": status,
-            "epic_key": epic_key,
+            "cat_key": cat_key,
             "type": "epic",
-            "epic_seq": epic_seq,
+            "cat_seq": cat_seq,
             "priority": 5,
             "description": None,
             "created_at": "2025-01-01T12:00:00",
@@ -414,7 +414,7 @@ class TestKeyboardNavigation:
     async def test_highlighting_task_updates_detail_header(self, mock_task_data: MockDict) -> None:
         """Highlighting a task updates the detail header."""
         mock_task_data["list_tasks"].return_value = [
-            make_task(id=42, title="My task", status="open", epic_key="AUTH", epic_seq=1),
+            make_task(id=42, title="My task", status="open", cat_key="AUTH", cat_seq=1),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -493,10 +493,10 @@ class TestDetailPane:
     async def test_shows_epic_info_with_progress(self, mock_task_data: MockDict) -> None:
         """Detail pane shows epic info with done/total progress."""
         mock_task_data["list_tasks"].return_value = [
-            make_task(id=2, status="open", epic_key="AUTH", parent_task_id=100),
+            make_task(id=2, status="open", cat_key="AUTH", parent_task_id=100),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=100, epic_key="AUTH", child_count=10, children_done=7),
+            make_epic(id=100, cat_key="AUTH", child_count=10, children_done=7),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -775,7 +775,7 @@ class TestEdgeCases:
                 id=1,
                 status="open",
                 description=None,
-                epic_key=None,
+                cat_key=None,
                 created_at=None,
                 updated_at=None,
                 completed_at=None,
@@ -977,11 +977,11 @@ class TestFilterBar:
             assert any("auth" in t.lower() for t in titles)
 
     @pytest.mark.asyncio
-    async def test_filter_by_epic_key(self, mock_task_data: MockDict) -> None:
-        """Filter matches against epic_key."""
+    async def test_filter_by_cat_key(self, mock_task_data: MockDict) -> None:
+        """Filter matches against cat_key."""
         mock_task_data["list_tasks"].return_value = [
-            make_task(id=1, title="Task A", status="open", epic_key="AUTH"),
-            make_task(id=2, title="Task B", status="open", epic_key="TUI"),
+            make_task(id=1, title="Task A", status="open", cat_key="AUTH"),
+            make_task(id=2, title="Task B", status="open", cat_key="TUI"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -1486,12 +1486,12 @@ class TestEpicGrouping:
     async def test_g_toggles_to_status_grouping(self, mock_task_data: MockDict) -> None:
         """Pressing g switches from epic grouping (default) to status grouping."""
         mock_task_data["list_tasks"].return_value = [
-            make_task(id=1, title="Auth task", status="open", epic_key="AUTH", parent_task_id=100),
-            make_task(id=2, title="TUI task", status="open", epic_key="TUI", parent_task_id=101),
+            make_task(id=1, title="Auth task", status="open", cat_key="AUTH", parent_task_id=100),
+            make_task(id=2, title="TUI task", status="open", cat_key="TUI", parent_task_id=101),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=100, epic_key="AUTH"),
-            make_epic(id=101, epic_key="TUI"),
+            make_epic(id=100, cat_key="AUTH"),
+            make_epic(id=101, cat_key="TUI"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -1515,7 +1515,7 @@ class TestEpicGrouping:
     async def test_g_toggles_back_to_epic(self, mock_task_data: MockDict) -> None:
         """Pressing g twice returns to epic grouping (default)."""
         mock_task_data["list_tasks"].return_value = [
-            make_task(id=1, title="Auth task", status="open", epic_key="AUTH"),
+            make_task(id=1, title="Auth task", status="open", cat_key="AUTH"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -1535,11 +1535,11 @@ class TestEpicGrouping:
     async def test_epic_grouping_shows_ungrouped(self, mock_task_data: MockDict) -> None:
         """Tasks without an epic appear under UNGROUPED (default view)."""
         mock_task_data["list_tasks"].return_value = [
-            make_task(id=1, title="Epic task", status="open", epic_key="AUTH", parent_task_id=100),
-            make_task(id=2, title="Loose task", status="open", epic_key=None),
+            make_task(id=1, title="Epic task", status="open", cat_key="AUTH", parent_task_id=100),
+            make_task(id=2, title="Loose task", status="open", cat_key=None),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=100, epic_key="AUTH"),
+            make_epic(id=100, cat_key="AUTH"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -1554,10 +1554,10 @@ class TestEpicGrouping:
     async def test_epic_grouping_shows_progress(self, mock_task_data: MockDict) -> None:
         """Epic headers show done/total progress in the age column."""
         mock_task_data["list_tasks"].return_value = [
-            make_task(id=1, title="Task", status="open", epic_key="AUTH", parent_task_id=100),
+            make_task(id=1, title="Task", status="open", cat_key="AUTH", parent_task_id=100),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=100, epic_key="AUTH", child_count=10, children_done=7),
+            make_epic(id=100, cat_key="AUTH", child_count=10, children_done=7),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -1586,13 +1586,13 @@ class TestEpicGrouping:
     async def test_epic_grouping_composes_with_filters(self, mock_task_data: MockDict) -> None:
         """Epic grouping (default) works together with status hide filters."""
         mock_task_data["list_tasks"].return_value = [
-            make_task(id=1, title="Fix auth", status="open", epic_key="AUTH", parent_task_id=100),
-            make_task(id=2, title="Fix deploy", status="open", epic_key="AUTH", parent_task_id=100),
-            make_task(id=3, title="Fix TUI", status="active", epic_key="TUI", parent_task_id=101),
+            make_task(id=1, title="Fix auth", status="open", cat_key="AUTH", parent_task_id=100),
+            make_task(id=2, title="Fix deploy", status="open", cat_key="AUTH", parent_task_id=100),
+            make_task(id=3, title="Fix TUI", status="active", cat_key="TUI", parent_task_id=101),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=100, epic_key="AUTH"),
-            make_epic(id=101, epic_key="TUI"),
+            make_epic(id=100, cat_key="AUTH"),
+            make_epic(id=101, cat_key="TUI"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -1630,16 +1630,16 @@ class TestEpicGrouping:
         """Done epics appear at bottom under COMPLETED, children hidden."""
         mock_task_data["list_tasks"].return_value = [
             make_task(
-                id=1, title="Active work", status="open", epic_key="LIVE", parent_task_id=200
+                id=1, title="Active work", status="open", cat_key="LIVE", parent_task_id=200
             ),
-            make_task(id=2, title="Old stuff", status="done", epic_key="DEAD", parent_task_id=201),
-            make_task(id=3, title="Also old", status="failed", epic_key="DEAD", parent_task_id=201),
+            make_task(id=2, title="Old stuff", status="done", cat_key="DEAD", parent_task_id=201),
+            make_task(id=3, title="Also old", status="failed", cat_key="DEAD", parent_task_id=201),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=200, epic_key="LIVE"),
+            make_epic(id=200, cat_key="LIVE"),
             make_epic(
                 id=201,
-                epic_key="DEAD",
+                cat_key="DEAD",
                 status="done",
                 child_count=2,
                 children_done=2,
@@ -1665,16 +1665,16 @@ class TestEpicGrouping:
     async def test_epic_grouping_hides_done_in_mixed_group(self, mock_task_data: MockDict) -> None:
         """Done/failed children are hidden behind a fold in active epics."""
         mock_task_data["list_tasks"].return_value = [
-            make_task(id=1, title="Open work", status="open", epic_key="MIX", parent_task_id=300),
+            make_task(id=1, title="Open work", status="open", cat_key="MIX", parent_task_id=300),
             make_task(
-                id=2, title="Finished work", status="done", epic_key="MIX", parent_task_id=300
+                id=2, title="Finished work", status="done", cat_key="MIX", parent_task_id=300
             ),
             make_task(
-                id=3, title="Failed work", status="failed", epic_key="MIX", parent_task_id=300
+                id=3, title="Failed work", status="failed", cat_key="MIX", parent_task_id=300
             ),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=300, epic_key="MIX", child_count=3, children_done=2, children_open=1),
+            make_epic(id=300, cat_key="MIX", child_count=3, children_done=2, children_open=1),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -1694,12 +1694,12 @@ class TestEpicGrouping:
     async def test_done_fold_expands_on_enter(self, mock_task_data: MockDict) -> None:
         """Pressing Enter on the done-fold row reveals completed tasks."""
         mock_task_data["list_tasks"].return_value = [
-            make_task(id=1, title="Open work", status="open", epic_key="MIX", parent_task_id=300),
+            make_task(id=1, title="Open work", status="open", cat_key="MIX", parent_task_id=300),
             make_task(
                 id=2,
                 title="Finished work",
                 status="done",
-                epic_key="MIX",
+                cat_key="MIX",
                 parent_task_id=300,
                 completed_at="2026-03-05 12:00:00",
             ),
@@ -1707,13 +1707,13 @@ class TestEpicGrouping:
                 id=3,
                 title="Old finish",
                 status="done",
-                epic_key="MIX",
+                cat_key="MIX",
                 parent_task_id=300,
                 completed_at="2026-03-01 12:00:00",
             ),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=300, epic_key="MIX"),
+            make_epic(id=300, cat_key="MIX"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -1748,7 +1748,7 @@ class TestEpicGrouping:
                 id=1,
                 title="Old child",
                 status="open",
-                epic_key="STALE",
+                cat_key="STALE",
                 parent_task_id=500,
                 updated_at="2025-01-01T00:00:00",
             ),
@@ -1756,14 +1756,14 @@ class TestEpicGrouping:
                 id=2,
                 title="Recent child",
                 status="open",
-                epic_key="FRESH",
+                cat_key="FRESH",
                 parent_task_id=501,
                 updated_at="2025-06-15T12:00:00",
             ),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=500, epic_key="STALE"),
-            make_epic(id=501, epic_key="FRESH"),
+            make_epic(id=500, cat_key="STALE"),
+            make_epic(id=501, cat_key="FRESH"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -1783,7 +1783,7 @@ class TestEpicGrouping:
                 id=1,
                 title="Idle child",
                 status="open",
-                epic_key="IDLE",
+                cat_key="IDLE",
                 parent_task_id=600,
                 updated_at="2025-06-15T12:00:00",
             ),
@@ -1791,14 +1791,14 @@ class TestEpicGrouping:
                 id=2,
                 title="Active child",
                 status="active",
-                epic_key="BUSY",
+                cat_key="BUSY",
                 parent_task_id=601,
                 updated_at="2025-01-01T00:00:00",
             ),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=600, epic_key="IDLE"),
-            make_epic(id=601, epic_key="BUSY"),
+            make_epic(id=600, cat_key="IDLE"),
+            make_epic(id=601, cat_key="BUSY"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -1818,7 +1818,7 @@ class TestEpicGrouping:
                 id=1,
                 title="Newest task",
                 status="open",
-                epic_key="Q",
+                cat_key="Q",
                 parent_task_id=700,
                 created_at="2025-03-01T00:00:00",
             ),
@@ -1826,7 +1826,7 @@ class TestEpicGrouping:
                 id=2,
                 title="Middle task",
                 status="open",
-                epic_key="Q",
+                cat_key="Q",
                 parent_task_id=700,
                 created_at="2025-02-01T00:00:00",
             ),
@@ -1834,13 +1834,13 @@ class TestEpicGrouping:
                 id=3,
                 title="Oldest task",
                 status="open",
-                epic_key="Q",
+                cat_key="Q",
                 parent_task_id=700,
                 created_at="2025-01-01T00:00:00",
             ),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=700, epic_key="Q"),
+            make_epic(id=700, cat_key="Q"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -1925,15 +1925,15 @@ class TestWontdoStatus:
         """Epics where all tasks are wontdo appear collapsed under COMPLETED."""
         mock_task_data["list_tasks"].return_value = [
             make_task(
-                id=1, title="Active work", status="open", epic_key="LIVE", parent_task_id=400
+                id=1, title="Active work", status="open", cat_key="LIVE", parent_task_id=400
             ),
-            make_task(id=2, title="Skipped", status="wontdo", epic_key="SKIP", parent_task_id=401),
+            make_task(id=2, title="Skipped", status="wontdo", cat_key="SKIP", parent_task_id=401),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=400, epic_key="LIVE"),
+            make_epic(id=400, cat_key="LIVE"),
             make_epic(
                 id=401,
-                epic_key="SKIP",
+                cat_key="SKIP",
                 status="done",
                 child_count=1,
                 children_done=1,
@@ -1984,11 +1984,11 @@ class TestCrossGroupEpicClustering:
     async def test_cross_group_children_show_epic_header(self, mock_task_data: MockDict) -> None:
         """Children whose epic is in another status group show a reference header."""
         mock_task_data["list_tasks"].return_value = [
-            make_task(id=1, title="Child A", status="open", epic_key="AUTH", parent_task_id=100),
-            make_task(id=2, title="Child B", status="open", epic_key="AUTH", parent_task_id=100),
+            make_task(id=1, title="Child A", status="open", cat_key="AUTH", parent_task_id=100),
+            make_task(id=2, title="Child B", status="open", cat_key="AUTH", parent_task_id=100),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=100, epic_key="AUTH", child_count=5, children_done=3),
+            make_epic(id=100, cat_key="AUTH", child_count=5, children_done=3),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -2006,11 +2006,11 @@ class TestCrossGroupEpicClustering:
     ) -> None:
         """Children under a cross-group epic use tree connectors."""
         mock_task_data["list_tasks"].return_value = [
-            make_task(id=1, title="Child A", status="open", epic_key="AUTH", parent_task_id=100),
-            make_task(id=2, title="Child B", status="open", epic_key="AUTH", parent_task_id=100),
+            make_task(id=1, title="Child A", status="open", cat_key="AUTH", parent_task_id=100),
+            make_task(id=2, title="Child B", status="open", cat_key="AUTH", parent_task_id=100),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=100, epic_key="AUTH"),
+            make_epic(id=100, cat_key="AUTH"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -2027,15 +2027,15 @@ class TestCrossGroupEpicClustering:
     ) -> None:
         """Children whose epic IS in the same status group cluster normally."""
         epic_task = make_task(
-            id=100, title="Auth Epic", status="open", epic_key="AUTH", type="epic"
+            id=100, title="Auth Epic", status="open", cat_key="AUTH", type="epic"
         )
         mock_task_data["list_tasks"].return_value = [
             epic_task,
-            make_task(id=1, title="Child A", status="open", epic_key="AUTH", parent_task_id=100),
-            make_task(id=2, title="Child B", status="open", epic_key="AUTH", parent_task_id=100),
+            make_task(id=1, title="Child A", status="open", cat_key="AUTH", parent_task_id=100),
+            make_task(id=2, title="Child B", status="open", cat_key="AUTH", parent_task_id=100),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=100, epic_key="AUTH"),
+            make_epic(id=100, cat_key="AUTH"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -2268,12 +2268,12 @@ class TestCollapseExpand:
                 id=1,
                 title="Child task",
                 status="open",
-                epic_key="EPIC",
+                cat_key="EPIC",
                 parent_task_id=100,
             ),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=100, epic_key="EPIC"),
+            make_epic(id=100, cat_key="EPIC"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -2305,12 +2305,12 @@ class TestCollapseExpand:
                 id=1,
                 title="Child task",
                 status="open",
-                epic_key="EPIC",
+                cat_key="EPIC",
                 parent_task_id=100,
             ),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=100, epic_key="EPIC"),
+            make_epic(id=100, cat_key="EPIC"),
         ]
         app = TaskTestApp()
         async with app.run_test() as pilot:
@@ -2338,22 +2338,22 @@ class TestCollapseExpand:
                 id=1,
                 title="Active work",
                 status="open",
-                epic_key="LIVE",
+                cat_key="LIVE",
                 parent_task_id=200,
             ),
             make_task(
                 id=2,
                 title="Done child",
                 status="done",
-                epic_key="DEAD",
+                cat_key="DEAD",
                 parent_task_id=201,
             ),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=200, epic_key="LIVE"),
+            make_epic(id=200, cat_key="LIVE"),
             make_epic(
                 id=201,
-                epic_key="DEAD",
+                cat_key="DEAD",
                 status="done",
                 child_count=1,
                 children_done=1,
@@ -2449,14 +2449,14 @@ class TestDoneFoldRecency:
                 id=1,
                 title="Active work",
                 status="open",
-                epic_key="LIVE",
+                cat_key="LIVE",
                 parent_task_id=200,
             ),
             make_task(
                 id=2,
                 title="Done child",
                 status="done",
-                epic_key="DEAD",
+                cat_key="DEAD",
                 parent_task_id=201,
                 completed_at="2025-01-01T12:00:00",
             ),
@@ -2464,16 +2464,16 @@ class TestDoneFoldRecency:
                 id=3,
                 title="Also done",
                 status="done",
-                epic_key="DEAD",
+                cat_key="DEAD",
                 parent_task_id=201,
                 completed_at="2025-01-02T12:00:00",
             ),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=200, epic_key="LIVE"),
+            make_epic(id=200, cat_key="LIVE"),
             make_epic(
                 id=201,
-                epic_key="DEAD",
+                cat_key="DEAD",
                 status="done",
                 child_count=2,
                 children_done=2,
@@ -2498,24 +2498,24 @@ class TestDoneFoldRecency:
                 id=1,
                 title="Active work",
                 status="open",
-                epic_key="LIVE",
+                cat_key="LIVE",
                 parent_task_id=200,
             ),
             make_task(
                 id=2,
                 title="Done child",
                 status="done",
-                epic_key="DEAD",
+                cat_key="DEAD",
                 parent_task_id=201,
                 completed_at=None,
                 updated_at="2025-01-01T12:00:00",
             ),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=200, epic_key="LIVE"),
+            make_epic(id=200, cat_key="LIVE"),
             make_epic(
                 id=201,
-                epic_key="DEAD",
+                cat_key="DEAD",
                 status="done",
                 child_count=1,
                 children_done=1,
@@ -2540,14 +2540,14 @@ class TestDoneFoldRecency:
                 id=1,
                 title="Active work",
                 status="open",
-                epic_key="LIVE",
+                cat_key="LIVE",
                 parent_task_id=200,
             ),
             make_task(
                 id=2,
                 title="Done child",
                 status="done",
-                epic_key="DEAD",
+                cat_key="DEAD",
                 parent_task_id=201,
                 completed_at=None,
                 updated_at=None,
@@ -2555,10 +2555,10 @@ class TestDoneFoldRecency:
             ),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=200, epic_key="LIVE"),
+            make_epic(id=200, cat_key="LIVE"),
             make_epic(
                 id=201,
-                epic_key="DEAD",
+                cat_key="DEAD",
                 status="done",
                 child_count=1,
                 children_done=1,
@@ -2630,19 +2630,19 @@ class TestContextSensitiveFooter:
                 id=100,
                 title="Epic: AUTH",
                 status="open",
-                epic_key="AUTH",
+                cat_key="AUTH",
                 type="epic",
             ),
             make_task(
                 id=1,
                 title="Child task",
                 status="open",
-                epic_key="AUTH",
+                cat_key="AUTH",
                 parent_task_id=100,
             ),
         ]
         mock_task_data["list_epics"].return_value = [
-            make_epic(id=100, epic_key="AUTH"),
+            make_epic(id=100, cat_key="AUTH"),
         ]
 
         class FooterApp(App[None]):
@@ -2693,28 +2693,28 @@ class TestContextSensitiveFooter:
                 id=1,
                 title="Open task",
                 status="open",
-                epic_key="AUTH",
+                cat_key="AUTH",
                 parent_task_id=100,
             ),
             make_task(
                 id=2,
                 title="Done task 1",
                 status="done",
-                epic_key="AUTH",
+                cat_key="AUTH",
                 parent_task_id=100,
             ),
             make_task(
                 id=3,
                 title="Done task 2",
                 status="done",
-                epic_key="AUTH",
+                cat_key="AUTH",
                 parent_task_id=100,
             ),
         ]
         mock_task_data["list_epics"].return_value = [
             make_epic(
                 id=100,
-                epic_key="AUTH",
+                cat_key="AUTH",
                 child_count=3,
                 children_done=2,
                 children_open=1,

--- a/tests/test_task_commands.py
+++ b/tests/test_task_commands.py
@@ -31,8 +31,8 @@ class TestTaskAdd:
             {
                 "id": 1,
                 "title": "Fix the auth bug",
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
             }
         )
         result = runner.invoke(app, ["add", "Fix the auth bug"])
@@ -45,7 +45,7 @@ class TestTaskAdd:
             description="",
             source_doc_id=None,
             parent_task_id=None,
-            epic_key=None,
+            cat_key=None,
             depends_on=None,
         )
 
@@ -60,14 +60,14 @@ class TestTaskAdd:
         assert "cannot be empty" in _out(result)
 
     @patch("emdx.commands.tasks.tasks")
-    def test_add_task_shows_epic_key(self, mock_tasks):
+    def test_add_task_shows_cat_key(self, mock_tasks):
         mock_tasks.create_task.return_value = 10
         mock_tasks.get_task.return_value = Task.from_row(
             {
                 "id": 10,
                 "title": "FEAT-3: Add auth",
-                "epic_key": "FEAT",
-                "epic_seq": 3,
+                "cat_key": "FEAT",
+                "cat_seq": 3,
             }
         )
         result = runner.invoke(app, ["add", "Add auth", "--cat", "FEAT"])
@@ -83,8 +83,8 @@ class TestTaskAdd:
             {
                 "id": 2,
                 "title": "Implement this",
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
             }
         )
         result = runner.invoke(app, ["add", "Implement this", "--doc", "42"])
@@ -98,7 +98,7 @@ class TestTaskAdd:
             description="",
             source_doc_id=42,
             parent_task_id=None,
-            epic_key=None,
+            cat_key=None,
             depends_on=None,
         )
 
@@ -109,8 +109,8 @@ class TestTaskAdd:
             {
                 "id": 3,
                 "title": "Another task",
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
             }
         )
         result = runner.invoke(app, ["add", "Another task", "-d", "99"])
@@ -123,7 +123,7 @@ class TestTaskAdd:
             description="",
             source_doc_id=99,
             parent_task_id=None,
-            epic_key=None,
+            cat_key=None,
             depends_on=None,
         )
 
@@ -134,8 +134,8 @@ class TestTaskAdd:
             {
                 "id": 4,
                 "title": "Refactor tests",
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
             }
         )
         result = runner.invoke(
@@ -150,7 +150,7 @@ class TestTaskAdd:
             description="Split into unit and integration",
             source_doc_id=None,
             parent_task_id=None,
-            epic_key=None,
+            cat_key=None,
             depends_on=None,
         )
 
@@ -161,8 +161,8 @@ class TestTaskAdd:
             {
                 "id": 5,
                 "title": "Task",
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
             }
         )
         result = runner.invoke(app, ["add", "Task", "-D", "Details here"])
@@ -172,7 +172,7 @@ class TestTaskAdd:
             description="Details here",
             source_doc_id=None,
             parent_task_id=None,
-            epic_key=None,
+            cat_key=None,
             depends_on=None,
         )
 
@@ -183,8 +183,8 @@ class TestTaskAdd:
             {
                 "id": 6,
                 "title": "Full task",
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
             }
         )
         result = runner.invoke(app, ["add", "Full task", "-d", "10", "-D", "Full description"])
@@ -197,17 +197,17 @@ class TestTaskAdd:
             description="Full description",
             source_doc_id=10,
             parent_task_id=None,
-            epic_key=None,
+            cat_key=None,
             depends_on=None,
         )
 
     @patch("emdx.commands.tasks.tasks")
     def test_add_task_nonexistent_epic_says_epic_not_found(self, mock_tasks):
         mock_tasks.resolve_task_id.return_value = None
-        result = runner.invoke(app, ["add", "Test task", "--epic", "999999"])
+        result = runner.invoke(app, ["add", "Test task", "--parent", "999999"])
         assert result.exit_code == 1
         out = _out(result)
-        assert "Epic not found" in out
+        assert "Parent not found" in out
         assert "Task not found" not in out
 
     def test_add_task_requires_title(self):
@@ -228,8 +228,8 @@ class TestTaskReady:
     @patch("emdx.commands.tasks.tasks")
     def test_ready_shows_tasks(self, mock_tasks):
         mock_tasks.get_ready_tasks.return_value = [
-            Task.from_row({"id": 1, "title": "First task", "epic_key": None, "epic_seq": None}),
-            Task.from_row({"id": 2, "title": "Second task", "epic_key": "SEC", "epic_seq": 1}),
+            Task.from_row({"id": 1, "title": "First task", "cat_key": None, "cat_seq": None}),
+            Task.from_row({"id": 2, "title": "Second task", "cat_key": "SEC", "cat_seq": 1}),
         ]
         result = runner.invoke(app, ["ready"])
         assert result.exit_code == 0
@@ -243,7 +243,7 @@ class TestTaskReady:
     @patch("emdx.commands.tasks.tasks")
     def test_ready_shows_epic_label(self, mock_tasks):
         mock_tasks.get_ready_tasks.return_value = [
-            Task.from_row({"id": 1, "title": "QW-3: Task", "epic_key": "QW", "epic_seq": 3}),
+            Task.from_row({"id": 1, "title": "QW-3: Task", "cat_key": "QW", "cat_seq": 3}),
         ]
         result = runner.invoke(app, ["ready"])
         out = _out(result)
@@ -362,8 +362,8 @@ class TestTaskList:
                     "id": 1,
                     "title": "Open task",
                     "status": "open",
-                    "epic_key": None,
-                    "epic_seq": None,
+                    "cat_key": None,
+                    "cat_seq": None,
                 }
             ),
             Task.from_row(
@@ -371,8 +371,8 @@ class TestTaskList:
                     "id": 2,
                     "title": "Active task",
                     "status": "active",
-                    "epic_key": None,
-                    "epic_seq": None,
+                    "cat_key": None,
+                    "cat_seq": None,
                 }
             ),
             Task.from_row(
@@ -380,8 +380,8 @@ class TestTaskList:
                     "id": 3,
                     "title": "Blocked task",
                     "status": "blocked",
-                    "epic_key": None,
-                    "epic_seq": None,
+                    "cat_key": None,
+                    "cat_seq": None,
                 }
             ),
         ]
@@ -398,7 +398,7 @@ class TestTaskList:
     def test_list_shows_status_text(self, mock_tasks):
         mock_tasks.list_tasks.return_value = [
             Task.from_row(
-                {"id": 1, "title": "Task", "status": "active", "epic_key": None, "epic_seq": None}
+                {"id": 1, "title": "Task", "status": "active", "cat_key": None, "cat_seq": None}
             ),
         ]
         result = runner.invoke(app, ["list"])
@@ -413,8 +413,8 @@ class TestTaskList:
                     "id": 1,
                     "title": "SEC-1: Harden auth",
                     "status": "open",
-                    "epic_key": "SEC",
-                    "epic_seq": 1,
+                    "cat_key": "SEC",
+                    "cat_seq": 1,
                 }
             ),
         ]
@@ -432,7 +432,7 @@ class TestTaskList:
         mock_tasks.list_tasks.assert_called_once_with(
             status=["open", "active", "blocked"],
             limit=20,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since=None,
         )
@@ -445,7 +445,7 @@ class TestTaskList:
         mock_tasks.list_tasks.assert_called_once_with(
             status=["done"],
             limit=20,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since=None,
         )
@@ -458,7 +458,7 @@ class TestTaskList:
         mock_tasks.list_tasks.assert_called_once_with(
             status=None,
             limit=20,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since=None,
         )
@@ -471,7 +471,7 @@ class TestTaskList:
         mock_tasks.list_tasks.assert_called_once_with(
             status=None,
             limit=20,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since=None,
         )
@@ -484,7 +484,7 @@ class TestTaskList:
         mock_tasks.list_tasks.assert_called_once_with(
             status=["open"],
             limit=20,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since=None,
         )
@@ -497,7 +497,7 @@ class TestTaskList:
         mock_tasks.list_tasks.assert_called_once_with(
             status=["open", "active"],
             limit=20,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since=None,
         )
@@ -510,7 +510,7 @@ class TestTaskList:
         mock_tasks.list_tasks.assert_called_once_with(
             status=["open", "active", "blocked"],
             limit=5,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since=None,
         )
@@ -523,7 +523,7 @@ class TestTaskList:
         mock_tasks.list_tasks.assert_called_once_with(
             status=["open", "active", "blocked"],
             limit=10,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since=None,
         )
@@ -532,16 +532,16 @@ class TestTaskList:
     def test_list_displays_status_as_text(self, mock_tasks):
         mock_tasks.list_tasks.return_value = [
             Task.from_row(
-                {"id": 1, "title": "Open", "status": "open", "epic_key": None, "epic_seq": None}
+                {"id": 1, "title": "Open", "status": "open", "cat_key": None, "cat_seq": None}
             ),
             Task.from_row(
-                {"id": 2, "title": "Active", "status": "active", "epic_key": None, "epic_seq": None}
+                {"id": 2, "title": "Active", "status": "active", "cat_key": None, "cat_seq": None}
             ),
             Task.from_row(
-                {"id": 3, "title": "Done", "status": "done", "epic_key": None, "epic_seq": None}
+                {"id": 3, "title": "Done", "status": "done", "cat_key": None, "cat_seq": None}
             ),
             Task.from_row(
-                {"id": 4, "title": "Failed", "status": "failed", "epic_key": None, "epic_seq": None}
+                {"id": 4, "title": "Failed", "status": "failed", "cat_key": None, "cat_seq": None}
             ),
         ]
         result = runner.invoke(app, ["list"])
@@ -557,7 +557,7 @@ class TestTaskList:
         long_title = "This is a very long task title that exceeds fifty characters by quite a bit"
         mock_tasks.list_tasks.return_value = [
             Task.from_row(
-                {"id": 1, "title": long_title, "status": "open", "epic_key": None, "epic_seq": None}
+                {"id": 1, "title": long_title, "status": "open", "cat_key": None, "cat_seq": None}
             ),
         ]
         result = runner.invoke(app, ["list"])
@@ -576,7 +576,7 @@ class TestTaskListDateFilters:
         mock_tasks.list_tasks.assert_called_once_with(
             status=["done"],
             limit=20,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since="2026-01-15",
         )
@@ -589,7 +589,7 @@ class TestTaskListDateFilters:
         mock_tasks.list_tasks.assert_called_once_with(
             status=["done"],
             limit=20,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since="2026-01-15",
         )
@@ -604,7 +604,7 @@ class TestTaskListDateFilters:
         mock_tasks.list_tasks.assert_called_once_with(
             status=["done"],
             limit=20,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since="2026-02-25",
         )
@@ -623,7 +623,7 @@ class TestTaskListDateFilters:
         mock_tasks.list_tasks.assert_called_once_with(
             status=["done", "wontdo"],
             limit=20,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since="2026-01-01",
         )
@@ -636,7 +636,7 @@ class TestTaskListDateFilters:
         mock_tasks.list_tasks.assert_called_once_with(
             status=["done"],
             limit=20,
-            epic_key=None,
+            cat_key=None,
             parent_task_id=None,
             since=None,
         )
@@ -726,8 +726,8 @@ class TestTaskView:
                 "title": "Fix auth bug",
                 "status": "open",
                 "description": "The auth middleware has a race condition",
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
                 "parent_task_id": None,
                 "source_doc_id": None,
                 "priority": 3,
@@ -755,8 +755,8 @@ class TestTaskView:
                 "title": "SEC-1: Harden auth",
                 "status": "active",
                 "description": "",
-                "epic_key": "SEC",
-                "epic_seq": 1,
+                "cat_key": "SEC",
+                "cat_seq": 1,
                 "parent_task_id": 500,
                 "source_doc_id": 99,
                 "output_doc_id": None,
@@ -770,8 +770,8 @@ class TestTaskView:
                 "title": "Security epic",
                 "status": "open",
                 "description": "",
-                "epic_key": "SEC",
-                "epic_seq": 49,
+                "cat_key": "SEC",
+                "cat_seq": 49,
                 "parent_task_id": None,
                 "source_doc_id": None,
                 "priority": 3,
@@ -804,8 +804,8 @@ class TestTaskView:
                 "title": "Task with deps",
                 "status": "blocked",
                 "description": "",
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
                 "parent_task_id": None,
                 "source_doc_id": None,
                 "priority": 3,
@@ -838,8 +838,8 @@ class TestTaskView:
                 "title": "Some task",
                 "status": "active",
                 "description": "",
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
                 "parent_task_id": None,
                 "source_doc_id": None,
                 "priority": 3,
@@ -1221,8 +1221,8 @@ class TestTaskAddWithAfter:
     @patch("emdx.commands.tasks.tasks")
     def test_add_with_single_after(self, mock_tasks):
         mock_tasks.create_task.return_value = 10
-        task_10 = Task.from_row({"id": 10, "title": "Deploy", "epic_key": None, "epic_seq": None})
-        task_5 = Task.from_row({"id": 5, "title": "Build", "epic_key": None, "epic_seq": None})
+        task_10 = Task.from_row({"id": 10, "title": "Deploy", "cat_key": None, "cat_seq": None})
+        task_5 = Task.from_row({"id": 5, "title": "Build", "cat_key": None, "cat_seq": None})
         mock_tasks.get_task.side_effect = lambda tid: task_10 if tid == 10 else task_5
         result = runner.invoke(app, ["add", "Deploy", "--after", "5"])
         assert result.exit_code == 0
@@ -1234,7 +1234,7 @@ class TestTaskAddWithAfter:
             description="",
             source_doc_id=None,
             parent_task_id=None,
-            epic_key=None,
+            cat_key=None,
             depends_on=[5],
         )
 
@@ -1242,9 +1242,9 @@ class TestTaskAddWithAfter:
     def test_add_with_multiple_after(self, mock_tasks):
         mock_tasks.create_task.return_value = 20
         tasks_by_id = {
-            20: Task.from_row({"id": 20, "title": "Release", "epic_key": None, "epic_seq": None}),
-            10: Task.from_row({"id": 10, "title": "Build", "epic_key": None, "epic_seq": None}),
-            11: Task.from_row({"id": 11, "title": "Test", "epic_key": None, "epic_seq": None}),
+            20: Task.from_row({"id": 20, "title": "Release", "cat_key": None, "cat_seq": None}),
+            10: Task.from_row({"id": 10, "title": "Build", "cat_key": None, "cat_seq": None}),
+            11: Task.from_row({"id": 11, "title": "Test", "cat_key": None, "cat_seq": None}),
         }
         mock_tasks.get_task.side_effect = lambda tid: tasks_by_id.get(tid)
         result = runner.invoke(app, ["add", "Release", "--after", "10", "--after", "11"])
@@ -1258,7 +1258,7 @@ class TestTaskAddWithAfter:
             description="",
             source_doc_id=None,
             parent_task_id=None,
-            epic_key=None,
+            cat_key=None,
             depends_on=[10, 11],
         )
 
@@ -1270,8 +1270,8 @@ class TestTaskDepAdd:
     def test_dep_add_success(self, mock_tasks):
         mock_tasks.resolve_task_id.side_effect = lambda x: int(x)
         tasks_by_id = {
-            5: Task.from_row({"id": 5, "title": "Task A", "epic_key": None, "epic_seq": None}),
-            3: Task.from_row({"id": 3, "title": "Task B", "epic_key": None, "epic_seq": None}),
+            5: Task.from_row({"id": 5, "title": "Task A", "cat_key": None, "cat_seq": None}),
+            3: Task.from_row({"id": 3, "title": "Task B", "cat_key": None, "cat_seq": None}),
         }
         mock_tasks.get_task.side_effect = lambda tid: tasks_by_id.get(tid)
         mock_tasks.add_dependency.return_value = True
@@ -1289,8 +1289,8 @@ class TestTaskDepAdd:
             {
                 "id": tid,
                 "title": "Task",
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
             }
         )
         mock_tasks.add_dependency.return_value = False
@@ -1321,8 +1321,8 @@ class TestTaskDepRm:
             {
                 "id": tid,
                 "title": "Task",
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
             }
         )
         mock_tasks.remove_dependency.return_value = True
@@ -1340,8 +1340,8 @@ class TestTaskDepRm:
             {
                 "id": tid,
                 "title": "Task",
-                "epic_key": None,
-                "epic_seq": None,
+                "cat_key": None,
+                "cat_seq": None,
             }
         )
         mock_tasks.remove_dependency.return_value = False
@@ -1508,8 +1508,8 @@ class TestPrefixedTaskId:
                 "title": "TOOL-12: Build widget",
                 "status": "open",
                 "description": "",
-                "epic_key": "TOOL",
-                "epic_seq": 12,
+                "cat_key": "TOOL",
+                "cat_seq": 12,
                 "parent_task_id": None,
                 "source_doc_id": None,
                 "priority": 3,
@@ -1650,15 +1650,15 @@ class TestResolveTaskId:
     def test_prefixed_id_found(self):
         from emdx.models.tasks import create_task, resolve_task_id
 
-        task_id = create_task("Prefixed test", epic_key="RSLV")
+        task_id = create_task("Prefixed test", cat_key="RSLV")
         assert resolve_task_id("RSLV-1") == task_id
 
-    def test_bare_integer_falls_back_to_epic_seq(self):
-        """When bare integer doesn't match a DB ID, try epic_seq."""
+    def test_bare_integer_falls_back_to_cat_seq(self):
+        """When bare integer doesn't match a DB ID, try cat_seq."""
         from emdx.models.tasks import create_task, resolve_task_id
 
-        task_id = create_task("Epic seq test", epic_key="SEQT")
-        # task_id is the DB id, but epic_seq is 1
+        task_id = create_task("Epic seq test", cat_key="SEQT")
+        # task_id is the DB id, but cat_seq is 1
         # If no task with DB id=1 exists (or it does but matches), test the seq
         result = resolve_task_id("SEQT-1")
         assert result == task_id
@@ -1676,7 +1676,7 @@ class TestResolveTaskId:
 
         assert resolve_task_id("sec-3") == 55
         mock_conn.execute.assert_called_once_with(
-            "SELECT id FROM tasks WHERE epic_key = ? AND epic_seq = ?",
+            "SELECT id FROM tasks WHERE cat_key = ? AND cat_seq = ?",
             ("SEC", 3),
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"

--- a/vscode-extension/src/emdx-client.ts
+++ b/vscode-extension/src/emdx-client.ts
@@ -358,7 +358,7 @@ class EmdxClient {
     const key = `tasks:${status ?? "all"}:${epicKey ?? "all"}`;
     const params: Record<string, unknown> = {};
     if (status) params.status = status;
-    if (epicKey) params.epic_key = epicKey;
+    if (epicKey) params.cat_key = epicKey;
     return this.rpcCached<Task[]>(key, "task.list", params);
   }
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -852,7 +852,7 @@ function buildTaskPreviewHtml(
   const meta = [
     `<strong>Status:</strong> ${icon} ${escapeHtml(task.status)}`,
     `<strong>Priority:</strong> ${task.priority}`,
-    task.epic_key ? `<strong>Epic:</strong> ${escapeHtml(task.epic_key)}` : null,
+    task.cat_key ? `<strong>Epic:</strong> ${escapeHtml(task.cat_key)}` : null,
     `<strong>Created:</strong> ${escapeHtml(task.created_at)}`,
     `<strong>Updated:</strong> ${escapeHtml(task.updated_at)}`,
     task.completed_at ? `<strong>Completed:</strong> ${escapeHtml(task.completed_at)}` : null,

--- a/vscode-extension/src/providers/tasks-tree.ts
+++ b/vscode-extension/src/providers/tasks-tree.ts
@@ -45,7 +45,7 @@ export class TaskTreeItem extends vscode.TreeItem {
     const prioritySuffix = priority ? ` ${priority}` : "";
 
     this.label = `${icon} ${task.title}${prioritySuffix}`;
-    this.description = task.epic_key ?? undefined;
+    this.description = task.cat_key ?? undefined;
     this.tooltip = new vscode.MarkdownString(
       [
         `**${task.title}**`,
@@ -53,7 +53,7 @@ export class TaskTreeItem extends vscode.TreeItem {
         `ID: ${task.id}`,
         `Status: ${task.status}`,
         `Priority: ${task.priority}`,
-        task.epic_key ? `Epic: ${task.epic_key}` : null,
+        task.cat_key ? `Epic: ${task.cat_key}` : null,
         task.description ? `\n---\n${task.description}` : null,
       ]
         .filter(Boolean)

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -63,8 +63,8 @@ export interface Task {
   description: string | null;
   status: TaskStatus;
   priority: number;
-  epic_key: string | null;
-  epic_seq: number | null;
+  cat_key: string | null;
+  cat_seq: number | null;
   source_doc_id: number | null;
   parent_task_id: number | null;
   created_at: string;

--- a/vscode-extension/webview/src/tasks/TaskView.tsx
+++ b/vscode-extension/webview/src/tasks/TaskView.tsx
@@ -7,8 +7,8 @@ export interface Task {
   description: string | null;
   status: TaskStatus;
   priority: number;
-  epic_key: string | null;
-  epic_seq: number | null;
+  cat_key: string | null;
+  cat_seq: number | null;
   source_doc_id: number | null;
   parent_task_id: number | null;
   created_at: string;
@@ -253,8 +253,8 @@ export function TaskView() {
                             {task.priority > 0 ? `P${task.priority}` : ""}
                           </span>
                           <span className="task-title">{task.title}</span>
-                          {task.epic_key && (
-                            <span className="badge badge-category">{task.epic_key}</span>
+                          {task.cat_key && (
+                            <span className="badge badge-category">{task.cat_key}</span>
                           )}
                         </div>
                       );
@@ -304,8 +304,8 @@ function TaskDetail({ task, onStatusChange }: TaskDetailProps) {
           {task.priority > 0 && (
             <span className="meta-item">Priority: P{task.priority}</span>
           )}
-          {task.epic_key && (
-            <span className="meta-item">Epic: {task.epic_key}</span>
+          {task.cat_key && (
+            <span className="meta-item">Epic: {task.cat_key}</span>
           )}
         </div>
       </header>

--- a/vscode-extension/webview/src/types.ts
+++ b/vscode-extension/webview/src/types.ts
@@ -44,8 +44,8 @@ export interface Task {
   description: string | null;
   status: TaskStatus;
   priority: number;
-  epic_key: string | null;
-  epic_seq: number | null;
+  cat_key: string | null;
+  cat_seq: number | null;
   source_doc_id: number | null;
   parent_task_id: number | null;
   created_at: string;


### PR DESCRIPTION
## Summary

- **CLI:** Rename `--epic/-e` to `--parent/-p` in `task add` and `task plan`; keep `--epic` as hidden deprecated alias for backward compatibility
- **DB migration:** `20260413_000000` renames columns `epic_key→cat_key`, `epic_seq→cat_seq` (and their indexes) via `ALTER TABLE RENAME COLUMN`
- **Code:** All Python source + TypeScript extension files updated from `epic_key`/`epic_seq` → `cat_key`/`cat_seq`
- **Display:** `task ready` now shows parent-child hierarchy with `  ↳ ` indentation for subtasks whose parent is also in the ready list
- **Docs:** CLAUDE.md updated with a two-mechanism table clarifying `--cat` (namespace/prefix) vs `--parent` (hierarchy)

## Test plan

- [x] All 1491 tests pass (9 skipped)
- [x] `ruff check` passes with zero errors
- [x] Deprecated `--epic` alias accepted without error
- [x] New `--parent` flag works identically to old `--epic`
- [x] Migration applies cleanly on existing databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)