### PR TITLE
fix(prime): show full epic IDs in ACTIVE EPICS banner (Issue #FIX-54)

### DIFF
--- a/emdx/commands/prime.py
+++ b/emdx/commands/prime.py
@@ -294,11 +294,24 @@ def _task_label(task: ReadyTask | InProgressTask) -> str:
     return f"{label:<13}"
 
 
+def _epic_label(epic: EpicInfo) -> str:
+    """Full epic identifier (e.g. FIX-50), matching `task epic list`'s Key column.
+
+    Showing only the key prefix invites `--epic <KEY>` guesses that resolve
+    to nothing (see #1029).
+    """
+    epic_key = epic.get("epic_key")
+    epic_seq = epic.get("epic_seq")
+    if epic_key and epic_seq:
+        return f"{epic_key}-{epic_seq}"
+    return epic_key or f"#{epic['id']}"
+
+
 def _format_epic_line(epic: EpicInfo) -> str:
     """Format an epic line with progress bar."""
     done = epic["children_done"]
     total = epic["child_count"]
-    cat = epic.get("epic_key") or ""
+    label = _epic_label(epic)
 
     # Progress bar: 5 chars wide
     if total > 0:
@@ -311,15 +324,15 @@ def _format_epic_line(epic: EpicInfo) -> str:
         progress = "     no tasks"
 
     name = epic["title"][:30]
-    return f"  {cat:<10}{name:<32}{progress}"
+    return f"  {label:<13}{name:<32}{progress}"
 
 
 def _format_epic_brief(epic: EpicInfo) -> str:
     """Format an epic as a compact one-liner for brief mode."""
     done = epic["children_done"]
     total = epic["child_count"]
-    cat = epic.get("epic_key") or ""
-    prefix = f"{cat}: " if cat else ""
+    label = _epic_label(epic)
+    prefix = f"{label}: " if epic.get("epic_key") else ""
     return f"  {prefix}{epic['title']} — {done}/{total} done"
 
 
@@ -333,7 +346,7 @@ def _get_active_epics() -> list[EpicInfo]:
     with db.get_connection() as conn:
         cursor = conn.cursor()
         cursor.execute("""
-            SELECT t.id, t.title, t.status, t.epic_key,
+            SELECT t.id, t.title, t.status, t.epic_key, t.epic_seq,
                 COUNT(c.id) as child_count,
                 COUNT(CASE WHEN c.status IN ('done', 'duplicate')
                     THEN 1 END) as children_done
@@ -350,8 +363,9 @@ def _get_active_epics() -> list[EpicInfo]:
                 title=r[1],
                 status=r[2],
                 epic_key=r[3],
-                child_count=r[4],
-                children_done=r[5],
+                epic_seq=r[4],
+                child_count=r[5],
+                children_done=r[6],
             )
             for r in rows
         ]

--- a/emdx/commands/types.py
+++ b/emdx/commands/types.py
@@ -17,6 +17,7 @@ class EpicInfo(TypedDict):
     title: str
     status: str
     epic_key: str | None
+    epic_seq: int | None
     child_count: int
     children_done: int
 

--- a/tests/test_commands_prime.py
+++ b/tests/test_commands_prime.py
@@ -47,13 +47,20 @@ def _make_task(
 
 
 def _make_epic(
-    id=100, title="My Epic", status="active", epic_key="SEC", child_count=5, children_done=2
+    id=100,
+    title="My Epic",
+    status="active",
+    epic_key="SEC",
+    epic_seq=1,
+    child_count=5,
+    children_done=2,
 ):
     return {
         "id": id,
         "title": title,
         "status": status,
         "epic_key": epic_key,
+        "epic_seq": epic_seq,
         "child_count": child_count,
         "children_done": children_done,
     }
@@ -90,6 +97,19 @@ class TestFormatEpicLine:
         assert "2/5 done" in line
         assert "\u25a0" in line
         assert "\u25a1" in line
+
+    def test_shows_full_epic_id(self):
+        """Banner rows show KEY-SEQ, not just the key prefix (GH #1029)."""
+        line = _format_epic_line(_make_epic(epic_key="FOO", epic_seq=12))
+        assert "FOO-12" in line
+
+    def test_missing_seq_falls_back_to_key(self):
+        line = _format_epic_line(_make_epic(epic_key="FOO", epic_seq=None))
+        assert "FOO" in line
+
+    def test_missing_key_falls_back_to_id(self):
+        line = _format_epic_line(_make_epic(id=321, epic_key=None, epic_seq=None))
+        assert "#321" in line
 
     def test_complete_epic_shows_checkmark(self):
         line = _format_epic_line(_make_epic(child_count=3, children_done=3))
@@ -659,9 +679,15 @@ class TestPrimeWithKeyDocs:
 class TestFormatEpicBrief:
     def test_shows_key_and_progress(self):
         line = _format_epic_brief(
-            _make_epic(epic_key="FEAT", title="Next Intelligence", child_count=18, children_done=3)
+            _make_epic(
+                epic_key="FEAT",
+                epic_seq=7,
+                title="Next Intelligence",
+                child_count=18,
+                children_done=3,
+            )
         )
-        assert "FEAT: Next Intelligence" in line
+        assert "FEAT-7: Next Intelligence" in line
         assert "3/18 done" in line
 
     def test_no_epic_key(self):
@@ -706,6 +732,7 @@ class TestPrimeBrief:
         mock_epics.return_value = [
             _make_epic(
                 epic_key="FEAT",
+                epic_seq=7,
                 title="Next Intelligence",
                 child_count=18,
                 children_done=3,
@@ -716,7 +743,7 @@ class TestPrimeBrief:
 
         result = runner.invoke(app, ["--brief"])
         assert "ACTIVE EPICS" in result.stdout
-        assert "FEAT: Next Intelligence" in result.stdout
+        assert "FEAT-7: Next Intelligence" in result.stdout
         assert "3/18 done" in result.stdout
 
     @patch("emdx.commands.prime._get_active_epics")


### PR DESCRIPTION
## Summary
- `emdx prime` epic rows showed only the `epic_key` prefix — multiple epics sharing a key were indistinguishable, and callers (especially agents) guessed `--epic <KEY>`, which wants a full epic ID (#1029)
- Rows now render `KEY-SEQ` (e.g. `FIX-50`), matching `task epic list`'s Key column; label column widened to the same 13 chars task rows use
- `--brief` mode shows the full ID too; graceful fallbacks when key/seq are missing

## Test plan
- [x] New unit tests for full-ID rendering + fallbacks
- [x] Updated brief-mode expectations
- [x] Full suite passes locally; mypy clean on touched files

Fixes #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)