### PR TITLE
feat(embeddings): prefer fastembed ONNX backend for ~14x faster cold start (Issue #FEAT-74)

### DIFF
--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -700,6 +700,14 @@ emdx maintain index --clear
 - `--stats` - Show index statistics
 - `--clear` - Clear all embeddings
 
+**Embedding backend:** emdx embeds with all-MiniLM-L6-v2, preferring the
+fastembed (ONNX) backend when installed — ~0.4s cold start vs ~5.5s for
+torch-based sentence-transformers, which remains the fallback. Set
+`EMDX_EMBEDDING_BACKEND=fastembed|sentence-transformers` to force one.
+Each backend stores vectors under its own `model_name`, so switching
+backends requires one `emdx maintain index` to rebuild (old vectors are
+ignored, not corrupted).
+
 #### **emdx maintain link**
 Create semantic links between related documents (moved from `emdx ai link`).
 

--- a/emdx/services/embedding_service.py
+++ b/emdx/services/embedding_service.py
@@ -1,20 +1,26 @@
 """
 Semantic embedding service for EMDX.
 
-Uses sentence-transformers for local embedding generation,
-enabling semantic search without API costs.
+Generates local embeddings for semantic search without API costs.
+Prefers the fastembed (ONNX) backend — same all-MiniLM-L6-v2 model as
+sentence-transformers but ~0.4s cold start instead of ~5.5s, since it
+avoids importing torch. Falls back to sentence-transformers when
+fastembed is not installed. Override with EMDX_EMBEDDING_BACKEND.
 """
 
 from __future__ import annotations
 
 import contextlib
+import importlib.util
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
+    from fastembed import TextEmbedding
     from sentence_transformers import SentenceTransformer
 
 try:
@@ -29,20 +35,78 @@ from ..database import db
 
 logger = logging.getLogger(__name__)
 
-# Lazy load - model is ~90MB, loads in ~2 seconds
-_model: SentenceTransformer | None = None
+_T = TypeVar("_T")
+
+BACKEND_ENV_VAR = "EMDX_EMBEDDING_BACKEND"
+_BACKEND_FASTEMBED = "fastembed"
+_BACKEND_SENTENCE_TRANSFORMERS = "sentence-transformers"
+
+# Lazy load — the model is ~90MB and loading it is the dominant startup cost
+_model: _FastembedModel | _SentenceTransformerModel | None = None
 
 # Loggers that emit noise during model loading
 _NOISY_LOGGERS = (
     "huggingface_hub",
     "transformers",
     "sentence_transformers",
+    "fastembed",
     "filelock",
 )
 
 
-def _load_model_silently(cls: type) -> SentenceTransformer:
-    """Load the SentenceTransformer model while suppressing all stdout/stderr noise.
+def _backend_name() -> str:
+    """Resolve which embedding backend to use.
+
+    EMDX_EMBEDDING_BACKEND wins if set to a known backend; otherwise
+    fastembed is preferred when importable. find_spec keeps this check
+    cheap — resolution must not import either backend.
+    """
+    override = os.environ.get(BACKEND_ENV_VAR)
+    if override in (_BACKEND_FASTEMBED, _BACKEND_SENTENCE_TRANSFORMERS):
+        return override
+    if override:
+        logger.warning("Unknown %s=%r — ignoring", BACKEND_ENV_VAR, override)
+    if importlib.util.find_spec("fastembed") is not None:
+        return _BACKEND_FASTEMBED
+    return _BACKEND_SENTENCE_TRANSFORMERS
+
+
+class _FastembedModel:
+    """Adapter giving fastembed's TextEmbedding an encode() like sentence-transformers.
+
+    Returns L2-normalized float32 vectors: 1-D for a single string,
+    2-D for a list. fastembed already normalizes; it yields float64,
+    so cast to float32 to match the DB blob format.
+    """
+
+    def __init__(self, model: TextEmbedding) -> None:
+        self._model = model
+
+    def encode(self, texts: str | list[str]) -> np.ndarray:
+        single = isinstance(texts, str)
+        inputs = [texts] if isinstance(texts, str) else texts
+        vectors = np.asarray(list(self._model.embed(inputs)), dtype=np.float32)
+        return vectors[0] if single else vectors
+
+
+class _SentenceTransformerModel:
+    """Adapter pinning the encode() options the service relies on."""
+
+    def __init__(self, model: SentenceTransformer) -> None:
+        self._model = model
+
+    def encode(self, texts: str | list[str]) -> np.ndarray:
+        result: np.ndarray = self._model.encode(
+            texts,
+            convert_to_numpy=True,
+            normalize_embeddings=True,
+            show_progress_bar=False,
+        )
+        return result
+
+
+def _load_model_silently(factory: Callable[[], _T]) -> _T:
+    """Run a model-loading factory while suppressing all stdout/stderr noise.
 
     HuggingFace libraries emit tqdm progress bars for weight loading and an
     unauthenticated-request warning to stdout/stderr. These corrupt CLI output
@@ -67,35 +131,49 @@ def _load_model_silently(cls: type) -> SentenceTransformer:
     devnull = open(os.devnull, "w")
     try:
         with contextlib.redirect_stdout(devnull), contextlib.redirect_stderr(devnull):
-            return cls("all-MiniLM-L6-v2")
+            return factory()
     finally:
         devnull.close()
         for name, level in saved_levels.items():
             logging.getLogger(name).setLevel(level)
 
 
-def _get_model() -> SentenceTransformer:
-    """Lazy load the embedding model."""
+def _get_model() -> _FastembedModel | _SentenceTransformerModel:
+    """Lazy load the embedding model on the resolved backend."""
     global _model
     if _model is None:
         if not HAS_NUMPY:
             raise ImportError(
                 "numpy is required for embedding features. Install it with: pip install 'emdx[ai]'"
             ) from None
-        try:
-            from sentence_transformers import SentenceTransformer
-        except ImportError:
-            raise ImportError(
-                "sentence-transformers is required for embedding features. "
-                "Install it with: pip install 'emdx[ai]'"
-            ) from None
 
-        # all-MiniLM-L6-v2: Good balance of speed/quality
+        # all-MiniLM-L6-v2: good balance of speed/quality
         # ~90MB download, ~80ms per doc, 384 dimensions
-        # Suppress HuggingFace/transformers noise (tqdm progress bars, HF_TOKEN warning)
-        # that would otherwise leak to stdout/stderr during CLI and pipe usage.
-        _model = _load_model_silently(SentenceTransformer)
-        logger.info("Loaded embedding model: all-MiniLM-L6-v2")
+        backend = _backend_name()
+        if backend == _BACKEND_FASTEMBED:
+            try:
+                from fastembed import TextEmbedding
+            except ImportError:
+                raise ImportError(
+                    "fastembed is required for embedding features "
+                    f"(requested via {BACKEND_ENV_VAR} or auto-detected). "
+                    "Install it with: pip install fastembed"
+                ) from None
+            _model = _load_model_silently(
+                lambda: _FastembedModel(TextEmbedding("sentence-transformers/all-MiniLM-L6-v2"))
+            )
+        else:
+            try:
+                from sentence_transformers import SentenceTransformer
+            except ImportError:
+                raise ImportError(
+                    "sentence-transformers is required for embedding features. "
+                    "Install it with: pip install 'emdx[ai]'"
+                ) from None
+            _model = _load_model_silently(
+                lambda: _SentenceTransformerModel(SentenceTransformer("all-MiniLM-L6-v2"))
+            )
+        logger.info("Loaded embedding model: all-MiniLM-L6-v2 (backend: %s)", backend)
     return _model
 
 
@@ -146,14 +224,25 @@ class EmbeddingStats:
 class EmbeddingService:
     """Manages document embeddings for semantic search."""
 
-    MODEL_NAME = "all-MiniLM-L6-v2"
     EMBEDDING_DIM = 384
+
+    @property
+    def MODEL_NAME(self) -> str:
+        """DB partition key for embeddings — historically a class constant.
+
+        The quantized ONNX weights fastembed ships produce slightly different
+        vectors than the torch weights, so each backend gets its own key to
+        keep the two vector spaces from mixing. Switching backends therefore
+        requires one re-index (emdx maintain index).
+        """
+        if _backend_name() == _BACKEND_FASTEMBED:
+            return "all-MiniLM-L6-v2-onnx"
+        return "all-MiniLM-L6-v2"
 
     def embed_text(self, text: str) -> np.ndarray:
         """Embed arbitrary text."""
         model = _get_model()
-        result: np.ndarray = model.encode(text, convert_to_numpy=True, normalize_embeddings=True)
-        return result
+        return model.encode(text)
 
     def embed_document(self, doc_id: int, force: bool = False) -> np.ndarray:
         """Embed a document (cached in database)."""
@@ -253,12 +342,7 @@ class EmbeddingService:
             texts = [f"{title}\n\n{content}" for _, title, content in batch]
 
             # Batch encode
-            embeddings = model.encode(
-                texts,
-                convert_to_numpy=True,
-                normalize_embeddings=True,
-                show_progress_bar=False,
-            )
+            embeddings = model.encode(texts)
 
             # Save all embeddings in batch
             with db.get_connection() as conn:
@@ -509,12 +593,7 @@ class EmbeddingService:
 
             # Embed all chunks for this document
             texts = [chunk.text for chunk in chunks]
-            embeddings = model.encode(
-                texts,
-                convert_to_numpy=True,
-                normalize_embeddings=True,
-                show_progress_bar=False,
-            )
+            embeddings = model.encode(texts)
 
             # Save chunk embeddings
             with db.get_connection() as conn:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ google-auth-oauthlib = "^1.2.0"
 [tool.poetry.group.ml.dependencies]
 scikit-learn = "^1.6.0"
 datasketch = "^1.6.0"
+fastembed = "^0.8.0"
 sentence-transformers = "^5.2.2"
 numpy = "^2.4.2"
 
@@ -97,6 +98,8 @@ module = [
     "datasketch.*",
     "sentence_transformers",
     "sentence_transformers.*",
+    "fastembed",
+    "fastembed.*",
     "transformers",
     "transformers.*",
     "psutil",

--- a/tests/test_embedding_backend.py
+++ b/tests/test_embedding_backend.py
@@ -1,0 +1,108 @@
+"""Tests for embedding backend selection and adapters.
+
+The backends themselves (fastembed, sentence-transformers) are never
+imported here — model loading costs seconds and downloads weights. These
+tests cover the resolution logic and the adapter contracts with mocks.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from emdx.services import embedding_service
+from emdx.services.embedding_service import (
+    BACKEND_ENV_VAR,
+    EmbeddingService,
+    _backend_name,
+    _FastembedModel,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_backend_env(monkeypatch):
+    """Isolate each test from the host's backend override and model cache."""
+    monkeypatch.delenv(BACKEND_ENV_VAR, raising=False)
+    monkeypatch.setattr(embedding_service, "_model", None)
+
+
+class TestBackendResolution:
+    def test_env_override_fastembed(self, monkeypatch):
+        monkeypatch.setenv(BACKEND_ENV_VAR, "fastembed")
+        assert _backend_name() == "fastembed"
+
+    def test_env_override_sentence_transformers(self, monkeypatch):
+        monkeypatch.setenv(BACKEND_ENV_VAR, "sentence-transformers")
+        assert _backend_name() == "sentence-transformers"
+
+    def test_unknown_override_falls_through_to_detection(self, monkeypatch):
+        monkeypatch.setenv(BACKEND_ENV_VAR, "bogus-backend")
+        with patch.object(embedding_service.importlib.util, "find_spec", return_value=None):
+            assert _backend_name() == "sentence-transformers"
+
+    def test_prefers_fastembed_when_installed(self):
+        with patch.object(
+            embedding_service.importlib.util, "find_spec", return_value=MagicMock()
+        ) as find_spec:
+            assert _backend_name() == "fastembed"
+        find_spec.assert_called_once_with("fastembed")
+
+    def test_falls_back_when_fastembed_missing(self):
+        with patch.object(embedding_service.importlib.util, "find_spec", return_value=None):
+            assert _backend_name() == "sentence-transformers"
+
+
+class TestModelNamePartitioning:
+    """Each backend gets its own model_name key so vector spaces never mix."""
+
+    def test_fastembed_model_name(self, monkeypatch):
+        monkeypatch.setenv(BACKEND_ENV_VAR, "fastembed")
+        assert EmbeddingService().MODEL_NAME == "all-MiniLM-L6-v2-onnx"
+
+    def test_sentence_transformers_model_name(self, monkeypatch):
+        monkeypatch.setenv(BACKEND_ENV_VAR, "sentence-transformers")
+        assert EmbeddingService().MODEL_NAME == "all-MiniLM-L6-v2"
+
+
+class TestFastembedAdapter:
+    """The adapter must match sentence-transformers' encode() shape semantics."""
+
+    def _adapter(self):
+        inner = MagicMock()
+        # fastembed yields one float64 vector per input text
+        inner.embed.side_effect = lambda texts: iter(
+            np.ones(4, dtype=np.float64) * (i + 1) for i in range(len(texts))
+        )
+        return _FastembedModel(inner), inner
+
+    def test_single_string_returns_1d_float32(self):
+        adapter, inner = self._adapter()
+        vec = adapter.encode("hello")
+        assert vec.shape == (4,)
+        assert vec.dtype == np.float32
+        inner.embed.assert_called_once_with(["hello"])
+
+    def test_list_returns_2d_float32(self):
+        adapter, inner = self._adapter()
+        vecs = adapter.encode(["a", "b", "c"])
+        assert vecs.shape == (3, 4)
+        assert vecs.dtype == np.float32
+        inner.embed.assert_called_once_with(["a", "b", "c"])
+
+
+class TestGetModel:
+    def test_import_error_when_forced_backend_missing(self, monkeypatch):
+        monkeypatch.setenv(BACKEND_ENV_VAR, "fastembed")
+        with (
+            patch.dict("sys.modules", {"fastembed": None}),
+            pytest.raises(ImportError, match="fastembed"),
+        ):
+            embedding_service._get_model()
+
+    def test_model_is_cached(self, monkeypatch):
+        monkeypatch.setenv(BACKEND_ENV_VAR, "fastembed")
+        fake = MagicMock()
+        monkeypatch.setattr(embedding_service, "_model", fake)
+        assert embedding_service._get_model() is fake

--- a/tests/test_embedding_backend.py
+++ b/tests/test_embedding_backend.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
 
-from emdx.services import embedding_service
-from emdx.services.embedding_service import (
+np = pytest.importorskip("numpy")
+
+from emdx.services import embedding_service  # noqa: E402
+from emdx.services.embedding_service import (  # noqa: E402
     BACKEND_ENV_VAR,
     EmbeddingService,
     _backend_name,


### PR DESCRIPTION
## Summary

Every `emdx save` with an embedding index present pays the full model startup cost: **5.5s and ~445MB peak RSS**, of which 3.7s is importing torch, 1.7s loading the model, and only 0.15s actual embedding work. This PR swaps in **fastembed** (ONNX runtime, no torch) running the *identical* `all-MiniLM-L6-v2` model: **0.40s total** (0.30s import + 0.09s load + 0.013s encode).

Auto-link-on-save stays synchronous and instant — no deferred queues, no daemon.

| | torch / sentence-transformers | fastembed (ONNX) |
|---|---|---|
| import | 3.68s | 0.30s |
| model load | 1.68s | 0.09s |
| encode 1 doc | 0.148s | 0.013s |
| **total** | **5.5s** | **0.40s** |
| peak RSS | 445MB | ~330MB |

## Design

- **Auto-resolution**: fastembed when importable, sentence-transformers as fallback. `EMDX_EMBEDDING_BACKEND=fastembed|sentence-transformers` forces either.
- **Vector-space partitioning**: fastembed's quantized ONNX weights produce slightly different vectors than the torch weights, so each backend gets its own `model_name` key (`all-MiniLM-L6-v2-onnx` vs `all-MiniLM-L6-v2`). They never mix; switching backends requires one `emdx maintain index` (old vectors are ignored, not corrupted). `MODEL_NAME` became a property — external access is instance-level only (`labs_ask.py`), so nothing breaks.
- **Adapters** pin the encode contract both backends must meet: L2-normalized float32, 1-D for a single string, 2-D for a list. (fastembed yields normalized float64 — verified empirically — so the adapter casts.)
- `_load_model_silently` generalized to a factory wrapper; fastembed downloads from HF Hub with the same tqdm/warning noise the torch path had.

## Verification

- 2095 passed, 8 skipped (full suite), including 11 new backend tests
- E2E against a scratch DB: `maintain index` → semantic search ranks correctly (database docs above bread recipe for a locking query); timed save with auto-link = **1.53s wall including CLI startup** (~0.7s baseline), embeddings written under the ONNX partition key
- ruff + mypy clean

## Follow-ups (not in this PR)

- Consider dropping `sentence-transformers`/torch from the ml group entirely once fastembed proves out
- After merge: run `emdx maintain index` once to rebuild the prod index under the ONNX key (~1,100 docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)