### PR TITLE
refactor(models): centralize model config in cli_config

### DIFF
--- a/emdx/commands/briefing.py
+++ b/emdx/commands/briefing.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from ..config.cli_config import DEFAULT_LLM_MODEL
 from ..database import db
 
 console = Console()
@@ -474,7 +475,7 @@ def _briefing_save(hours: int, model: str | None) -> None:
             system_prompt=system_prompt,
             user_message=prompt,
             title=title,
-            model=model or "claude-sonnet-4-5-20250929",
+            model=model or DEFAULT_LLM_MODEL,
         )
         if result.success and result.output_content:
             print(result.output_content)

--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -18,6 +18,7 @@ import typer
 from rich.panel import Panel
 from rich.table import Table
 
+from emdx.config.cli_config import DEFAULT_LLM_MODEL
 from emdx.database.documents import (
     find_supersede_candidate,
     set_parent,
@@ -1370,7 +1371,7 @@ def _view_review(doc: Document) -> None:
             system_prompt=system_prompt,
             user_message=user_message,
             title=f"Review: {title[:50]}",
-            model="claude-sonnet-4-5-20250929",
+            model=DEFAULT_LLM_MODEL,
         )
     except RuntimeError as e:
         console.print(f"[red]Review generation failed: {e}[/red]")

--- a/emdx/commands/wiki.py
+++ b/emdx/commands/wiki.py
@@ -21,6 +21,7 @@ from rich import box
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from ..config.cli_config import DEFAULT_LLM_MODEL
 from ..utils.output import console
 
 logger = logging.getLogger(__name__)
@@ -612,7 +613,7 @@ def wiki_generate(
     effective_topics = topic_list[:limit]
 
     # Create a run record
-    run_model = model or "claude-sonnet-4-5-20250929"
+    run_model = model or DEFAULT_LLM_MODEL
     run_id = create_wiki_run(model=run_model, dry_run=dry_run)
 
     generated = 0

--- a/emdx/config/cli_config.py
+++ b/emdx/config/cli_config.py
@@ -84,21 +84,30 @@ CLI_CONFIGS: dict[CliTool, CliConfig] = {
     ),
 }
 
-# Model aliases for convenience
+# Model aliases for convenience.
+# Values use dateless model aliases so snapshot retirements can't break them.
 MODEL_ALIASES: dict[str, dict[str, str]] = {
     "opus": {
         "claude": "claude-opus-4-6",
     },
     "sonnet": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": "claude-sonnet-4-5",
+    },
+    "haiku": {
+        "claude": "claude-haiku-4-5",
     },
     "auto": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": "claude-sonnet-4-5",
     },
     "fast": {
-        "claude": "claude-sonnet-4-5-20250929",
+        "claude": "claude-sonnet-4-5",
     },
 }
+
+# Single source of truth for the default models used by LLM-backed features.
+# Services must import these instead of hardcoding model ID literals.
+DEFAULT_LLM_MODEL: str = MODEL_ALIASES["sonnet"]["claude"]
+DEFAULT_OPUS_MODEL: str = MODEL_ALIASES["opus"]["claude"]
 
 
 def get_default_cli_tool() -> CliTool:

--- a/emdx/services/ask_service.py
+++ b/emdx/services/ask_service.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from ..config.cli_config import DEFAULT_LLM_MODEL
 from ..database import db
 from ..utils.environment import get_subprocess_env
 
@@ -285,7 +286,7 @@ class Answer:
 class AskService:
     """Answer questions using your knowledge base."""
 
-    DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
+    DEFAULT_MODEL = DEFAULT_LLM_MODEL
     MIN_EMBEDDINGS_FOR_SEMANTIC = 50
 
     def __init__(self, model: str | None = None):

--- a/emdx/services/entity_service.py
+++ b/emdx/services/entity_service.py
@@ -783,13 +783,6 @@ VALID_RELATIONSHIP_TYPES = frozenset(
     }
 )
 
