### PR TITLE
fix(models): replace invalid/retired model IDs with dateless aliases

### DIFF
--- a/emdx/commands/compact.py
+++ b/emdx/commands/compact.py
@@ -214,7 +214,7 @@ def compact(
         None, "--topic", help="Filter to documents matching this topic/query"
     ),
     model: str | None = typer.Option(
-        None, "--model", "-m", help="Model to use for synthesis (default: claude-opus-4)"
+        None, "--model", "-m", help="Model to use for synthesis (default: claude-opus-4-6)"
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompts"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),

--- a/emdx/commands/wiki.py
+++ b/emdx/commands/wiki.py
@@ -1600,7 +1600,7 @@ def wiki_model(
     """Set or clear a per-topic model override for wiki generation.
 
     Examples:
-        emdx maintain wiki model 5 claude-opus-4-5-20250514     # Set override
+        emdx maintain wiki model 5 claude-opus-4-6              # Set override
         emdx maintain wiki model 5 --clear                       # Remove override
     """
     from ..database import db

--- a/emdx/services/entity_service.py
+++ b/emdx/services/entity_service.py
@@ -782,18 +782,18 @@ VALID_RELATIONSHIP_TYPES = frozenset(
     }
 )
 
-# Model shorthand → full model ID mapping
+# Model shorthand → model ID mapping (dateless aliases: stable across snapshot bumps)
 _MODEL_MAP: dict[str, str] = {
-    "haiku": "claude-haiku-4-5-20250315",
-    "sonnet": "claude-sonnet-4-20250514",
-    "opus": "claude-opus-4-20250514",
+    "haiku": "claude-haiku-4-5",
+    "sonnet": "claude-sonnet-4-5",
+    "opus": "claude-opus-4-6",
 }
 
 # Cost per million tokens (input, output) for estimation
 _MODEL_COSTS: dict[str, tuple[float, float]] = {
-    "haiku": (0.80, 4.00),
+    "haiku": (1.00, 5.00),
     "sonnet": (3.00, 15.00),
-    "opus": (15.00, 75.00),
+    "opus": (5.00, 25.00),
 }
 
 # Maximum content length to send to the LLM (chars)

--- a/emdx/services/synthesis_service.py
+++ b/emdx/services/synthesis_service.py
@@ -254,14 +254,14 @@ class SynthesisService:
     """AI-powered document synthesis using Claude API."""
 
     # Always use Opus for synthesis - quality critical, infrequent operation
-    DEFAULT_MODEL = "claude-opus-4-20250514"
+    DEFAULT_MODEL = "claude-opus-4-6"
     MAX_TOKENS = 8000
 
     def __init__(self, model: str | None = None):
         """Initialize the synthesis service.
 
         Args:
-            model: Model to use (defaults to claude-opus-4)
+            model: Model to use (defaults to claude-opus-4-6)
         """
         self.model = model or self.DEFAULT_MODEL
 

--- a/tests/test_entity_extraction_llm.py
+++ b/tests/test_entity_extraction_llm.py
@@ -32,17 +32,17 @@ class TestResolveModel:
     """Test model shorthand resolution."""
 
     def test_haiku_resolves(self) -> None:
-        assert resolve_model("haiku") == "claude-haiku-4-5-20250315"
+        assert resolve_model("haiku") == "claude-haiku-4-5"
 
     def test_sonnet_resolves(self) -> None:
-        assert resolve_model("sonnet") == "claude-sonnet-4-20250514"
+        assert resolve_model("sonnet") == "claude-sonnet-4-5"
 
     def test_opus_resolves(self) -> None:
-        assert resolve_model("opus") == "claude-opus-4-20250514"
+        assert resolve_model("opus") == "claude-opus-4-6"
 
     def test_case_insensitive(self) -> None:
-        assert resolve_model("Haiku") == "claude-haiku-4-5-20250315"
-        assert resolve_model("SONNET") == "claude-sonnet-4-20250514"
+        assert resolve_model("Haiku") == "claude-haiku-4-5"
+        assert resolve_model("SONNET") == "claude-sonnet-4-5"
 
     def test_full_id_passthrough(self) -> None:
         full_id = "claude-custom-model-2026"
@@ -395,7 +395,7 @@ class TestCallClaudeForEntities:
         )
         _call_claude_for_entities("content", "Title", model="sonnet")
         call_args = mock_run.call_args[0][0]
-        assert "claude-sonnet-4-20250514" in call_args
+        assert "claude-sonnet-4-5" in call_args
 
 
 # ── Database persistence ─────────────────────────────────────────────
@@ -576,7 +576,7 @@ class TestExtractAndSaveEntitiesLLM:
 
         assert stats["entities_saved"] == 2
         assert stats["relationships_saved"] == 1
-        assert stats["model"] == "claude-haiku-4-5-20250315"
+        assert stats["model"] == "claude-haiku-4-5"
         assert stats["estimated_input_tokens"] > 0
         assert stats["estimated_cost_usd"] > 0.0
 


### PR DESCRIPTION
Fixes #1055, fixes #1056 (from the 2026-07-18 audit).

## Changes

- **`entity_service._MODEL_MAP`** — `haiku` pointed at a nonexistent ID (`claude-haiku-4-5-20250315`); `sonnet`/`opus` pointed at retired 4.0 snapshots (`claude-*-4-20250514`, retirement date passed 2026-06-15). All three now use dateless aliases (`claude-haiku-4-5`, `claude-sonnet-4-5`, `claude-opus-4-6`) so future snapshot retirements can't break resolution. This unbreaks `emdx maintain entities --llm` (haiku is the module default).
- **`entity_service._MODEL_COSTS`** — haiku/opus updated to current per-tier pricing ($1/$5, $5/$25 per 1M tokens); opus was ~3× high.
- **`OpusSynthesisService.DEFAULT_MODEL`** — retired `claude-opus-4-20250514` → `claude-opus-4-6` (unbreaks `emdx labs compact`).
- Stale model strings in `compact --model` help text and the `wiki model` docstring example updated to match.
- Test assertions in `test_entity_extraction_llm.py` updated to the new IDs.

## Testing

- `pytest tests/test_entity_extraction_llm.py tests/test_compact*.py tests/test_wiki_model_override.py` — 75 passed
- `ruff check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429)_