### PR TITLE
fix(save): refuse existing file path passed positionally; feat(tasks): lifecycle events

### DIFF
--- a/docs/database-design.md
+++ b/docs/database-design.md
@@ -297,6 +297,19 @@ CREATE TABLE knowledge_events (
 );
 ```
 
+Event types:
+
+| event_type | When | metadata_json |
+|-----------|------|---------------|
+| `search` / `view` / `create` / `update` / `delete` / `ask` | Document operations | varies; `doc_id` set where applicable |
+| `task_create` | `emdx task add` | `{"task_id": N, "epic_key": "...", "status": "open"}` |
+| `task_status` | Status transitions (`task active/done/block`, etc.) | `{"task_id": N, "old_status": "...", "new_status": "...", "epic_key": "..."}` |
+| `task_delete` | `emdx task delete` | `{"task_id": N}` |
+
+Task events keep `doc_id` NULL (it references documents, not tasks); the
+task ID lives in `metadata_json`. External consumers can poll this table
+instead of diffing the `tasks` table to react to task changes.
+
 #### `document_versions` — Content History
 ```sql
 CREATE TABLE document_versions (

--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -86,6 +86,39 @@ def _stdin_ready(timeout: float) -> bool:
     return bool(ready)
 
 
+def _guard_path_like_positional(arg: str) -> None:
+    """Refuse a positional arg that is an existing file path (#1051).
+
+    Callers (usually agents) sometimes pass a file path positionally instead
+    of via -f/--file. The save "succeeds" with the literal path string as the
+    document body, and the real content is lost once the file at that path is
+    cleaned up. Fail loudly instead; the literal-string case survives via
+    stdin (`printf '%s' "/some/path" | emdx save`).
+    """
+    if "\n" in arg:
+        return
+    try:
+        is_file = Path(arg).expanduser().is_file()
+    except (OSError, ValueError):
+        return
+
+    if is_file:
+        console.print(f"[red]Error: positional argument is an existing file path: {arg}[/red]")
+        console.print(
+            "[red]Use -f/--file to save the file's contents, "
+            "or pipe via stdin to save the literal string.[/red]"
+        )
+        raise typer.Exit(1)
+
+    # Path-looking but nonexistent: usually a temp file already cleaned up or
+    # a mistyped path. Warn but proceed with the literal string.
+    if arg.startswith(("/", "~")) and " " not in arg:
+        console.print(
+            f"[yellow]Warning: '{arg}' looks like a file path but no such file exists; "
+            "saving it as literal content. Use -f/--file to save a file's contents.[/yellow]"
+        )
+
+
 def get_input_content(input_arg: str | None, file_path: str | None = None) -> InputContent:
     """Handle input from stdin, --file, or positional content argument.
 
@@ -94,6 +127,10 @@ def get_input_content(input_arg: str | None, file_path: str | None = None) -> In
     When --file or a positional argument is provided, stdin is never read:
     probing an open non-TTY stdin that has no data blocks forever under
     backgrounded/tool-invoked callers (see #732, #1034).
+
+    A positional argument that is an existing file path is refused (#1051):
+    it almost always means the caller meant -f/--file, and accepting it
+    silently records the path string instead of the file's contents.
     """
     import sys
 
@@ -112,6 +149,7 @@ def get_input_content(input_arg: str | None, file_path: str | None = None) -> In
 
     # Priority 2: Positional argument (skip stdin — content already in hand)
     if input_arg:
+        _guard_path_like_positional(input_arg)
         return InputContent(content=input_arg, source_type="direct")
 
     # Priority 3: stdin, guarded so an open-but-idle stdin can't wedge us

--- a/emdx/models/events.py
+++ b/emdx/models/events.py
@@ -1,7 +1,7 @@
 """Knowledge event recording for emdx.
 
 Append-only event log for tracking KB interactions: searches, views,
-creates, updates, deletes, and asks.
+creates, updates, deletes, asks, and task lifecycle changes.
 """
 
 from __future__ import annotations
@@ -15,7 +15,22 @@ from emdx.database.connection import db_connection
 logger = logging.getLogger(__name__)
 
 # Valid event types
-EVENT_TYPES = frozenset({"search", "view", "create", "update", "delete", "ask"})
+EVENT_TYPES = frozenset(
+    {
+        # Document events
+        "search",
+        "view",
+        "create",
+        "update",
+        "delete",
+        "ask",
+        # Task lifecycle events (#1012) — task_id lives in metadata_json,
+        # doc_id stays NULL (it references documents, not tasks)
+        "task_create",
+        "task_status",
+        "task_delete",
+    }
+)
 
 
 def record_event(
@@ -28,7 +43,8 @@ def record_event(
 
     Args:
         event_type: One of 'search', 'view', 'create', 'update',
-                    'delete', 'ask'.
+                    'delete', 'ask', 'task_create', 'task_status',
+                    'task_delete'.
         doc_id: Optional document ID associated with the event.
         query: Optional search query (for search/ask events).
         metadata: Optional dict of extra context (serialised as JSON).

--- a/emdx/models/tasks.py
+++ b/emdx/models/tasks.py
@@ -10,6 +10,7 @@ from emdx.config.constants import (
     DEFAULT_TASK_PRIORITY,
 )
 from emdx.database import db
+from emdx.models.events import record_event
 from emdx.models.task import Task, TaskLogEntry
 from emdx.models.types import TaskRef
 
@@ -96,7 +97,12 @@ def create_task(
                 [(task_id, dep_id) for dep_id in depends_on if dep_id is not None],
             )
         conn.commit()
-        return task_id
+
+    record_event(
+        "task_create",
+        metadata={"task_id": task_id, "epic_key": epic_key, "status": status},
+    )
+    return task_id
 
 
 def create_epic(name: str, category_key: str, description: str = "") -> int:
@@ -157,6 +163,7 @@ def delete_epic(epic_id: int, force: bool = False) -> dict[str, int]:
         conn.execute("DELETE FROM tasks WHERE id = ?", (epic_id,))
         conn.commit()
 
+    record_event("task_delete", metadata={"task_id": epic_id})
     return {"children_unlinked": children_unlinked}
 
 
@@ -338,9 +345,31 @@ def update_task(task_id: int, **kwargs: Any) -> bool:
     params.append(task_id)
 
     with db.get_connection() as conn:
+        old_status: str | None = None
+        old_epic_key: str | None = None
+        if "status" in filtered_kwargs:
+            row = conn.execute(
+                "SELECT status, epic_key FROM tasks WHERE id = ?", (task_id,)
+            ).fetchone()
+            if row:
+                old_status, old_epic_key = row[0], row[1]
+
         cursor = conn.execute(f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", params)
         conn.commit()
-        return cursor.rowcount > 0
+        updated = cursor.rowcount > 0
+
+    new_status = filtered_kwargs.get("status")
+    if updated and new_status is not None and new_status != old_status:
+        record_event(
+            "task_status",
+            metadata={
+                "task_id": task_id,
+                "old_status": old_status,
+                "new_status": new_status,
+                "epic_key": filtered_kwargs.get("epic_key", old_epic_key),
+            },
+        )
+    return updated
 
 
 def set_task_output_doc(task_id: int, doc_id: int) -> None:
@@ -362,7 +391,11 @@ def delete_task(task_id: int) -> bool:
     with db.get_connection() as conn:
         cursor = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         conn.commit()
-        return cursor.rowcount > 0
+        deleted = cursor.rowcount > 0
+
+    if deleted:
+        record_event("task_delete", metadata={"task_id": task_id})
+    return deleted
 
 
 def get_dependencies(task_id: int) -> list[Task]:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -18,6 +18,9 @@ def clean_events_table(isolate_test_database: Path) -> Generator[None, None, Non
         conn.execute("DELETE FROM document_versions")
         conn.execute("DELETE FROM document_tags")
         conn.execute("DELETE FROM documents")
+        conn.execute("DELETE FROM task_deps")
+        conn.execute("DELETE FROM task_log")
+        conn.execute("DELETE FROM tasks")
         conn.commit()
 
     yield
@@ -27,6 +30,9 @@ def clean_events_table(isolate_test_database: Path) -> Generator[None, None, Non
         conn.execute("DELETE FROM document_versions")
         conn.execute("DELETE FROM document_tags")
         conn.execute("DELETE FROM documents")
+        conn.execute("DELETE FROM task_deps")
+        conn.execute("DELETE FROM task_log")
+        conn.execute("DELETE FROM tasks")
         conn.commit()
 
 
@@ -115,6 +121,9 @@ class TestRecordEvent:
         assert "update" in EVENT_TYPES
         assert "delete" in EVENT_TYPES
         assert "ask" in EVENT_TYPES
+        assert "task_create" in EVENT_TYPES
+        assert "task_status" in EVENT_TYPES
+        assert "task_delete" in EVENT_TYPES
 
 
 class TestSaveDocumentEvent:
@@ -136,6 +145,112 @@ class TestSaveDocumentEvent:
         assert row is not None
         assert row[0] == "create"
         assert row[1] == doc_id
+
+
+def _task_events(event_type: str) -> list[dict[str, object]]:
+    """Fetch metadata dicts for all events of the given type."""
+    import json
+
+    from emdx.database.connection import db_connection
+
+    with db_connection.get_connection() as conn:
+        rows = conn.execute(
+            "SELECT metadata_json, doc_id FROM knowledge_events WHERE event_type = ?",
+            (event_type,),
+        ).fetchall()
+    result = []
+    for row in rows:
+        meta = json.loads(row[0]) if row[0] else {}
+        meta["_doc_id"] = row[1]
+        result.append(meta)
+    return result
+
+
+class TestTaskLifecycleEvents:
+    """Task lifecycle changes are recorded to knowledge_events (#1012)."""
+
+    def test_create_task_records_event(self) -> None:
+        from emdx.models.tasks import create_task
+
+        task_id = create_task("Test task")
+
+        events = _task_events("task_create")
+        matching = [e for e in events if e["task_id"] == task_id]
+        assert len(matching) == 1
+        assert matching[0]["status"] == "open"
+        assert matching[0]["epic_key"] is None
+        # doc_id references documents, not tasks — must stay NULL
+        assert matching[0]["_doc_id"] is None
+
+    def test_create_task_with_epic_records_epic_key(self) -> None:
+        from emdx.models.tasks import create_task
+
+        task_id = create_task("Epic task", epic_key="EVT")
+
+        events = _task_events("task_create")
+        matching = [e for e in events if e["task_id"] == task_id]
+        assert len(matching) == 1
+        assert matching[0]["epic_key"] == "EVT"
+
+    def test_status_change_records_transition(self) -> None:
+        from emdx.models.tasks import create_task, update_task
+
+        task_id = create_task("Test task")
+        update_task(task_id, status="active")
+        update_task(task_id, status="done")
+
+        transitions = [
+            (e["old_status"], e["new_status"])
+            for e in _task_events("task_status")
+            if e["task_id"] == task_id
+        ]
+        assert transitions == [("open", "active"), ("active", "done")]
+
+    def test_same_status_records_no_event(self) -> None:
+        from emdx.models.tasks import create_task, update_task
+
+        task_id = create_task("Test task")
+        update_task(task_id, status="open")
+
+        assert [e for e in _task_events("task_status") if e["task_id"] == task_id] == []
+
+    def test_non_status_update_records_no_event(self) -> None:
+        from emdx.models.tasks import create_task, update_task
+
+        task_id = create_task("Test task")
+        update_task(task_id, title="Renamed")
+
+        assert [e for e in _task_events("task_status") if e["task_id"] == task_id] == []
+
+    def test_update_missing_task_records_no_event(self) -> None:
+        from emdx.models.tasks import update_task
+
+        assert update_task(999999, status="done") is False
+        assert [e for e in _task_events("task_status") if e["task_id"] == 999999] == []
+
+    def test_delete_task_records_event(self) -> None:
+        from emdx.models.tasks import create_task, delete_task
+
+        task_id = create_task("Doomed task")
+        assert delete_task(task_id) is True
+
+        events = _task_events("task_delete")
+        assert [e for e in events if e["task_id"] == task_id]
+
+    def test_delete_missing_task_records_no_event(self) -> None:
+        from emdx.models.tasks import delete_task
+
+        assert delete_task(999999) is False
+        assert [e for e in _task_events("task_delete") if e["task_id"] == 999999] == []
+
+    def test_delete_epic_records_event(self) -> None:
+        from emdx.models.tasks import create_epic, delete_epic
+
+        epic_id = create_epic("Test epic", "EVT")
+        delete_epic(epic_id)
+
+        events = _task_events("task_delete")
+        assert [e for e in events if e["task_id"] == epic_id]
 
 
 class TestUpdateDocumentEvent:

--- a/tests/test_input_content.py
+++ b/tests/test_input_content.py
@@ -169,6 +169,77 @@ class TestDirectContentInput:
         assert result.content == content
 
 
+class TestPathLikePositionalGuard:
+    """Positional args that are existing file paths are refused (#1051).
+
+    Passing a path positionally (instead of via -f/--file) used to silently
+    save the literal path string as the document body — permanent content
+    loss once the file at that path was cleaned up.
+    """
+
+    def test_existing_file_path_positionally_exits(self):
+        import typer
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("real content that would be lost")
+            fpath = f.name
+
+        try:
+            with patch("sys.stdin.isatty", return_value=True):
+                with pytest.raises(typer.Exit):
+                    get_input_content(fpath)
+        finally:
+            Path(fpath).unlink()
+
+    def test_multiline_content_containing_existing_path_is_saved(self):
+        """Only single-line args are path-checked — real content passes through."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("file content")
+            fpath = f.name
+
+        try:
+            content = f"{fpath}\nplus a second line"
+            with patch("sys.stdin.isatty", return_value=True):
+                result = get_input_content(content)
+
+            assert result.source_type == "direct"
+            assert result.content == content
+        finally:
+            Path(fpath).unlink()
+
+    def test_nonexistent_path_like_arg_warns_but_saves(self):
+        """A path-looking string with no file behind it saves as literal content."""
+        with patch("sys.stdin.isatty", return_value=True):
+            result = get_input_content("/no/such/file/anywhere.md")
+
+        assert result.source_type == "direct"
+        assert result.content == "/no/such/file/anywhere.md"
+
+    def test_directory_path_is_not_refused(self):
+        """Directories aren't files — arg is kept as literal content."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("sys.stdin.isatty", return_value=True):
+                result = get_input_content(tmpdir)
+
+            assert result.source_type == "direct"
+            assert result.content == tmpdir
+
+    def test_file_flag_still_reads_the_same_path(self):
+        """The refused path works fine when passed explicitly via --file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("real content")
+            fpath = f.name
+
+        try:
+            with patch("sys.stdin.isatty", return_value=True):
+                result = get_input_content(None, file_path=fpath)
+
+            assert result.source_type == "file"
+            assert result.content == "real content"
+        finally:
+            Path(fpath).unlink()
+
+
 class TestNoInput:
     """No input at all raises an error."""
 


### PR DESCRIPTION
Two fixes for open issues:

Issue #1051 — emdx save silently stored a file PATH as the document body
when the path was passed positionally instead of via -f/--file, causing
permanent content loss once the file at that path was cleaned up. A
single-line positional arg that is an existing file now fails loudly with
a pointer to -f/--file (literal-string saves survive via stdin). A
path-looking arg with no file behind it warns but proceeds.

Issue #1012 — task lifecycle changes are now recorded to the
knowledge_events table so external consumers can react to task changes
without diffing the tasks table:
- task_create on emdx task add (task_id, epic_key, status)
- task_status on status transitions (old_status, new_status, epic_key)
- task_delete on task/epic deletion (task_id)

Events are recorded at the model layer (create_task, update_task,
delete_task, delete_epic) so every CLI path is covered; doc_id stays
NULL for task events since it references documents.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VQduhLf1XbnhtTVus83g7H