### PR TITLE
fix(tui): move activity data loading off the event loop, batch tag queries

### DIFF
--- a/emdx/ui/activity/activity_data.py
+++ b/emdx/ui/activity/activity_data.py
@@ -3,6 +3,7 @@
 Loads recent documents (excluding superseded) and sorts by timestamp descending.
 """
 
+import asyncio
 import logging
 from datetime import datetime
 
@@ -33,20 +34,26 @@ class ActivityDataLoader:
     ) -> list[ActivityItem]:
         """Load all documents and sort by timestamp descending.
 
+        The DB work is synchronous SQLite; run it in a thread so the awaiting
+        TUI event loop isn't blocked for the duration of the queries.
+
         Args:
             doc_type_filter: Filter documents by type: "user", "wiki", or "all".
 
         Returns:
             Sorted list of document items.
         """
+        return await asyncio.to_thread(self._load_all_sync, doc_type_filter)
+
+    def _load_all_sync(self, doc_type_filter: str = "all") -> list[ActivityItem]:
         docs: list[ActivityItem] = []
         if HAS_DOCS:
-            docs = await self._load_documents(doc_type_filter=doc_type_filter)
+            docs = self._load_documents(doc_type_filter=doc_type_filter)
 
         docs.sort(key=lambda item: -item.timestamp.timestamp())
         return docs
 
-    async def _load_documents(self, doc_type_filter: str = "all") -> list[ActivityItem]:
+    def _load_documents(self, doc_type_filter: str = "all") -> list[ActivityItem]:
         """Load recent documents (top-level only, superseded are hidden).
 
         Args:
@@ -61,14 +68,12 @@ class ActivityDataLoader:
             logger.error(f"Error listing recent documents: {e}", exc_info=True)
             return items
 
-        # Bulk-load tags for all docs in one pass
+        # Bulk-load tags for all docs in a single query (avoids N+1)
         doc_tags: dict[int, list[str]] = {}
         try:
-            from emdx.models.tags import get_document_tags
+            from emdx.models.tags import get_tags_for_documents
 
-            for doc in docs:
-                doc_id = doc.id
-                doc_tags[doc_id] = get_document_tags(doc_id)
+            doc_tags = get_tags_for_documents([doc.id for doc in docs])
         except ImportError:
             pass
         except Exception as e:

--- a/tests/test_activity_doc_type.py
+++ b/tests/test_activity_doc_type.py
@@ -104,7 +104,7 @@ class TestDataLoaderDocTypeFilter:
         ):
             mock_svc.list_recent_documents.return_value = docs
             loader = ActivityDataLoader()
-            items = await loader._load_documents(doc_type_filter="user")
+            items = loader._load_documents(doc_type_filter="user")
 
         assert len(items) == 1
         assert isinstance(items[0], DocumentItem)
@@ -124,7 +124,7 @@ class TestDataLoaderDocTypeFilter:
         ):
             mock_svc.list_recent_documents.return_value = docs
             loader = ActivityDataLoader()
-            items = await loader._load_documents(doc_type_filter="wiki")
+            items = loader._load_documents(doc_type_filter="wiki")
 
         assert len(items) == 1
         assert isinstance(items[0], DocumentItem)
@@ -144,7 +144,7 @@ class TestDataLoaderDocTypeFilter:
         ):
             mock_svc.list_recent_documents.return_value = docs
             loader = ActivityDataLoader()
-            items = await loader._load_documents(doc_type_filter="all")
+            items = loader._load_documents(doc_type_filter="all")
 
         assert len(items) == 2
 
@@ -159,7 +159,7 @@ class TestDataLoaderDocTypeFilter:
         ):
             mock_svc.list_recent_documents.return_value = docs
             loader = ActivityDataLoader()
-            items = await loader._load_documents(doc_type_filter="user")
+            items = loader._load_documents(doc_type_filter="user")
 
         assert len(items) == 1
         assert isinstance(items[0], DocumentItem)


### PR DESCRIPTION
Fixes #1061 (from the 2026-07-18 audit).

`ActivityDataLoader.load_all` was `async` but did synchronous SQLite work directly on the TUI event loop — including an N+1 loop calling `get_document_tags()` per document (up to 100 queries) — so every periodic activity refresh stalled the whole UI.

- The sync DB work now runs via `asyncio.to_thread` (mirroring the existing `hybrid_search.search_unified` pattern); `load_all` keeps its async signature so call sites are unchanged
- Tags are fetched in a single query using the existing `get_tags_for_documents` batch helper

Note: the knowledge-graph panel's smaller per-selection reads (already guarded by a doc_id cache) are left as-is; if they're still noticeable they can get the same treatment in a follow-up.

Testing: 42 activity tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429)_