### PR TITLE
feat(maintain): add compact command — VACUUM + FTS optimize (Issue #FEAT-73)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,7 @@ emdx maintain link --all               # Auto-link related documents
 emdx maintain backup                   # Create compressed daily backup
 emdx maintain backup --list            # List existing backups
 emdx maintain backup --restore <file>  # Restore from a backup
+emdx maintain compact                  # Compact DB (VACUUM + FTS optimize)
 emdx maintain freshness                # Score document freshness (staleness)
 emdx maintain freshness --stale        # Show only stale docs
 

--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -434,6 +434,22 @@ emdx maintain backup --json
 
 > **Tip:** Backups can be triggered automatically via Claude Code hooks (e.g., on session start). Use `--quiet` for silent hook-driven backups.
 
+#### **emdx maintain compact**
+Compact the database to keep on-disk size and query latency in check as the knowledge base grows. Runs FTS5 index optimization, `PRAGMA optimize`, `VACUUM`, and a WAL checkpoint.
+
+```bash
+# Compact the database
+emdx maintain compact
+
+# JSON output (sizes before/after, bytes reclaimed)
+emdx maintain compact --json
+```
+
+**Options:**
+- `--json` - Structured JSON output
+
+> **Tip:** Run periodically (e.g. monthly) or after bulk deletes. Safe to run any time — it only reorganizes storage, never changes content.
+
 #### **emdx maintain cloud-backup**
 Upload, list, and download knowledge base backups to cloud providers (GitHub Gists or Google Drive).
 

--- a/emdx/commands/maintain.py
+++ b/emdx/commands/maintain.py
@@ -811,6 +811,77 @@ def backup_command(
 
 app.command(name="backup")(backup_command)
 
+
+def compact_command(
+    json_output: bool = typer.Option(False, "--json", help="Structured JSON output"),
+) -> None:
+    """Compact the database: FTS optimize, PRAGMA optimize, and VACUUM.
+
+    As the knowledge base grows, the SQLite file accumulates free pages and
+    the FTS5 index fragments, growing on-disk size and write/query latency.
+    Run this periodically (e.g. monthly, or after bulk deletes) to keep
+    saves and queries fast.
+
+    Examples:
+        emdx maintain compact
+        emdx maintain compact --json
+    """
+    import json as json_mod
+    import time
+
+    from ..config.settings import get_db_path
+    from ..database import db
+
+    db_path = get_db_path()
+    if not db_path.exists():
+        msg = f"Database not found: {db_path}"
+        if json_output:
+            print(json_mod.dumps({"success": False, "message": msg}))
+        else:
+            print(msg)
+        raise typer.Exit(code=1)
+
+    size_before = db_path.stat().st_size
+    start = time.monotonic()
+
+    with db.get_connection() as conn:
+        # Merge FTS5 b-tree segments into one (defragments the search index)
+        conn.execute("INSERT INTO documents_fts(documents_fts) VALUES('optimize')")
+        conn.commit()
+        # Refresh query-planner statistics
+        conn.execute("PRAGMA optimize")
+        # Reclaim free pages; must run outside a transaction
+        conn.execute("VACUUM")
+        # Fold the WAL back into the main file so the reclaim shows on disk
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+    duration = time.monotonic() - start
+    size_after = db_path.stat().st_size
+    reclaimed = size_before - size_after
+
+    if json_output:
+        print(
+            json_mod.dumps(
+                {
+                    "success": True,
+                    "size_before_bytes": size_before,
+                    "size_after_bytes": size_after,
+                    "reclaimed_bytes": reclaimed,
+                    "duration_seconds": round(duration, 2),
+                }
+            )
+        )
+    else:
+        mb = 1024 * 1024
+        print(
+            f"Compacted {db_path.name}: "
+            f"{size_before / mb:.1f}MB -> {size_after / mb:.1f}MB "
+            f"({reclaimed / mb:.1f}MB reclaimed, {duration:.1f}s)"
+        )
+
+
+app.command(name="compact")(compact_command)
+
 # Register index/link commands from maintain_index as direct subcommands
 from emdx.commands.maintain_index import (  # noqa: E402
     create_links,

--- a/tests/test_maintain_compact.py
+++ b/tests/test_maintain_compact.py
@@ -1,0 +1,40 @@
+"""Tests for the maintain compact subcommand."""
+
+from __future__ import annotations
+
+import json
+import re
+
+from typer.testing import CliRunner
+
+from emdx.main import app
+from emdx.models.documents import delete_document, save_document
+
+runner = CliRunner()
+
+
+def _out(result) -> str:
+    """Strip ANSI escape sequences from CliRunner output for assertions."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
+
+
+class TestMaintainCompact:
+    def test_compact_runs_and_reports_sizes(self):
+        # Create some churn so VACUUM has something to reclaim
+        doc_ids = [save_document(f"Compact test {i}", "body " * 500, None) for i in range(5)]
+        for doc_id in doc_ids:
+            delete_document(str(doc_id))
+
+        result = runner.invoke(app, ["maintain", "compact"])
+        assert result.exit_code == 0
+        assert "Compacted" in _out(result)
+        assert "reclaimed" in _out(result)
+
+    def test_compact_json_output(self):
+        result = runner.invoke(app, ["maintain", "compact", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(_out(result))
+        assert data["success"] is True
+        assert data["size_before_bytes"] >= data["size_after_bytes"]
+        assert data["reclaimed_bytes"] == data["size_before_bytes"] - data["size_after_bytes"]
+        assert data["duration_seconds"] >= 0


### PR DESCRIPTION
## Summary
- New `emdx maintain compact` keeps on-disk size and query latency in check as the KB grows (#1039)
- Runs, in order: FTS5 `optimize` (merges index segments), `PRAGMA optimize` (query-planner stats), `VACUUM` (reclaims free pages), `PRAGMA wal_checkpoint(TRUNCATE)` (folds the WAL so the reclaim shows on disk)
- Reports before/after sizes and bytes reclaimed; `--json` for structured output
- Documented in docs/cli-api.md and CLAUDE.md with periodic-use guidance

## Test plan
- [x] Tests: end-to-end run against the test DB (with delete churn), JSON schema assertions
- [x] Full suite: 2095 passed; ruff + mypy clean

Fixes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)