### PR TITLE
fix(backup): make restore atomic — validate, snapshot, then swap

### DIFF
--- a/emdx/services/backup_service.py
+++ b/emdx/services/backup_service.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import gzip
 import logging
+import os
 import shutil
 import sqlite3
 import time
@@ -138,6 +139,12 @@ class BackupService:
         """Restore the knowledge base from a backup file.
 
         Handles both compressed (.db.gz) and uncompressed (.db) backups.
+
+        The live database is never written in place: the backup is validated
+        (PRAGMA integrity_check) in a temp copy first, the current database is
+        preserved as ``<name>.pre-restore``, and the validated copy is swapped
+        in atomically with os.replace(). On any failure the live database is
+        left untouched.
         """
         start = time.monotonic()
 
@@ -151,28 +158,40 @@ class BackupService:
                 message=f"Backup file not found: {backup_path}",
             )
 
+        # Temp files live next to the live DB so os.replace() stays on one filesystem
+        temp_source = self.db_path.parent / f".{self.db_path.name}.restore-src"
+        temp_restore = self.db_path.parent / f".{self.db_path.name}.restore-tmp"
         try:
             if backup_path.suffix == ".gz":
-                # Decompress to a temp file, then restore
-                temp_db = backup_path.with_suffix("")
-                with gzip.open(backup_path, "rb") as f_in, open(temp_db, "wb") as f_out:
+                with gzip.open(backup_path, "rb") as f_in, open(temp_source, "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
-                source_path = temp_db
+                source_path = temp_source
             else:
                 source_path = backup_path
 
-            # Restore via SQLite backup API
+            # Materialize the restored DB in a temp file via the SQLite backup API
             src = sqlite3.connect(source_path)
-            dst = sqlite3.connect(self.db_path)
+            dst = sqlite3.connect(temp_restore)
             try:
                 src.backup(dst)
             finally:
                 dst.close()
                 src.close()
 
-            # Clean up temp decompressed file
-            if backup_path.suffix == ".gz" and source_path.exists():
-                source_path.unlink()
+            # Validate before touching the live DB
+            check_conn = sqlite3.connect(temp_restore)
+            try:
+                integrity = check_conn.execute("PRAGMA integrity_check").fetchone()[0]
+            finally:
+                check_conn.close()
+            if integrity != "ok":
+                raise RuntimeError(f"backup failed integrity check: {integrity}")
+
+            # Keep a safety copy of the current DB, then swap in the validated copy
+            if self.db_path.exists():
+                pre_restore = self.db_path.parent / f"{self.db_path.name}.pre-restore"
+                shutil.copy2(self.db_path, pre_restore)
+            os.replace(temp_restore, self.db_path)
 
             duration = time.monotonic() - start
             return BackupResult(
@@ -193,6 +212,9 @@ class BackupService:
                 pruned_count=0,
                 message=f"Restore failed: {e}",
             )
+        finally:
+            for tmp in (temp_source, temp_restore):
+                tmp.unlink(missing_ok=True)
 
     def _parse_backup_date(self, path: Path) -> datetime | None:
         """Extract date from backup filename like emdx-backup-2026-02-28_143022.db.gz."""

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -156,6 +156,79 @@ class TestBackupService:
         assert not result.success
         assert "not found" in result.message
 
+    def test_restore_corrupt_backup_leaves_live_db_untouched(
+        self, svc: BackupService, tmp_path: Path
+    ) -> None:
+        """A corrupt/garbage backup must fail without modifying the live DB."""
+        corrupt = tmp_path / "corrupt.db"
+        corrupt.write_bytes(b"this is not a sqlite database" * 100)
+
+        result = svc.restore_backup(corrupt)
+        assert not result.success
+
+        # Live DB still intact and readable
+        conn = sqlite3.connect(svc.db_path)
+        row = conn.execute("SELECT title FROM docs WHERE id=1").fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "hello"
+
+    def test_restore_truncated_gz_leaves_live_db_untouched(
+        self, svc: BackupService, tmp_path: Path
+    ) -> None:
+        """A truncated .gz backup must fail without modifying the live DB."""
+        result = svc.create_backup(compress=True)
+        assert result.success and result.path is not None
+        data = result.path.read_bytes()
+        result.path.write_bytes(data[: len(data) // 2])
+
+        restore_result = svc.restore_backup(result.path)
+        assert not restore_result.success
+
+        conn = sqlite3.connect(svc.db_path)
+        row = conn.execute("SELECT title FROM docs WHERE id=1").fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "hello"
+
+    def test_restore_creates_pre_restore_safety_copy(self, svc: BackupService) -> None:
+        result = svc.create_backup(compress=True)
+        assert result.success and result.path is not None
+
+        # Change the live DB so the safety copy is distinguishable
+        conn = sqlite3.connect(svc.db_path)
+        conn.execute("UPDATE docs SET title='changed' WHERE id=1")
+        conn.commit()
+        conn.close()
+
+        restore_result = svc.restore_backup(result.path)
+        assert restore_result.success
+
+        pre_restore = svc.db_path.parent / f"{svc.db_path.name}.pre-restore"
+        assert pre_restore.exists()
+        conn = sqlite3.connect(pre_restore)
+        row = conn.execute("SELECT title FROM docs WHERE id=1").fetchone()
+        conn.close()
+        assert row[0] == "changed"
+
+    def test_restore_failure_cleans_up_temp_files(
+        self, svc: BackupService, tmp_path: Path
+    ) -> None:
+        """Failed restores must not leak decompressed/temp DB files."""
+        corrupt_gz = tmp_path / "emdx-backup-corrupt.db.gz"
+        with gzip.open(corrupt_gz, "wb") as f:
+            f.write(b"not a sqlite database" * 100)
+
+        result = svc.restore_backup(corrupt_gz)
+        assert not result.success
+
+        leftovers = [
+            p
+            for p in svc.db_path.parent.iterdir()
+            if "restore-src" in p.name or "restore-tmp" in p.name
+        ]
+        assert leftovers == []
+
     def test_retention_pruning(self, svc: BackupService, backup_dir: Path) -> None:
         """Old backups beyond retention tiers get pruned."""
         now = datetime.now(tz=timezone.utc)


### PR DESCRIPTION
Fixes #1054 (Critical, from the 2026-07-18 audit).

## Problem

`restore_backup` wrote directly onto the live database (`sqlite3.connect(self.db_path)` as the backup destination). A corrupt/truncated backup file, or an interruption mid-restore, left the real knowledge base partially overwritten — and the exception handler then reported "Restore failed" after the damage was done. Failed `.gz` restores also leaked the decompressed temp copy.

## Fix

Restore now never touches the live DB until a validated replacement exists:

1. Materialize the backup into a temp copy **next to the live DB** (same filesystem, so the final swap is atomic)
2. `PRAGMA integrity_check` on the copy — garbage/truncated backups fail here
3. Preserve the current DB as `<name>.pre-restore`
4. `os.replace()` the validated copy over the live DB
5. Temp files (including the decompressed `.gz` source) removed in a `finally`

On any failure the live database is left untouched.

## Testing

New tests: corrupt backup leaves live DB untouched; truncated `.gz` leaves live DB untouched; `.pre-restore` safety copy contains the pre-restore state; failed restores leak no temp files. `pytest tests/test_backup.py` — 26 passed. `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429)_