### PR TITLE
fix: pass scrubbed env to claude CLI subprocess calls

### DIFF
--- a/emdx/commands/explore.py
+++ b/emdx/commands/explore.py
@@ -31,6 +31,7 @@ from ..services.clustering import (
     find_clusters,
     require_sklearn,
 )
+from ..utils.environment import get_subprocess_env
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -351,6 +352,7 @@ def _generate_questions(topics: list[TopicCluster]) -> list[TopicQuestions]:
         try:
             proc = subprocess.run(
                 ["claude", "--print", "-p", prompt, "--model", "sonnet"],
+                env=get_subprocess_env(),
                 capture_output=True,
                 text=True,
                 timeout=120,

--- a/emdx/services/ask_service.py
+++ b/emdx/services/ask_service.py
@@ -19,6 +19,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 from ..database import db
+from ..utils.environment import get_subprocess_env
 
 if TYPE_CHECKING:
     from .embedding_service import ChunkMatch, EmbeddingService
@@ -255,6 +256,7 @@ def _execute_claude_prompt(
             capture_output=True,
             text=True,
             timeout=ANSWER_TIMEOUT,
+            env=get_subprocess_env(),
         )
         if result.returncode != 0:
             error_msg = result.stderr.strip() or f"Exit code {result.returncode}"

--- a/emdx/services/entity_service.py
+++ b/emdx/services/entity_service.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field
 from typing import TypedDict
 
 from ..database import db, document_links
+from ..utils.environment import get_subprocess_env
 
 logger = logging.getLogger(__name__)
 
@@ -995,6 +996,7 @@ def _call_claude_for_entities(
             capture_output=True,
             text=True,
             timeout=_CLAUDE_TIMEOUT,
+            env=get_subprocess_env(),
         )
     except FileNotFoundError:
         raise RuntimeError(

--- a/emdx/services/synthesis_service.py
+++ b/emdx/services/synthesis_service.py
@@ -17,6 +17,7 @@ from enum import Enum
 from typing import Any
 
 from ..database import db
+from ..utils.environment import get_subprocess_env
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,7 @@ def _execute_prompt(
             capture_output=True,
             text=True,
             timeout=SYNTHESIS_TIMEOUT,
+            env=get_subprocess_env(),
         )
         if result.returncode != 0:
             error_msg = result.stderr.strip() or f"Exit code {result.returncode}"

--- a/emdx/services/wiki_clustering_service.py
+++ b/emdx/services/wiki_clustering_service.py
@@ -18,6 +18,7 @@ import subprocess
 from dataclasses import dataclass
 
 from ..database import db
+from ..utils.environment import get_subprocess_env
 
 logger = logging.getLogger(__name__)
 
@@ -529,6 +530,7 @@ def auto_label_cluster(cluster: TopicCluster) -> str:
             capture_output=True,
             text=True,
             timeout=30,
+            env=get_subprocess_env(),
         )
         if result.returncode == 0 and result.stdout.strip():
             label = result.stdout.strip().strip('"').strip("'")


### PR DESCRIPTION
Fixes #1057 (from the 2026-07-18 audit).

`get_subprocess_env()` (strips `CLAUDECODE` so a nested `claude` invocation works from inside a Claude Code session) existed in `utils/environment.py` but nothing imported it — the helper was written for these call sites and never connected. Wired into all five `claude` CLI spawn points:

- `services/ask_service.py` (also covers `emdx view --review` via `_execute_claude_prompt`)
- `services/entity_service.py`
- `services/synthesis_service.py`
- `services/wiki_clustering_service.py`
- `commands/explore.py`

Testing: 228 passed across the ask/compact/distill/entity/explore test files; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429)_