### PR TITLE
fix(distill): SearchHit is not subscriptable — labs distill crash (Issue #BUG-2)

### DIFF
--- a/emdx/commands/distill.py
+++ b/emdx/commands/distill.py
@@ -37,8 +37,8 @@ def _get_documents_by_query(
     limit: int = 20,
 ) -> list[DistillDocumentDict]:
     """Get documents matching a search query."""
-    docs = search_documents(query=query, limit=limit)
-    return _fetch_full_content(cast(list[DistillDocumentDict], docs))
+    hits = search_documents(query=query, limit=limit)
+    return _fetch_full_content([hit.id for hit in hits])
 
 
 def _get_documents_by_tags(
@@ -47,15 +47,13 @@ def _get_documents_by_tags(
 ) -> list[DistillDocumentDict]:
     """Get documents matching tags."""
     docs = search_by_tags(tag_names=tags, mode="any", limit=limit)
-    return _fetch_full_content(cast(list[DistillDocumentDict], docs))
+    return _fetch_full_content([d["id"] for d in docs])
 
 
-def _fetch_full_content(docs: list[DistillDocumentDict]) -> list[DistillDocumentDict]:
-    """Fetch full content for a list of document summaries."""
-    if not docs:
+def _fetch_full_content(doc_ids: list[int]) -> list[DistillDocumentDict]:
+    """Fetch full content for the given document IDs, preserving order."""
+    if not doc_ids:
         return []
-
-    doc_ids = [d["id"] for d in docs]
 
     with db.get_connection() as conn:
         cursor = conn.cursor()
@@ -67,13 +65,13 @@ def _fetch_full_content(docs: list[DistillDocumentDict]) -> list[DistillDocument
         rows = cursor.fetchall()
 
     # Build map for ordering
-    content_map = {
-        row["id"]: {"id": row["id"], "title": row["title"], "content": row["content"]}
+    content_map: dict[int, DistillDocumentDict] = {
+        row["id"]: DistillDocumentDict(id=row["id"], title=row["title"], content=row["content"])
         for row in rows
     }
 
     # Return in original order
-    return [content_map[d["id"]] for d in docs if d["id"] in content_map]  # type: ignore[misc]
+    return [content_map[doc_id] for doc_id in doc_ids if doc_id in content_map]
 
 
 def _parse_audience(audience_str: str) -> Audience:

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -128,6 +128,74 @@ class TestDistillService:
 
 
 # ---------------------------------------------------------------------------
+# Document fetching regression tests (BUG-2)
+# ---------------------------------------------------------------------------
+class TestDistillDocumentFetching:
+    """Regression tests for BUG-2: `_get_documents_by_query` crashed with
+    TypeError: 'SearchHit' object is not subscriptable.
+
+    These exercise the real search -> fetch pipeline against the test DB
+    (no mocking of search_documents/search_by_tags/_fetch_full_content),
+    which is exactly the path the old cast()-based code broke on.
+    """
+
+    def test_get_documents_by_query_real_search_path(self):
+        """Query path: SearchHit results must be converted to dicts with content."""
+        from emdx.commands.distill import _get_documents_by_query
+        from emdx.database.documents import save_document
+
+        doc_id = save_document(
+            title="Distill regression auth doc",
+            content="Authentication uses distillregressiontoken for sessions.",
+            project="distill-test",
+        )
+
+        docs = _get_documents_by_query("distillregressiontoken")
+
+        assert docs, "expected the seeded document to match the query"
+        match = next(d for d in docs if d["id"] == doc_id)
+        assert match["title"] == "Distill regression auth doc"
+        assert "distillregressiontoken" in match["content"]
+
+    def test_get_documents_by_tags_real_search_path(self):
+        """Tags path: TagSearchResultDict rows have no 'content' key; full
+        content must be fetched from the DB."""
+        from emdx.commands.distill import _get_documents_by_tags
+        from emdx.database.documents import save_document
+        from emdx.models.tags import add_tags_to_document
+
+        doc_id = save_document(
+            title="Distill regression tagged doc",
+            content="Full body content for the tagged distill regression doc.",
+            project="distill-test",
+        )
+        add_tags_to_document(doc_id, ["distill-regression-tag"])
+
+        docs = _get_documents_by_tags(["distill-regression-tag"])
+
+        assert docs, "expected the tagged document to be found"
+        match = next(d for d in docs if d["id"] == doc_id)
+        assert match["title"] == "Distill regression tagged doc"
+        assert match["content"] == "Full body content for the tagged distill regression doc."
+
+    def test_fetch_full_content_preserves_order_and_skips_missing(self):
+        from emdx.commands.distill import _fetch_full_content
+        from emdx.database.documents import save_document
+
+        id_a = save_document(title="Distill order A", content="A", project="distill-test")
+        id_b = save_document(title="Distill order B", content="B", project="distill-test")
+
+        docs = _fetch_full_content([id_b, 999999999, id_a])
+
+        assert [d["id"] for d in docs] == [id_b, id_a]
+
+    def test_fetch_full_content_empty(self):
+        from emdx.commands.distill import _fetch_full_content
+
+        assert _fetch_full_content([]) == []
+
+
+# ---------------------------------------------------------------------------
 # Distill command tests
 # ---------------------------------------------------------------------------
 class TestDistillCommand:


### PR DESCRIPTION
## Summary

CRITICAL audit finding (emdx BUG-2, audit doc #7623): `emdx labs distill <topic>` crashed with `TypeError: 'SearchHit' object is not subscriptable` on any run whose search returned at least one document.

### Root cause
- `_get_documents_by_query` cast `list[SearchHit]` (from `database.search.search_documents`) to `list[DistillDocumentDict]`. `SearchHit` is a slotted dataclass with attribute forwarding only — no `__getitem__` — so `_fetch_full_content`'s `d["id"]` raised `TypeError`. The `cast()` silenced mypy on a real bug.
- `_get_documents_by_tags` had a sibling cast claiming a `content` key that `TagSearchResultDict` does not have (type-level lie only — dicts are subscriptable, and content was re-fetched anyway).

### Fix
`_fetch_full_content` now accepts `list[int]` doc IDs — it re-fetched full rows from the DB regardless — and constructs `DistillDocumentDict` from the rows directly. Callers pass `[hit.id for hit in hits]` / `[d["id"] for d in docs]`. Both bogus `cast()` calls and the `type: ignore[misc]` are removed.

### Verification
- Reproduced the crash empirically against an isolated DB (`EMDX_DB=/tmp/distill-test.db`), then confirmed both the query path and `--tags` path work end-to-end after the fix.
- New regression tests exercise the real search -> fetch pipeline (no mocking of `search_documents`/`search_by_tags`/`_fetch_full_content` — the existing tests mocked `_get_documents_by_query`, which is why this slipped through). The query-path test reproduces the exact original `TypeError` on unfixed code.
- `pytest tests/`: 2099 passed, 8 skipped (1 pre-existing env-dependent failure in `test_compact.py` also fails on clean main, deselected)
- `ruff check .`: zero errors; `mypy emdx/commands/distill.py`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)