### PR TITLE
fix: narrow staleness-check exception handling to sqlite3.OperationalError

### DIFF
--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -1499,7 +1500,7 @@ def _flag_wiki_staleness(doc_id: int) -> None:
         from emdx.services.wiki_staleness_service import check_doc_staleness
 
         check_doc_staleness(doc_id)
-    except Exception:
+    except sqlite3.OperationalError:
         pass  # Wiki tables may not exist; non-critical
 
 

--- a/emdx/database/documents.py
+++ b/emdx/database/documents.py
@@ -5,6 +5,7 @@ Document CRUD operations for emdx knowledge base
 from __future__ import annotations
 
 import logging
+import sqlite3
 from typing import Union, cast
 
 from ..models.document import Document
@@ -291,7 +292,7 @@ def update_document(doc_id: int, title: str, content: str) -> bool:
             from emdx.services.wiki_synthesis_service import mark_stale
 
             mark_stale(doc_id, reason="source_updated")
-        except Exception:
+        except sqlite3.OperationalError:
             pass  # Wiki tables may not exist yet; non-critical
 
     return updated


### PR DESCRIPTION
Fixes #1064 (from the 2026-07-18 audit).

The "wiki tables may not exist" guards around `mark_stale` (`database/documents.py`) and `check_doc_staleness` (`commands/core.py`) used `except Exception: pass`, which also swallowed `TypeError`/`AttributeError`/logic bugs inside the staleness services — staleness flagging could silently stop working with no signal. Narrowed to `sqlite3.OperationalError`, the only expected failure (missing table).

Testing: `pytest tests/test_commands_core.py tests/test_documents.py tests/test_history.py` — 152 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429)_