### PR TITLE
fix: remove dead --db-url/EMDX_DATABASE_URL option

### DIFF
--- a/emdx/main.py
+++ b/emdx/main.py
@@ -143,9 +143,6 @@ def main(
     version: bool = typer.Option(False, "--version", "-V", help="Show version and exit"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output"),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress non-error output"),
-    db_url: str | None = typer.Option(
-        None, "--db-url", envvar="EMDX_DATABASE_URL", help="Database connection URL"
-    ),
 ) -> None:
     """
     emdx - A knowledge base for developers and AI agents

--- a/tests/test_commands_stale.py
+++ b/tests/test_commands_stale.py
@@ -134,7 +134,7 @@ class TestMaintainStaleBackwardCompat:
     ) -> Generator[None, None, None]:
         """Set up a fresh test database."""
         test_db = tmp_path / "test.db"
-        monkeypatch.setenv("EMDX_DATABASE_URL", f"sqlite:///{test_db}")
+        monkeypatch.setenv("EMDX_TEST_DB", str(test_db))
         db.ensure_schema()
         yield
 
@@ -186,7 +186,7 @@ class TestMaintainTouchBackwardCompat:
     ) -> Generator[None, None, None]:
         """Set up a fresh test database."""
         test_db = tmp_path / "test.db"
-        monkeypatch.setenv("EMDX_DATABASE_URL", f"sqlite:///{test_db}")
+        monkeypatch.setenv("EMDX_TEST_DB", str(test_db))
         db.ensure_schema()
         yield
 
@@ -235,7 +235,7 @@ class TestPrimeIntegration:
     ) -> None:
         """get_top_stale_for_priming returns a list."""
         test_db = tmp_path / "test.db"
-        monkeypatch.setenv("EMDX_DATABASE_URL", f"sqlite:///{test_db}")
+        monkeypatch.setenv("EMDX_TEST_DB", str(test_db))
         db.ensure_schema()
 
         result = get_top_stale_for_priming(limit=5)

--- a/tests/test_stale.py
+++ b/tests/test_stale.py
@@ -35,7 +35,7 @@ def _strip_ansi(text: str) -> str:
 def setup_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
     """Set up a fresh test database for each test."""
     test_db = tmp_path / "test.db"
-    monkeypatch.setenv("EMDX_DATABASE_URL", f"sqlite:///{test_db}")
+    monkeypatch.setenv("EMDX_TEST_DB", str(test_db))
     db.ensure_schema()
     yield
 


### PR DESCRIPTION
Fixes #1059 (from the 2026-07-18 audit).

`--db-url` (envvar `EMDX_DATABASE_URL`) was declared on the main callback but its value was never read anywhere — `get_db_path()` only honors `EMDX_TEST_DB` and `EMDX_DB`, so the option silently did nothing and sat outside the documented DB-path priority chain.

Four test sites set `EMDX_DATABASE_URL` expecting DB isolation it never provided (`test_stale.py`, `test_commands_stale.py` ×3); they now use `EMDX_TEST_DB`, the documented test-isolation tier.

Testing: `pytest tests/test_stale.py tests/test_commands_stale.py` — 53 passed; ruff clean; grep confirms zero remaining references to `db_url`/`EMDX_DATABASE_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429)_