-# Model shorthand → model ID mapping (dateless aliases: stable across snapshot bumps)
-_MODEL_MAP: dict[str, str] = {
-    "haiku": "claude-haiku-4-5",
-    "sonnet": "claude-sonnet-4-5",
-    "opus": "claude-opus-4-6",
-}
-
 # Cost per million tokens (input, output) for estimation
 _MODEL_COSTS: dict[str, tuple[float, float]] = {
     "haiku": (1.00, 5.00),
@@ -842,13 +835,20 @@ class LLMExtractionStats(TypedDict):
 def resolve_model(shorthand: str) -> str:
     """Resolve a model shorthand to a full model ID.
 
+    Delegates to the central alias map in config.cli_config so all code
+    paths agree on what 'haiku'/'sonnet'/'opus' mean.
+
     Args:
         shorthand: 'haiku', 'sonnet', 'opus', or a full model ID.
 
     Returns:
-        The full model ID string.
+        The full model ID string (unknown values pass through unchanged).
     """
-    return _MODEL_MAP.get(shorthand.lower(), shorthand)
+    from ..config.cli_config import CliTool, resolve_model_alias
+
+    resolved = resolve_model_alias(shorthand.lower(), CliTool.CLAUDE)
+    # Unknown shorthand: pass the caller's original spelling through
+    return resolved if resolved != shorthand.lower() else shorthand
 
 
 def estimate_cost(content_length: int, model: str = "haiku") -> float:

--- a/emdx/services/synthesis_service.py
+++ b/emdx/services/synthesis_service.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+from ..config.cli_config import DEFAULT_LLM_MODEL, DEFAULT_OPUS_MODEL
 from ..database import db
 from ..utils.environment import get_subprocess_env
 
@@ -120,7 +121,7 @@ class DistillService:
     - Summarizing content for different audiences
     """
 
-    DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
+    DEFAULT_MODEL = DEFAULT_LLM_MODEL
 
     AUDIENCE_PROMPTS = {
         Audience.ME: (
@@ -256,7 +257,7 @@ class SynthesisService:
     """AI-powered document synthesis using Claude API."""
 
     # Always use Opus for synthesis - quality critical, infrequent operation
-    DEFAULT_MODEL = "claude-opus-4-6"
+    DEFAULT_MODEL = DEFAULT_OPUS_MODEL
     MAX_TOKENS = 8000
 
     def __init__(self, model: str | None = None):

--- a/emdx/services/wiki_quality_service.py
+++ b/emdx/services/wiki_quality_service.py
@@ -18,6 +18,7 @@ import re
 import time
 from typing import TYPE_CHECKING
 
+from ..config.cli_config import DEFAULT_LLM_MODEL
 from ..database import db
 
 if TYPE_CHECKING:
@@ -467,7 +468,7 @@ def llm_quality_assessment(
         f"{source_summaries}"
     )
 
-    used_model = model or "claude-sonnet-4-5-20250929"
+    used_model = model or DEFAULT_LLM_MODEL
 
     try:
         result = _execute_prompt(

--- a/emdx/services/wiki_synthesis_service.py
+++ b/emdx/services/wiki_synthesis_service.py
@@ -22,6 +22,7 @@ import re
 import time
 from dataclasses import dataclass, field
 
+from ..config.cli_config import DEFAULT_LLM_MODEL
 from ..database import db
 from ..database.documents import save_document
 from ..database.types import WikiArticleTimingDict
@@ -43,7 +44,7 @@ MAX_DOC_CHARS = 12_000
 STUFF_THRESHOLD_CHARS = 80_000
 
 # Default model — Sonnet for speed/cost balance on bulk generation
-DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
+DEFAULT_MODEL = DEFAULT_LLM_MODEL
 
 # Wiki article tag applied to all generated articles
 WIKI_ARTICLE_TAG = "wiki-article"

--- a/tests/test_view_review.py
+++ b/tests/test_view_review.py
@@ -154,7 +154,9 @@ class TestViewReviewHelper:
         _view_review(_DOC)
 
         call_kwargs = mock_execute.call_args
-        assert call_kwargs[1]["model"] == "claude-sonnet-4-5-20250929"
+        from emdx.config.cli_config import DEFAULT_LLM_MODEL
+
+        assert call_kwargs[1]["model"] == DEFAULT_LLM_MODEL
 
     @patch(
         "emdx.services.ask_service._execute_claude_prompt",


### PR DESCRIPTION
Fixes #1058 (from the 2026-07-18 audit). Follows up #1070, which fixed the broken/retired IDs; this removes the duplication that let them drift in the first place.

## Changes

- **`cli_config.MODEL_ALIASES` is now the single source of truth** — dateless alias values (`claude-sonnet-4-5`, `claude-opus-4-6`, plus a `haiku` entry it was missing). The module was previously orphaned (imported by nothing).
- **New `DEFAULT_LLM_MODEL` / `DEFAULT_OPUS_MODEL` constants** — `ask_service`, both synthesis services, `wiki_synthesis_service`, `wiki_quality_service`, `core --review`, `briefing`, and `wiki generate` import them instead of embedding literals (previously 8+ files, already drifted).
- **`entity_service.resolve_model` delegates to `cli_config.resolve_model_alias`**, keeping its case-insensitive, unknown-passthrough contract; the duplicate `_MODEL_MAP` is deleted. `opus` now means the same thing on every code path.

A future model bump is a one-file change.

## Testing

Full suite: **2117 passed**; ruff + mypy clean. One test assertion (`test_view_review`) updated to reference the constant instead of the dated literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfNqW33v44UFuM37kiV429)_