### PR TITLE
fix(services): path traversal, argv exposure, IP-redaction gaps (Issue #SECURITY-8)

### DIFF
--- a/emdx/services/backup_providers/google_drive.py
+++ b/emdx/services/backup_providers/google_drive.py
@@ -38,6 +38,28 @@ def _set_secure_permissions(path: Path) -> None:
     os.chmod(path, 0o600)
 
 
+def _sanitize_remote_filename(filename: str, backup_id: str) -> str:
+    """Sanitize a remote-controlled Drive filename for safe local use.
+
+    Google Drive allows arbitrary characters in file names, including
+    path separators and traversal sequences. Reduce the name to its
+    basename and fall back to a deterministic name if the result is
+    empty or a dot-name.
+
+    Args:
+        filename: The raw file name from Drive metadata.
+        backup_id: The Drive file ID, used for the fallback name.
+
+    Returns:
+        A safe, non-empty basename.
+    """
+    # Strip both POSIX and Windows separators, then take the basename.
+    safe = Path(filename.replace("\\", "/")).name
+    if not safe or safe in {".", ".."}:
+        safe = f"backup-{backup_id}.db.gz"
+    return safe
+
+
 class GoogleDriveProvider:
     """Cloud backup provider that stores database snapshots in Google Drive.
 
@@ -215,10 +237,16 @@ class GoogleDriveProvider:
         target = Path(target_dir)
         target.mkdir(parents=True, exist_ok=True)
 
-        # Get file metadata for the filename
+        # Get file metadata for the filename.
+        # The name is remote-controlled (Drive allows '/' and '..' in
+        # names), so sanitize it before joining to avoid path traversal.
         file_meta = service.files().get(fileId=backup_id, fields="name").execute()
-        filename = file_meta.get("name", f"backup-{backup_id}.db.gz")
+        filename = _sanitize_remote_filename(
+            file_meta.get("name", f"backup-{backup_id}.db.gz"), backup_id
+        )
         dest_path = target / filename
+        if not dest_path.resolve().is_relative_to(target.resolve()):
+            raise RuntimeError(f"Refusing to write outside target directory: {filename!r}")
 
         request = service.files().get_media(fileId=backup_id)
 

--- a/emdx/services/synthesis_service.py
+++ b/emdx/services/synthesis_service.py
@@ -58,13 +58,18 @@ def _execute_prompt(
     """
     prompt = f"<system>\n{system_prompt}\n</system>\n\n{user_message}"
 
-    cmd = ["claude", "--print", prompt]
+    # Pass the prompt via stdin, never argv: process arguments are
+    # world-readable (ps/procfs) and can exceed ARG_MAX for large
+    # documents. `claude --print` reads the prompt from stdin when no
+    # positional prompt is given.
+    cmd = ["claude", "--print"]
     if model:
         cmd.extend(["--model", model])
 
     try:
         result = subprocess.run(
             cmd,
+            input=prompt,
             capture_output=True,
             text=True,
             timeout=SYNTHESIS_TIMEOUT,

--- a/emdx/services/wiki_privacy_service.py
+++ b/emdx/services/wiki_privacy_service.py
@@ -32,9 +32,16 @@ _PATH_PATTERNS = [
     re.compile(r"C:\\Users\\[a-zA-Z0-9_-]+\\"),  # Windows paths
 ]
 
-# Internal IPs
+# Internal IPs (RFC 1918). Each alternative matches a full 4-octet
+# address — a shared 2-octet suffix would redact only 3 octets of
+# 10.x.y.z (leaking the host octet) and false-positive on version
+# strings like "macOS 10.15.7".
 _IP_PATTERNS = [
-    re.compile(r"\b(?:10|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}\b"),
+    re.compile(
+        r"\b(?:10(?:\.\d{1,3}){3}"
+        r"|172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2}"
+        r"|192\.168(?:\.\d{1,3}){2})\b"
+    ),
 ]
 
 # Temporal references that are meaningless out of context

--- a/tests/test_google_drive_provider.py
+++ b/tests/test_google_drive_provider.py
@@ -1,0 +1,99 @@
+"""Tests for the Google Drive backup provider.
+
+Regression tests for path traversal in ``GoogleDriveProvider.download``:
+the destination filename comes from remote-controlled Drive metadata,
+which may contain '/' or '..', so it must be reduced to a safe basename
+and confined to the target directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from emdx.services.backup_providers.google_drive import (
+    GoogleDriveProvider,
+    _sanitize_remote_filename,
+)
+
+
+class TestSanitizeRemoteFilename:
+    def test_plain_name_unchanged(self) -> None:
+        assert _sanitize_remote_filename("backup.db.gz", "id1") == "backup.db.gz"
+
+    def test_traversal_reduced_to_basename(self) -> None:
+        assert _sanitize_remote_filename("../../.zshrc", "id1") == ".zshrc"
+
+    def test_absolute_path_reduced_to_basename(self) -> None:
+        assert _sanitize_remote_filename("/Users/x/.ssh/config", "id1") == "config"
+
+    def test_windows_separators_stripped(self) -> None:
+        assert _sanitize_remote_filename("..\\..\\evil.db", "id1") == "evil.db"
+
+    @pytest.mark.parametrize("name", ["", ".", "..", "foo/..", "/", "//"])
+    def test_empty_and_dot_names_fall_back(self, name: str) -> None:
+        assert _sanitize_remote_filename(name, "abc123") == "backup-abc123.db.gz"
+
+
+class TestDownloadPathTraversal:
+    def _make_provider(self, remote_name: str) -> GoogleDriveProvider:
+        provider = GoogleDriveProvider()
+        service = MagicMock()
+        service.files.return_value.get.return_value.execute.return_value = {"name": remote_name}
+        provider._get_service = MagicMock(return_value=service)  # type: ignore[method-assign]
+        return provider
+
+    def _run_download(self, provider: GoogleDriveProvider, target_dir: Path) -> str:
+        downloader = MagicMock()
+        downloader.next_chunk.return_value = (None, True)
+        with patch(
+            "googleapiclient.http.MediaIoBaseDownload",
+            return_value=downloader,
+        ):
+            return provider.download("file123", str(target_dir))
+
+    def test_traversal_name_confined_to_target(self, tmp_path: Path) -> None:
+        target = tmp_path / "restore"
+        provider = self._make_provider("../../evil.db")
+
+        result = self._run_download(provider, target)
+
+        dest = Path(result)
+        assert dest.parent == target
+        assert dest.name == "evil.db"
+        # Nothing escaped the target directory
+        assert not (tmp_path / "evil.db").exists()
+        assert dest.exists()
+
+    def test_absolute_name_confined_to_target(self, tmp_path: Path) -> None:
+        target = tmp_path / "restore"
+        provider = self._make_provider("/etc/passwd")
+
+        result = self._run_download(provider, target)
+
+        dest = Path(result)
+        assert dest.parent == target
+        assert dest.name == "passwd"
+
+    def test_dot_dot_name_uses_fallback(self, tmp_path: Path) -> None:
+        target = tmp_path / "restore"
+        provider = self._make_provider("..")
+
+        result = self._run_download(provider, target)
+
+        dest = Path(result)
+        assert dest.parent == target
+        assert dest.name == "backup-file123.db.gz"
+
+    def test_benign_name_preserved(self, tmp_path: Path) -> None:
+        target = tmp_path / "restore"
+        provider = self._make_provider("emdx-backup-2026-07-06.db.gz")
+
+        result = self._run_download(provider, target)
+
+        dest = Path(result)
+        assert dest.parent == target
+        assert dest.name == "emdx-backup-2026-07-06.db.gz"
+        assert dest.exists()

--- a/tests/test_synthesis_service.py
+++ b/tests/test_synthesis_service.py
@@ -1,0 +1,82 @@
+"""Tests for synthesis service prompt execution.
+
+Regression tests for argv exposure: document contents must be passed
+to the ``claude`` CLI via stdin, never as a positional argument —
+process arguments are world-readable via ps/procfs and can exceed
+ARG_MAX for large documents.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from emdx.services.synthesis_service import SYNTHESIS_TIMEOUT, _execute_prompt
+
+
+def _success_run(returncode: int = 0, stdout: str = "synthesized") -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = ""
+    return result
+
+
+class TestExecutePromptStdin:
+    @patch("emdx.services.synthesis_service.subprocess.run")
+    def test_prompt_passed_via_stdin_not_argv(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = _success_run()
+        secret_content = "password=hunter2 and sk-ant-secret-key-material"
+
+        result = _execute_prompt("You are a synthesizer", secret_content, "title")
+
+        assert result.success
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["claude", "--print"]
+        # No part of the prompt appears in argv
+        assert all(secret_content not in arg for arg in cmd)
+        # Full prompt (system + user) goes through stdin
+        stdin = mock_run.call_args.kwargs["input"]
+        assert secret_content in stdin
+        assert "You are a synthesizer" in stdin
+
+    @patch("emdx.services.synthesis_service.subprocess.run")
+    def test_model_flag_still_on_argv(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = _success_run()
+
+        _execute_prompt("system", "user message", "title", model="claude-fable-5")
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["claude", "--print", "--model", "claude-fable-5"]
+        assert "user message" in mock_run.call_args.kwargs["input"]
+
+    @patch("emdx.services.synthesis_service.subprocess.run")
+    def test_large_prompt_never_hits_argv(self, mock_run: MagicMock) -> None:
+        """Prompts larger than ARG_MAX must not be argv arguments."""
+        mock_run.return_value = _success_run()
+        huge = "x" * 300_000  # > Linux MAX_ARG_STRLEN (128 KiB)
+
+        _execute_prompt("system", huge, "title")
+
+        cmd = mock_run.call_args[0][0]
+        assert max(len(arg) for arg in cmd) < 1024
+        assert huge in mock_run.call_args.kwargs["input"]
+
+    @patch("emdx.services.synthesis_service.subprocess.run")
+    def test_nonzero_exit_raises_runtime_error(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = _success_run(returncode=1)
+        mock_run.return_value.stderr = "boom"
+
+        with pytest.raises(RuntimeError, match="boom"):
+            _execute_prompt("system", "user", "title")
+
+    @patch("emdx.services.synthesis_service.subprocess.run")
+    def test_timeout_raises_runtime_error(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd=["claude", "--print"], timeout=SYNTHESIS_TIMEOUT
+        )
+
+        with pytest.raises(RuntimeError, match="timed out"):
+            _execute_prompt("system", "user", "title")

--- a/tests/test_wiki_privacy.py
+++ b/tests/test_wiki_privacy.py
@@ -1,0 +1,79 @@
+"""Tests for wiki privacy redaction (emdx/services/wiki_privacy_service.py).
+
+Regression tests for the private-IP redaction regex: the old pattern
+gave the ``10`` alternative only two trailing octet groups, so
+``10.1.2.3`` was redacted to ``[INTERNAL_IP].3`` (leaking the host
+octet) and version strings like ``macOS 10.15.7`` were mangled.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from emdx.services.wiki_privacy_service import postprocess_validate, preprocess_content
+
+
+class TestPrivateIpRedaction:
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "10.1.2.3",
+            "10.0.0.1",
+            "10.255.255.255",
+            "172.16.0.1",
+            "172.31.255.255",
+            "192.168.1.100",
+            "192.168.0.1",
+        ],
+    )
+    def test_private_ips_fully_redacted(self, ip: str) -> None:
+        content = f"The server lives at {ip} behind the VPN."
+        result, warnings = preprocess_content(content)
+
+        assert ip not in result
+        assert "[INTERNAL_IP]" in result
+        # No partial redaction leaving a trailing octet (e.g. "[INTERNAL_IP].3")
+        assert "[INTERNAL_IP]." not in result
+        assert any("internal IP" in w for w in warnings)
+
+    def test_10_x_host_octet_does_not_leak(self) -> None:
+        """Regression: 10.1.2.3 must not become '[INTERNAL_IP].3'."""
+        result, _ = preprocess_content("connect to 10.1.2.3 now")
+        assert result == "connect to [INTERNAL_IP] now"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "macOS 10.15.7 is old",  # version string, only 3 octets
+            "Python 3.10.12 release",
+            "see 8.8.8.8 for DNS",  # public IP
+            "172.32.1.1 is not RFC 1918",  # outside 172.16-31
+            "172.15.0.1 is not RFC 1918",
+            "192.169.1.1 is not RFC 1918",
+            "11.0.0.1 is public",
+        ],
+    )
+    def test_non_private_addresses_untouched(self, text: str) -> None:
+        result, warnings = preprocess_content(text)
+        assert result == text
+        assert not any("internal IP" in w for w in warnings)
+
+    def test_multiple_ips_counted(self) -> None:
+        content = "hosts: 10.0.0.1, 192.168.1.2, 172.16.5.5"
+        result, warnings = preprocess_content(content)
+        assert result.count("[INTERNAL_IP]") == 3
+        assert any("3 internal IP" in w for w in warnings)
+
+    def test_postprocess_validate_redacts_private_ips(self) -> None:
+        """Layer 3 reuses the same patterns and must also fully redact."""
+        result, warnings = postprocess_validate("leaked 10.1.2.3 in output")
+        assert "10.1.2.3" not in result
+        assert "[INTERNAL_IP]" in result
+        assert "[INTERNAL_IP]." not in result
+        assert any("internal IP" in w for w in warnings)
+
+    def test_postprocess_validate_leaves_version_strings(self) -> None:
+        content = "Tested on macOS 10.15.7"
+        result, warnings = postprocess_validate(content)
+        assert result == content
+        assert not any("internal IP" in w for w in warnings)


### PR DESCRIPTION
Fixes 3 verified security warnings from the 2026-07-05 audit (emdx task SECURITY-8, findings doc emdx #7624).

## Findings and fixes

**1. Path traversal in Google Drive backup download** — `emdx/services/backup_providers/google_drive.py`
The destination path in `GoogleDriveProvider.download()` was built as `target / filename` where `filename` came verbatim from Drive file metadata. Drive allows `/` and `..` in file names, so a renamed or attacker-shared file could write outside the target directory.
**Fix:** new `_sanitize_remote_filename()` reduces the remote name to its basename (handling both POSIX and Windows separators), rejects empty/dot names with a deterministic fallback, and `download()` additionally verifies the resolved destination stays inside the target directory before opening it for write.

**2. Full document contents passed to `claude` CLI via argv** — `emdx/services/synthesis_service.py`
`_execute_prompt` built `["claude", "--print", prompt]` with complete raw document content in argv — world-readable via `ps`/procfs for the subprocess lifetime, and capable of exceeding ARG_MAX (`E2BIG` crash) for large documents.
**Fix:** the prompt is now passed via `input=` (stdin); argv carries only `--print` and the optional `--model` flag.

**3. Private-IP redaction regex leaked the last octet of 10.x addresses** — `emdx/services/wiki_privacy_service.py`
The old pattern gave the `10` alternative only two trailing octet groups, so `10.1.2.3` redacted to `[INTERNAL_IP].3` (host octet leak) and version strings like `macOS 10.15.7` were falsely redacted. `postprocess_validate` reused the same pattern, so Layer 3 inherited both defects.
**Fix:** per-range alternatives with correct octet counts: `10(?:\.\d{1,3}){3}`, `172.(16-31)(?:\.\d{1,3}){2}`, `192.168(?:\.\d{1,3}){2}`.

## Tests

- `tests/test_google_drive_provider.py` — sanitizer unit tests + download-level traversal/containment tests (14 tests)
- `tests/test_synthesis_service.py` — stdin vs argv, large-prompt, model-flag, and error-contract tests (5 tests)
- `tests/test_wiki_privacy.py` — full redaction of 10.x.y.z / 172.16-31 / 192.168, no false positives on version strings or public IPs, Layer-3 postprocess coverage (18 tests)

Full suite: 2132 passed, 8 skipped (1 pre-existing failure in `test_compact.py::test_compact_requires_at_least_two_docs`, reproduced on origin/main, unrelated). Ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)