### PR TITLE
fix(save): never block on idle non-TTY stdin (Issue #FIX-52)

### DIFF
--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -11,7 +11,7 @@ emdx [OPTIONS] COMMAND [ARGS]...
 ## 📚 **Document Management**
 
 ### **emdx save**
-Save content to the knowledge base. Content sources in priority order: stdin > `--file` > positional argument.
+Save content to the knowledge base. Content sources in priority order: `--file` > positional argument > stdin.
 
 ```bash
 # Save inline content (positional arg is always content, never a file path)

--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -65,13 +65,35 @@ class DocumentMetadata:
     project: str | None = None
 
 
+# How long to wait for data on an open non-TTY stdin before treating it as
+# empty. Only applies when stdin is the sole possible content source; a
+# wedged harness that holds stdin open forever gets a clean error instead
+# of hanging the process (see #1034).
+STDIN_PROBE_TIMEOUT = 5.0
+
+
+def _stdin_ready(timeout: float) -> bool:
+    """Return True if stdin has data (or EOF) available within timeout."""
+    import select
+    import sys
+
+    try:
+        ready, _, _ = select.select([sys.stdin], [], [], timeout)
+    except (OSError, ValueError, TypeError):
+        # Unprobeable stdin (e.g. Windows non-socket, test doubles):
+        # fall back to the blocking read rather than dropping input.
+        return True
+    return bool(ready)
+
+
 def get_input_content(input_arg: str | None, file_path: str | None = None) -> InputContent:
     """Handle input from stdin, --file, or positional content argument.
 
-    Priority: --file > stdin > positional content arg.
+    Priority: --file > positional content arg > stdin.
 
-    When --file is explicitly provided, stdin is skipped entirely to avoid
-    blocking on non-TTY stdin that has no data (see #732).
+    When --file or a positional argument is provided, stdin is never read:
+    probing an open non-TTY stdin that has no data blocks forever under
+    backgrounded/tool-invoked callers (see #732, #1034).
     """
     import sys
 
@@ -88,16 +110,16 @@ def get_input_content(input_arg: str | None, file_path: str | None = None) -> In
             console.print(f"[red]Error reading file: {e}[/red]")
             raise typer.Exit(1) from e
 
-    # Priority 2: Check if stdin has data
-    if not sys.stdin.isatty():
+    # Priority 2: Positional argument (skip stdin — content already in hand)
+    if input_arg:
+        return InputContent(content=input_arg, source_type="direct")
+
+    # Priority 3: stdin, guarded so an open-but-idle stdin can't wedge us
+    if not sys.stdin.isatty() and _stdin_ready(STDIN_PROBE_TIMEOUT):
         content = sys.stdin.read()
         if content.strip():  # Only use stdin if it has actual content
             return InputContent(content=content, source_type="stdin")
         # Fall through if stdin is empty
-
-    # Priority 3: Positional argument is always treated as content
-    if input_arg:
-        return InputContent(content=input_arg, source_type="direct")
 
     # No input provided
     console.print(
@@ -214,7 +236,7 @@ def save(
 ) -> None:
     """Save content to the knowledge base.
 
-    Content sources (in priority order): --file > stdin > positional argument.
+    Content sources (in priority order): --file > positional argument > stdin.
     """
     # Validate --done requires --task
     if mark_done and task is None:

--- a/tests/test_commands_core.py
+++ b/tests/test_commands_core.py
@@ -65,6 +65,43 @@ class TestGetInputContent:
         assert result.content == "piped content"
         assert result.source_type == "stdin"
 
+    @patch("sys.stdin")
+    def test_positional_skips_stdin_probe(self, mock_stdin):
+        """Positional arg must never touch stdin, even open non-TTY stdin (GH #1034)."""
+        mock_stdin.isatty.return_value = False
+        mock_stdin.read.side_effect = AssertionError("stdin.read() must not be called")
+
+        result = get_input_content("hello world")
+        assert result.content == "hello world"
+        assert result.source_type == "direct"
+        mock_stdin.read.assert_not_called()
+
+    @patch("sys.stdin")
+    def test_file_skips_stdin_probe(self, mock_stdin, tmp_path):
+        """--file must never touch stdin, even open non-TTY stdin (GH #1034)."""
+        mock_stdin.isatty.return_value = False
+        mock_stdin.read.side_effect = AssertionError("stdin.read() must not be called")
+        f = tmp_path / "note.md"
+        f.write_text("file content")
+
+        result = get_input_content(None, file_path=str(f))
+        assert result.content == "file content"
+        mock_stdin.read.assert_not_called()
+
+    @patch("emdx.commands.core._stdin_ready", return_value=False)
+    @patch("sys.stdin")
+    def test_idle_stdin_errors_instead_of_hanging(self, mock_stdin, mock_ready):
+        """Open non-TTY stdin with no data errors out instead of blocking (GH #1034)."""
+        import pytest
+        from click.exceptions import Exit
+
+        mock_stdin.isatty.return_value = False
+        mock_stdin.read.side_effect = AssertionError("stdin.read() must not be called")
+
+        with pytest.raises(Exit):
+            get_input_content(None)
+        mock_stdin.read.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # generate_title helper

--- a/tests/test_input_content.py
+++ b/tests/test_input_content.py
@@ -11,15 +11,31 @@ from emdx.commands.core import get_input_content
 
 
 class TestStdinInput:
-    """Stdin takes highest priority when it has content."""
+    """Stdin is the fallback source when no explicit content is given."""
 
-    def test_stdin_with_content_wins_over_positional_arg(self):
-        stdin_content = "# From stdin\n\nShould take priority."
-        mock_stdin = io.StringIO(stdin_content)
+    def test_positional_arg_wins_over_stdin(self):
+        """Explicit positional content skips stdin entirely (#1034).
+
+        Probing an open non-TTY stdin with no data blocks forever under
+        backgrounded/tool-invoked callers, so a positional arg must never
+        touch stdin.
+        """
+        mock_stdin = io.StringIO("# From stdin\n\nMust be ignored.")
 
         with patch("sys.stdin", mock_stdin):
             with patch("sys.stdin.isatty", return_value=False):
                 result = get_input_content("positional text")
+
+        assert result.source_type == "direct"
+        assert result.content == "positional text"
+
+    def test_stdin_used_when_no_other_source(self):
+        stdin_content = "# From stdin\n\nOnly source available."
+        mock_stdin = io.StringIO(stdin_content)
+
+        with patch("sys.stdin", mock_stdin):
+            with patch("sys.stdin.isatty", return_value=False):
+                result = get_input_content(None)
 
         assert result.source_type == "stdin"
         assert "From stdin" in result.content
@@ -41,13 +57,13 @@ class TestStdinInput:
         finally:
             Path(fpath).unlink()
 
-    def test_whitespace_only_stdin_falls_through(self):
+    def test_whitespace_only_stdin_errors_when_sole_source(self):
+        import typer
+
         with patch("sys.stdin", io.StringIO("   \n\t  \n  ")):
             with patch("sys.stdin.isatty", return_value=False):
-                result = get_input_content("direct text")
-
-        assert result.source_type == "direct"
-        assert result.content == "direct text"
+                with pytest.raises(typer.Exit):
+                    get_input_content(None)
 
 
 class TestFileInput:


### PR DESCRIPTION
## Summary
- `emdx save --title Untitled` probed stdin with an unconditional blocking `sys.stdin.read()` **before** consulting the positional argument, so callers that leave stdin open without EOF (backgrounded processes, agent/CI harnesses) wedged forever — even with content passed positionally (#1034)
- Positional arg and `--file` now skip the stdin probe entirely; documented priority becomes `--file` > positional > stdin
- Bare `emdx save --title Untitled` guards the stdin read with `select()` + 5s timeout: an open-but-idle stdin now yields a clean 'No input provided' error instead of a hang
- Unprobeable stdin (Windows, odd fds) falls back to the old blocking read, so no input is ever dropped

## Behavior change
`echo x | emdx save --title Untitled "y"` previously saved the piped stdin; it now saves the positional `y`. This is the fix the issue asks for — explicit content beats an implicit pipe.

## Test plan
- [x] New regression tests: positional/--file never touch stdin; idle stdin errors instead of hanging
- [x] Updated priority tests in test_input_content.py
- [x] Full suite: 2083 passed
- [x] ruff clean

Fixes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)