### PR TITLE
fix(edit): preserve Markdown headings — only strip the preamble (Issue #FIX-51)

### DIFF
--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -42,6 +42,11 @@ from emdx.utils.text_formatting import truncate_title
 
 app = typer.Typer(help="Core CRUD operations for documents")
 
+# Marks the end of the instructional header in `emdx edit` temp files.
+# Only lines above (and including) this are stripped on save, so Markdown
+# headings in the document body survive round-trips through the editor.
+EDIT_PREAMBLE_SENTINEL = "# ---- edit below this line; this marker and lines above are removed ----"
+
 
 @dataclass
 class InputContent:
@@ -1478,11 +1483,10 @@ def edit(
             tmp_file.write(f"# Editing: {doc.title} (ID: {doc.id})\n")
             tmp_file.write(f"# Project: {doc.project or 'None'}\n")
             tmp_file.write(f"# Created: {str(doc.created_at or '')[:16]}\n")
-            tmp_file.write("# Lines starting with '#' will be removed\n")
             tmp_file.write("#\n")
-            tmp_file.write("# First line (after comments) will be used as the title\n")
-            tmp_file.write("# The rest will be the content\n")
-            tmp_file.write("#\n")
+            tmp_file.write("# First line below the marker is the title\n")
+            tmp_file.write("# The rest is the content (saved verbatim, headings included)\n")
+            tmp_file.write(f"{EDIT_PREAMBLE_SENTINEL}\n")
 
             # Write title and content
             tmp_file.write(f"{doc.title}\n\n")
@@ -1502,8 +1506,19 @@ def edit(
             with open(tmp_file_path) as f:
                 lines = f.readlines()
 
-            # Remove comment lines
-            lines = [line for line in lines if not line.strip().startswith("#")]
+            # Strip only the instructional preamble, never the body: everything
+            # up to and including the sentinel line is discarded. If the user
+            # deleted the sentinel, fall back to dropping the leading comment
+            # block so Markdown headings in the body survive either way.
+            sentinel_idx = next(
+                (i for i, line in enumerate(lines) if line.strip() == EDIT_PREAMBLE_SENTINEL),
+                None,
+            )
+            if sentinel_idx is not None:
+                lines = lines[sentinel_idx + 1 :]
+            else:
+                while lines and lines[0].strip().startswith("#"):
+                    lines.pop(0)
 
             # Extract title and content
             if not lines:

--- a/tests/test_commands_core.py
+++ b/tests/test_commands_core.py
@@ -3,7 +3,7 @@
 import json
 import re
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
@@ -458,6 +458,81 @@ class TestEditCommand:
         """Edit with no ID should fail."""
         result = runner.invoke(app, ["edit"])
         assert result.exit_code != 0
+
+    def _doc_with_headings(self):
+        return Document.from_row(
+            {
+                "id": 7,
+                "title": "My Doc",
+                "content": "intro\n\n## Section A\n\nbody a\n\n## Section B\n\nbody b",
+                "project": None,
+                "created_at": datetime(2024, 1, 1),
+            }
+        )
+
+    @patch("emdx.commands.core.subprocess.run")
+    @patch("emdx.commands.core.update_document")
+    @patch("emdx.commands.core.get_document")
+    def test_edit_unchanged_is_noop(self, mock_get_doc, mock_update, mock_run):
+        """Saving the buffer untouched must not change the document (GH #1035)."""
+        mock_get_doc.return_value = self._doc_with_headings()
+        mock_run.return_value = MagicMock(returncode=0)  # editor saves unchanged
+
+        result = runner.invoke(app, ["edit", "7"])
+        assert result.exit_code == 0
+        assert "No changes made" in _out(result)
+        mock_update.assert_not_called()
+
+    @patch("emdx.commands.core.subprocess.run")
+    @patch("emdx.commands.core.update_document")
+    @patch("emdx.commands.core.get_document")
+    def test_edit_preserves_markdown_headings(self, mock_get_doc, mock_update, mock_run):
+        """Lines starting with # in the body survive an edit (GH #1035)."""
+        mock_get_doc.return_value = self._doc_with_headings()
+        mock_update.return_value = True
+
+        def fake_editor(cmd, *args, **kwargs):
+            path = cmd[1]
+            with open(path) as f:
+                buffer = f.read()
+            with open(path, "w") as f:
+                f.write(buffer + "\n\n## Section C\n\nsee #42 for details\n")
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_editor
+
+        result = runner.invoke(app, ["edit", "7"])
+        assert result.exit_code == 0
+        mock_update.assert_called_once()
+        _, new_title, new_content = mock_update.call_args[0]
+        assert new_title == "My Doc"
+        assert "## Section A" in new_content
+        assert "## Section B" in new_content
+        assert "## Section C" in new_content
+        assert "#42 for details" in new_content
+
+    @patch("emdx.commands.core.subprocess.run")
+    @patch("emdx.commands.core.update_document")
+    @patch("emdx.commands.core.get_document")
+    def test_edit_sentinel_deleted_falls_back(self, mock_get_doc, mock_update, mock_run):
+        """If the user deletes the whole preamble, body headings still survive."""
+        mock_get_doc.return_value = self._doc_with_headings()
+        mock_update.return_value = True
+
+        def fake_editor(cmd, *args, **kwargs):
+            path = cmd[1]
+            with open(path, "w") as f:
+                f.write("My Doc\n\nnew intro\n\n## Kept Heading\n\nbody\n")
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_editor
+
+        result = runner.invoke(app, ["edit", "7"])
+        assert result.exit_code == 0
+        mock_update.assert_called_once()
+        _, new_title, new_content = mock_update.call_args[0]
+        assert new_title == "My Doc"
+        assert "## Kept Heading" in new_content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `emdx edit` stripped **every** line starting with `#` from the edited buffer, silently destroying Markdown headings in the body and clobbering titles (#1035)
- The instructional header is now delimited by a sentinel line; only the preamble (sentinel and above) is discarded on save
- If the user deletes the sentinel, we fall back to dropping just the leading comment block, so body headings still survive
- Editing a doc and saving it unchanged is now a guaranteed no-op

## Test plan
- [x] New regression tests: unchanged round-trip is a no-op, body headings/`#42` refs survive edits, sentinel-deleted fallback
- [x] Full suite: 2079 passed
- [x] ruff + mypy clean

Fixes #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)