### PR TITLE
chore(ci): remove PEP 735 dependency-groups section shadowing dev deps (Issue #FIX-55)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,6 @@ emdx = "emdx.main:run"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[dependency-groups]
-dev = [
-    "pytest>=9.0.3",
-]
-
 [tool.ruff]
 line-length = 100
 


### PR DESCRIPTION
## Summary
- CI has been red on every branch since the `[dependency-groups]` section landed in #1028
- On the latest Poetry (installed as `version: latest` in CI), a PEP 735 `dev` group **shadows** `[tool.poetry.group.dev.dependencies]`, so CI's dev install resolved to just `pytest` — no pytest-cov (`unrecognized arguments: --cov`), no mypy (`Command not found: mypy`), no ruff
- The `pytest>=9.0.3` constraint is already covered by `pytest = "^9.0.0"` in the poetry dev group, so the section is pure duplication — deleted

## Test plan
- [x] `poetry check` passes
- [x] This PR's own CI run is the real test: test (3.11/3.13) and type-check should go green for the first time since April

🤖 Generated with [Claude Code](https://claude.com/claude-code)