### PR TITLE
fix(tui): replace discarded asyncio.create_task with run_worker

### DIFF
--- a/emdx/ui/browser_container.py
+++ b/emdx/ui/browser_container.py
@@ -346,14 +346,14 @@ class BrowserContainer(App[None]):
 
     def action_open_command_palette(self) -> None:
         """Open the command palette modal."""
-        import asyncio
-
         try:
             from emdx.ui.command_palette import CommandPaletteScreen
 
             def on_palette_result(result: dict | None) -> None:
                 if result:
-                    asyncio.create_task(self._handle_palette_result(result))
+                    # run_worker (not bare create_task): asyncio holds only a weak
+                    # ref to tasks, so an unreferenced task can be GC'd mid-flight
+                    self.run_worker(self._handle_palette_result(result), exclusive=True)
 
             self.push_screen(CommandPaletteScreen(), on_palette_result)
 

--- a/emdx/ui/command_palette/palette_screen.py
+++ b/emdx/ui/command_palette/palette_screen.py
@@ -5,7 +5,6 @@ Provides quick access to documents, commands, and navigation
 via keyboard-driven fuzzy search.
 """
 
-import asyncio
 import logging
 import traceback
 from typing import Any
@@ -204,7 +203,9 @@ class CommandPaletteScreen(ModalScreen):
         # Use unique render ID to avoid race conditions
         self._render_id = getattr(self, "_render_id", 0) + 1
         current_render = self._render_id
-        self.call_later(lambda: asyncio.create_task(self._render_results(state, current_render)))
+        # run_worker (not bare create_task): asyncio holds only a weak ref to
+        # tasks, so an unreferenced task can be GC'd before it renders
+        self.call_later(lambda: self.run_worker(self._render_results(state, current_render)))
 
     async def _render_results(self, state: PaletteState, render_id: int) -> None:
         """Render results to the ListView."""
@@ -249,9 +250,14 @@ class CommandPaletteScreen(ModalScreen):
         if self._debounce_timer:
             self._debounce_timer.stop()
 
-        # Debounce search (100ms)
+        # Debounce search (100ms). Exclusive worker: cancels any in-flight
+        # search so a slow older search can't clobber newer results, and keeps
+        # a strong reference (bare create_task tasks can be GC'd mid-flight).
         self._debounce_timer = self.set_timer(
-            0.1, lambda: asyncio.create_task(self.presenter.search(query))
+            0.1,
+            lambda: self.run_worker(
+                self.presenter.search(query), group="palette-search", exclusive=True
+            ),
         )
 
     def action_cursor_up(self) -> None:


### PR DESCRIPTION
Fixes #1060 (from the 2026-07-18 audit).

asyncio holds only a weak reference to running tasks, so three sites that created tasks without keeping a reference could have their work garbage-collected mid-flight — silently dropping palette navigation, result renders, or searches:

- `browser_container.py` `on_palette_result` → `run_worker(..., exclusive=True)` (matches the existing `action_select_doc` pattern)
- `palette_screen.py` `_on_state_update` render → `run_worker(...)`
- `palette_screen.py` debounced search → `run_worker(..., group="palette-search", exclusive=True)`

The exclusive search group also fixes the stale-result race: a slow older search is now cancelled by new input instead of racing the newer search for the shared presenter state (the `_render_id` guard only de-duped rendering, not the state mutation).

Testing: 106 palette/browser/container tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429)_