### PR TITLE
refactor(sql): bind LIMIT as a parameter instead of f-string interpolation

### DIFF
--- a/emdx/commands/wiki.py
+++ b/emdx/commands/wiki.py
@@ -1005,10 +1005,12 @@ def wiki_coverage(
             ") "
             "ORDER BY d.id"
         )
+        query_params: list[int] = []
         if limit > 0:
-            query += f" LIMIT {limit}"
+            query += " LIMIT ?"
+            query_params.append(limit)
 
-        uncovered_rows = conn.execute(query).fetchall()
+        uncovered_rows = conn.execute(query, query_params).fetchall()
 
     if json_output:
         data = {

--- a/emdx/services/auto_tagger.py
+++ b/emdx/services/auto_tagger.py
@@ -308,7 +308,8 @@ class AutoTagger:
                 query += " HAVING tags IS NULL"
 
             if limit:
-                query += f" LIMIT {limit}"
+                query += " LIMIT ?"
+                params.append(limit)
 
             cursor.execute(query, params)
             documents = cursor.fetchall()

--- a/emdx/services/duplicate_detector.py
+++ b/emdx/services/duplicate_detector.py
@@ -210,10 +210,12 @@ class DuplicateDetector:
                 AND LENGTH(d.content) > 50
                 ORDER BY d.access_count DESC, d.id
             """
+            params: list[int] = []
             if max_documents:
-                query += f" LIMIT {max_documents}"
+                query += " LIMIT ?"
+                params.append(max_documents)
 
-            cursor.execute(query)
+            cursor.execute(query, params)
             documents = [cast(DuplicateDocument, dict(row)) for row in cursor.fetchall()]
 
         if len(documents) < 2:


### PR DESCRIPTION
Fixes #1069 (from the 2026-07-18 audit — the security sweep's only note; everything else was clean).

`wiki.py` coverage query, `duplicate_detector.py`, and `auto_tagger.py` interpolated an int-typed limit into SQL via f-string. Not injectable today (values come from Typer int options), but they deviated from the codebase's otherwise-uniform parameterized pattern and could become unsafe if a call site changes. All three now bind `LIMIT ?`.

Testing: 70 auto-tagger/duplicate/wiki-coverage tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429)_