### PR TITLE
fix(cloud-backup): surface provider failures instead of crashing or lying

### DIFF
--- a/emdx/commands/backup.py
+++ b/emdx/commands/backup.py
@@ -98,7 +98,14 @@ def list_backups(
             print(f"Error: {e}")
         raise typer.Exit(code=1) from None
 
-    backups = svc.list_backups()
+    try:
+        backups = svc.list_backups()
+    except RuntimeError as e:
+        if json_output:
+            print(json_mod.dumps({"error": str(e)}))
+        else:
+            print(f"Error: {e}")
+        raise typer.Exit(code=1) from None
 
     if json_output:
         print(json_mod.dumps(backups, indent=2))

--- a/emdx/services/backup_providers/github.py
+++ b/emdx/services/backup_providers/github.py
@@ -153,18 +153,21 @@ class GitHubGistProvider:
         return str(dest_gz)
 
     def list_backups(self) -> list[BackupMetadata]:
-        """List all emdx backup gists, newest first."""
-        try:
-            result = self._run_gh(
-                [
-                    "gist",
-                    "list",
-                    "--limit",
-                    "100",
-                ]
-            )
-        except RuntimeError:
-            return []
+        """List all emdx backup gists, newest first.
+
+        Raises:
+            RuntimeError: If gh is not installed/authenticated or the listing
+                fails. An availability failure must not be reported as "no
+                backups" — callers would wrongly conclude their backups are gone.
+        """
+        result = self._run_gh(
+            [
+                "gist",
+                "list",
+                "--limit",
+                "100",
+            ]
+        )
 
         backups: list[BackupMetadata] = []
 

--- a/emdx/services/cloud_backup_service.py
+++ b/emdx/services/cloud_backup_service.py
@@ -76,7 +76,10 @@ class CloudBackupService:
                 message=f"Backup uploaded to {self.provider.name}: {metadata['backup_id']}",
                 metadata=metadata,
             )
-        except RuntimeError as e:
+        except Exception as e:
+            # Providers raise more than RuntimeError (OSError from file I/O,
+            # HTTP errors from gdrive); all become a failure result, not a crash
+            logger.debug("Cloud upload failed", exc_info=True)
             return CloudBackupResult(
                 success=False,
                 message=f"Upload failed: {e}",
@@ -100,7 +103,8 @@ class CloudBackupService:
                 message=f"Backup downloaded to {path}",
                 path=path,
             )
-        except RuntimeError as e:
+        except Exception as e:
+            logger.debug("Cloud download failed", exc_info=True)
             return CloudDownloadResult(
                 success=False,
                 message=f"Download failed: {e}",
@@ -108,12 +112,31 @@ class CloudBackupService:
             )
 
     def list_backups(self) -> list[BackupMetadata]:
-        """List all backups from the cloud provider."""
-        return self.provider.list_backups()
+        """List all backups from the cloud provider.
+
+        Raises:
+            RuntimeError: If the provider is unavailable (e.g. gh not
+                installed / not authenticated) or the listing fails.
+        """
+        try:
+            return self.provider.list_backups()
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Listing backups failed: {e}") from e
 
     def delete(self, backup_id: str) -> bool:
-        """Delete a backup from the cloud provider."""
-        return self.provider.delete(backup_id)
+        """Delete a backup from the cloud provider.
+
+        Raises:
+            RuntimeError: If the provider is unavailable or the delete fails.
+        """
+        try:
+            return self.provider.delete(backup_id)
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Deleting backup failed: {e}") from e
 
     def check_auth(self) -> ProviderAuthStatus:
         """Check authentication status for the current provider."""

--- a/tests/test_cloud_backup.py
+++ b/tests/test_cloud_backup.py
@@ -178,10 +178,13 @@ class TestGitHubGistProvider:
         assert provider.list_backups() == []
 
     @patch("subprocess.run")
-    def test_list_backups_gh_error(self, mock_run: MagicMock) -> None:
+    def test_list_backups_gh_error_raises(self, mock_run: MagicMock) -> None:
+        """gh failures (not installed / not authenticated) must surface as an
+        error, not be reported as an empty backup list."""
         mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
         provider = GitHubGistProvider()
-        assert provider.list_backups() == []
+        with pytest.raises(RuntimeError):
+            provider.list_backups()
 
     @patch("subprocess.run")
     def test_delete_success(self, mock_run: MagicMock) -> None:


### PR DESCRIPTION
Fixes #1062 (from the 2026-07-18 audit).

Three related error-handling problems in the cloud-backup path:

- **`CloudBackupService.upload`/`download`** caught only `RuntimeError`; provider `OSError` (file I/O) and Google Drive HTTP errors escaped as raw tracebacks. They now become `success=False` results (with the exception logged at debug).
- **`list_backups`/`delete`** had no error handling at all; non-`RuntimeError` failures are now wrapped in `RuntimeError` with context.
- **The worst one:** the GitHub provider swallowed *every* `gh` failure in `list_backups` and returned `[]`, so "gh not installed" / "not authenticated" was displayed as *"No cloud backups found."* — telling a user with an auth problem their backups are gone. Availability failures now raise, and `emdx maintain cloud-backup list` prints the actual error and exits 1 (JSON mode gets `{"error": ...}`).

Testing: updated `test_list_backups_gh_error` to assert the raise; 57 backup/cloud-backup tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429)_