### PR TITLE
perf(cli): lazy-load wiki, task, tag, and trash command groups

### DIFF
--- a/emdx/main.py
+++ b/emdx/main.py
@@ -24,6 +24,10 @@ LAZY_SUBCOMMANDS = {
     "compact": "emdx.commands.compact:app",
     "maintain": "emdx.commands.maintain:app",
     "labs": "emdx.commands.labs:app",
+    "wiki": "emdx.commands.wiki:wiki_app",
+    "task": "emdx.commands.tasks:app",
+    "tag": "emdx.commands.tags:app",
+    "trash": "emdx.commands.trash:app",
 }
 
 # Pre-computed help strings so --help doesn't trigger imports
@@ -33,6 +37,10 @@ LAZY_HELP = {
     "compact": "Reduce KB redundancy through AI synthesis",
     "maintain": "Maintenance and analysis tools",
     "labs": "Experimental commands (may change or be removed)",
+    "wiki": "Auto-wiki from your knowledge base",
+    "task": "Agent work queue",
+    "tag": "Manage document tags",
+    "trash": "Manage deleted documents",
 }
 
 
@@ -58,10 +66,6 @@ from emdx.commands.prime import prime as prime_command  # noqa: E402
 from emdx.commands.serve import serve as serve_command  # noqa: E402
 from emdx.commands.stale import stale_command, touch_command  # noqa: E402
 from emdx.commands.status import status as status_command  # noqa: E402
-from emdx.commands.tags import app as tag_app  # noqa: E402
-from emdx.commands.tasks import app as tasks_app  # noqa: E402
-from emdx.commands.trash import app as trash_app  # noqa: E402
-from emdx.commands.wiki import wiki_app  # noqa: E402
 from emdx.ui.gui import gui as gui_command  # noqa: E402
 
 # Create main app with lazy loading support
@@ -92,19 +96,8 @@ for command in core_app.registered_commands:
 for command in gist_app.registered_commands:
     app.registered_commands.append(command)
 
-# Tag commands (subcommand group: emdx tag <subcommand>)
-app.add_typer(tag_app, name="tag", help="Manage document tags")
-
-# Trash commands (subcommand group: emdx trash <subcommand>)
-app.add_typer(trash_app, name="trash", help="Manage deleted documents")
-
-# Add tasks as a subcommand group
-app.add_typer(tasks_app, name="task", help="Agent work queue")
-
-# maintain is lazy-loaded (heavy scipy/sklearn imports via clustering)
-
-# Add wiki as a top-level command group (also available under maintain for backward compat)
-app.add_typer(wiki_app, name="wiki", help="Auto-wiki from your knowledge base")
+# tag, trash, task, wiki, and maintain are lazy-loaded (see LAZY_SUBCOMMANDS):
+# their modules are heavy enough to dominate CLI startup when imported eagerly
 
 # Add db as a subcommand group
 app.add_typer(db_app, name="db", help="Database management")

--- a/emdx/utils/lazy_group.py
+++ b/emdx/utils/lazy_group.py
@@ -158,7 +158,10 @@ class LazyCommand(click.Group):
         help_text: str,
         parent_group: LazyTyperGroup,
     ) -> None:
-        super().__init__(name=name, help=help_text)
+        # invoke_without_command so bare invocation (e.g. `emdx trash`) parses
+        # and reaches invoke(); the real group then applies its own
+        # invoke_without_command semantics (default action or "Missing command").
+        super().__init__(name=name, help=help_text, invoke_without_command=True)
         self.import_path = import_path
         self.help_text = help_text
         self.short_help = help_text  # For --help listings
@@ -262,6 +265,17 @@ class LazyCommand(click.Group):
         real_cmd = self._load_real_command()
         # Update the parent group's cache
         self.parent_group._loaded_commands[self.name or ""] = real_cmd
+        # Bare invocation of a group that doesn't define a default action:
+        # show its help (matching eager-group behavior) instead of delegating,
+        # which would fail with a bare "Missing command." error.
+        if (
+            not ctx._protected_args
+            and not ctx.args
+            and isinstance(real_cmd, click.Group)
+            and not real_cmd.invoke_without_command
+        ):
+            click.echo(real_cmd.get_help(ctx))
+            ctx.exit()
         # Delegate to the real command
         return real_cmd.invoke(ctx)
 


### PR DESCRIPTION
Refs #1067 (from the 2026-07-18 audit's performance benchmark, which showed emdx is startup-bound: ~200ms floor per invocation, with queries a small fraction on top).

`python -X importtime` attributes ~44ms to `emdx.commands.wiki`, ~28ms to `tasks`, and ~24ms to `tags` — all eagerly imported by `emdx.main` on **every** invocation, including `save`/`find`/`prime` calls that never touch them. This moves those groups (plus `trash`) onto the existing lazy-loading registry already used by `maintain`/`labs`.

`LazyCommand` needed two adjustments to host groups that define a default bare action:

- Construct with `invoke_without_command=True` so bare invocation (e.g. `emdx trash`, which lists the trash) parses and reaches the real group's own semantics
- On bare invocation of a group *without* a default action (e.g. `emdx task`), print its help — matching eager-group behavior — instead of a bare "Missing command." error

## Verification

- `emdx trash` (default action), `emdx maintain` (default action), `emdx task` (help), `emdx wiki --help`, `emdx tag list`, `emdx task ready` all behave as before, verified against a seeded 20k-doc DB
- Full test suite: **2114 passed** — and drops from ~199s to ~89s locally, since every CliRunner invocation skips the same imports
- ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429)_