### PR TITLE
fix(embeddings): suppress HuggingFace noise during model loading

### DIFF
--- a/emdx/services/embedding_service.py
+++ b/emdx/services/embedding_service.py
@@ -7,7 +7,9 @@ enabling semantic search without API costs.
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import os
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -30,6 +32,47 @@ logger = logging.getLogger(__name__)
 # Lazy load - model is ~90MB, loads in ~2 seconds
 _model: SentenceTransformer | None = None
 
+# Loggers that emit noise during model loading
+_NOISY_LOGGERS = (
+    "huggingface_hub",
+    "transformers",
+    "sentence_transformers",
+    "filelock",
+)
+
+
+def _load_model_silently(cls: type) -> SentenceTransformer:
+    """Load the SentenceTransformer model while suppressing all stdout/stderr noise.
+
+    HuggingFace libraries emit tqdm progress bars for weight loading and an
+    unauthenticated-request warning to stdout/stderr. These corrupt CLI output
+    and break pipes. Suppress them for the duration of the load only.
+    """
+    # Silence noisy loggers temporarily
+    saved_levels: dict[str, int] = {}
+    for name in _NOISY_LOGGERS:
+        lg = logging.getLogger(name)
+        saved_levels[name] = lg.level
+        lg.setLevel(logging.ERROR)
+
+    # Also disable transformers progress bars via its own API if available
+    try:
+        import transformers.utils.logging as tfl
+
+        tfl.set_verbosity_error()
+    except Exception:
+        pass
+
+    # Redirect stdout and stderr to /dev/null to catch any remaining tqdm output
+    devnull = open(os.devnull, "w")
+    try:
+        with contextlib.redirect_stdout(devnull), contextlib.redirect_stderr(devnull):
+            return cls("all-MiniLM-L6-v2")
+    finally:
+        devnull.close()
+        for name, level in saved_levels.items():
+            logging.getLogger(name).setLevel(level)
+
 
 def _get_model() -> SentenceTransformer:
     """Lazy load the embedding model."""
@@ -49,7 +92,9 @@ def _get_model() -> SentenceTransformer:
 
         # all-MiniLM-L6-v2: Good balance of speed/quality
         # ~90MB download, ~80ms per doc, 384 dimensions
-        _model = SentenceTransformer("all-MiniLM-L6-v2")
+        # Suppress HuggingFace/transformers noise (tqdm progress bars, HF_TOKEN warning)
+        # that would otherwise leak to stdout/stderr during CLI and pipe usage.
+        _model = _load_model_silently(SentenceTransformer)
         logger.info("Loaded embedding model: all-MiniLM-L6-v2")
     return _model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ emdx = "emdx.main:run"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]
+
 [tool.ruff]
 line-length = 100
 
@@ -97,6 +102,8 @@ module = [
     "datasketch.*",
     "sentence_transformers",
     "sentence_transformers.*",
+    "transformers",
+    "transformers.*",
     "psutil",
     "psutil.*",
     "watchdog",


### PR DESCRIPTION
## Summary

- Adds `_load_model_silently()` helper in `embedding_service.py` that wraps `SentenceTransformer` initialization
- Redirects stdout/stderr to `/dev/null` during model load to suppress tqdm weight-loading progress bars
- Temporarily raises log level to ERROR for `huggingface_hub`, `transformers`, `sentence_transformers`, and `filelock` loggers to suppress the unauthenticated HF_TOKEN warning
- Also calls `transformers.utils.logging.set_verbosity_error()` when available as a belt-and-suspenders measure

Fixes #1027.

## Test plan

- [x] All 1838 non-TUI tests pass
- [x] `ruff check` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)