### PR TITLE
docs: document undocumented env vars; add version-sync guard tests

### DIFF
--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -1183,6 +1183,9 @@ emdx gist 42 --update abc123def456
 - `EMDX_TEST_DB` - Test isolation database (set by pytest fixtures)
 - `EMDX_TASK_ID` - Task ID for agent sessions (used by hooks, see [Hooks & Integration](#-hooks--integration))
 - `EMDX_DOC_ID` - Document ID for context injection (used by `prime.sh` hook)
+- `EMDX_CLI_TOOL` - Preferred CLI backend for LLM features (default: `claude`)
+- `EMDX_CODE_THEME` - Syntax-highlighting theme for rendered markdown (e.g. `monokai`)
+- `EMDX_EXECUTION_ID` - Execution identifier recorded on document events (set by agent harnesses)
 - `GITHUB_TOKEN` - For Gist integration
 - `EDITOR` - Default editor for `emdx edit`
 

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,39 @@
+"""Guard against version drift across the four files that must stay in sync.
+
+See CLAUDE.md "Release Process": pyproject.toml, emdx/__init__.py,
+.claude-plugin/plugin.json, and .claude-plugin/marketplace.json must all
+carry the same version.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from emdx import __version__
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def test_pyproject_version_matches() -> None:
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
+    assert match is not None, "no version field found in pyproject.toml"
+    assert match.group(1) == __version__
+
+
+def test_plugin_json_version_matches() -> None:
+    plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
+    assert plugin["version"] == __version__
+
+
+def test_marketplace_json_plugin_version_matches() -> None:
+    marketplace = json.loads((REPO_ROOT / ".claude-plugin" / "marketplace.json").read_text())
+    # The top-level "version" is the marketplace descriptor version and is
+    # intentionally independent; the plugin entry's version must match.
+    plugin_versions = [p["version"] for p in marketplace["plugins"]]
+    assert plugin_versions, "no plugin entries found in marketplace.json"
+    assert all(v == __version__ for v in plugin_versions), (
+        f"marketplace.json plugin versions {plugin_versions} != emdx.__version__ {__version__}"
+    )


### PR DESCRIPTION
Fixes #1068 (from the 2026-07-18 audit).

- Adds `EMDX_CLI_TOOL`, `EMDX_CODE_THEME`, and `EMDX_EXECUTION_ID` (read in code, previously undocumented) to the environment-variable table in `docs/cli-api.md`
- Adds `tests/test_version_sync.py` asserting `pyproject.toml`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` plugin versions all equal `emdx.__version__` — the release process requires bumping four files together and nothing guarded that (`marketplace.json`'s top-level descriptor version is intentionally exempt)

Testing: 3 new tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429)_