### PR TITLE
fix(tasks): make list --all actually return all tasks (Issue #FIX-53)

### DIFF
--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -838,7 +838,9 @@ def list_cmd(
     status: str | None = typer.Option(None, "-s", "--status", help="Filter by status (comma-sep)"),
     all: bool = typer.Option(False, "--all", "-a", help="Include all tasks"),
     done: bool = typer.Option(False, "--done", help="Show done tasks"),
-    limit: int = typer.Option(20, "-n", "--limit"),
+    limit: int | None = typer.Option(
+        None, "-n", "--limit", help="Max tasks to show (default 20; --all shows everything)"
+    ),
     epic: TaskRef | None = typer.Option(None, "-e", "--epic", help="Epic ID (e.g. 510 or SEC-1)"),
     cat: str | None = typer.Option(None, "-c", "--cat", help="Filter by category"),
     since: str | None = typer.Option(
@@ -882,6 +884,11 @@ def list_cmd(
         status_list = ["done"]
     else:
         status_list = ["open", "active", "blocked"]
+
+    # --all means all: only cap when the user explicitly passed -n/--limit.
+    # SQLite treats LIMIT -1 as unlimited.
+    if limit is None:
+        limit = -1 if all else 20
 
     resolved_epic = _resolve_id(epic) if epic else None
     task_list = tasks.list_tasks(

--- a/tests/test_task_commands.py
+++ b/tests/test_task_commands.py
@@ -452,12 +452,13 @@ class TestTaskList:
 
     @patch("emdx.commands.tasks.tasks")
     def test_list_includes_all_statuses_with_all_flag(self, mock_tasks):
+        """--all bypasses the default limit entirely (GH #1014)."""
         mock_tasks.list_tasks.return_value = []
         result = runner.invoke(app, ["list", "--all"])
         assert result.exit_code == 0
         mock_tasks.list_tasks.assert_called_once_with(
             status=None,
-            limit=20,
+            limit=-1,
             epic_key=None,
             parent_task_id=None,
             since=None,
@@ -470,7 +471,21 @@ class TestTaskList:
         assert result.exit_code == 0
         mock_tasks.list_tasks.assert_called_once_with(
             status=None,
-            limit=20,
+            limit=-1,
+            epic_key=None,
+            parent_task_id=None,
+            since=None,
+        )
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_list_all_with_explicit_limit_respects_it(self, mock_tasks):
+        """An explicit -n alongside --all still caps the result (GH #1014)."""
+        mock_tasks.list_tasks.return_value = []
+        result = runner.invoke(app, ["list", "--all", "-n", "5"])
+        assert result.exit_code == 0
+        mock_tasks.list_tasks.assert_called_once_with(
+            status=None,
+            limit=5,
             epic_key=None,
             parent_task_id=None,
             since=None,


### PR DESCRIPTION
## Summary
- `emdx task list --all` silently applied the default `--limit 20`, truncating output (#1014)
- `--all` now bypasses the limit entirely (SQLite `LIMIT -1` = unlimited)
- An explicit `-n`/`--limit` passed alongside `--all` still wins

## Test plan
- [x] Updated tests assert `limit=-1` for `--all`/`-a`, new test for `--all -n 5`
- [x] Full suite: 2084 passed
- [x] ruff clean

Fixes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)