### PR TITLE
fix(save/tags): output_doc_id linkage + exclude superseded docs from tag search

### DIFF
--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -366,7 +366,7 @@ def save(
     if task is not None:
         from emdx.models.tasks import update_task
 
-        update_kwargs: dict[str, Any] = {"source_doc_id": doc_id}
+        update_kwargs: dict[str, Any] = {"output_doc_id": doc_id}
         if mark_done:
             update_kwargs["status"] = "done"
         update_task(task, **update_kwargs)

--- a/emdx/models/tags.py
+++ b/emdx/models/tags.py
@@ -277,6 +277,7 @@ def search_by_tags(
                 JOIN document_tags dt ON d.id = dt.document_id
                 JOIN tags t ON dt.tag_id = t.id
                 WHERE d.is_deleted = FALSE
+                AND d.parent_id IS NULL
                 AND ({all_condition})
             """
         elif mode == "all" and not prefix_match:

--- a/emdx/models/tags.py
+++ b/emdx/models/tags.py
@@ -289,6 +289,7 @@ def search_by_tags(
                 JOIN document_tags dt ON d.id = dt.document_id
                 JOIN tags t ON dt.tag_id = t.id
                 WHERE d.is_deleted = FALSE
+                AND d.parent_id IS NULL
                 AND d.id IN (
                     SELECT document_id
                     FROM document_tags dt
@@ -310,6 +311,7 @@ def search_by_tags(
                 JOIN document_tags dt ON d.id = dt.document_id
                 JOIN tags t ON dt.tag_id = t.id
                 WHERE d.is_deleted = FALSE
+                AND d.parent_id IS NULL
                 AND ({tag_conditions})
             """
 

--- a/tests/test_models_tags.py
+++ b/tests/test_models_tags.py
@@ -690,6 +690,40 @@ class TestSearchByTags:
         result_ids = [r["id"] for r in results]
         assert doc1 in result_ids
 
+    def test_search_excludes_superseded_documents_any_branch(self) -> None:
+        """A superseded doc (parent_id set via --supersede) shouldn't surface
+        alongside its replacement, matching list_documents()'s default. Uses
+        prefix_match=True (default), which hits the ANY-tag query branch."""
+        from emdx.database.documents import set_parent
+        from emdx.models.tags import add_tags_to_document, search_by_tags
+
+        old_doc = _create_document(title="Versioned Doc v1")
+        new_doc = _create_document(title="Versioned Doc v2")
+        add_tags_to_document(old_doc, ["versioned-repro"])
+        add_tags_to_document(new_doc, ["versioned-repro"])
+        set_parent(old_doc, new_doc, relationship="supersedes")
+
+        results = search_by_tags(["versioned-repro"])
+        result_ids = [r["id"] for r in results]
+        assert new_doc in result_ids
+        assert old_doc not in result_ids
+
+    def test_search_excludes_superseded_documents_all_branch(self) -> None:
+        """Same as above but for the strict ALL-tags branch (prefix_match=False)."""
+        from emdx.database.documents import set_parent
+        from emdx.models.tags import add_tags_to_document, search_by_tags
+
+        old_doc = _create_document(title="Versioned Doc v1")
+        new_doc = _create_document(title="Versioned Doc v2")
+        add_tags_to_document(old_doc, ["versioned-repro", "shared"])
+        add_tags_to_document(new_doc, ["versioned-repro", "shared"])
+        set_parent(old_doc, new_doc, relationship="supersedes")
+
+        results = search_by_tags(["versioned-repro", "shared"], mode="all", prefix_match=False)
+        result_ids = [r["id"] for r in results]
+        assert new_doc in result_ids
+        assert old_doc not in result_ids
+
 
 # =========================================================================
 # rename_tag

--- a/tests/test_save_task_flags.py
+++ b/tests/test_save_task_flags.py
@@ -35,7 +35,7 @@ class TestSaveTaskFlag:
         mock_update_task: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """--task flag links saved document to task via source_doc_id."""
+        """--task flag links saved document to task via output_doc_id."""
         f = tmp_path / "doc.md"
         f.write_text("# Task output\nContent here")
 
@@ -50,8 +50,8 @@ class TestSaveTaskFlag:
         out = _out(result)
         assert "Task:" in out or "#10" in out
 
-        # Verify update_task was called with source_doc_id
-        mock_update_task.assert_called_once_with(10, source_doc_id=42)
+        # Verify update_task was called with output_doc_id
+        mock_update_task.assert_called_once_with(10, output_doc_id=42)
 
     @patch("emdx.models.tasks.update_task")
     @patch("emdx.models.tasks.get_task")
@@ -82,8 +82,8 @@ class TestSaveTaskFlag:
         )
         assert result.exit_code == 0
 
-        # Verify update_task was called with source_doc_id
-        mock_update_task.assert_called_once_with(5, source_doc_id=99)
+        # Verify update_task was called with output_doc_id
+        mock_update_task.assert_called_once_with(5, output_doc_id=99)
 
 
 class TestSaveDoneFlag:
@@ -124,8 +124,8 @@ class TestSaveDoneFlag:
         out = _out(result)
         assert "(done)" in out or "done" in out.lower()
 
-        # Verify update_task was called with both source_doc_id and status
-        mock_update_task.assert_called_once_with(15, source_doc_id=77, status="done")
+        # Verify update_task was called with both output_doc_id and status
+        mock_update_task.assert_called_once_with(15, output_doc_id=77, status="done")
 
     @patch("emdx.models.tasks.update_task")
     @patch("emdx.models.tasks.get_task")


### PR DESCRIPTION
## Summary

Two independent, small bug fixes bundled onto this branch (each addresses a separately filed issue with no code overlap):

### 1. `emdx save --task N` links via the wrong field (#1085)

`--task N` is documented (`--help`, `docs/cli-api.md`) as linking the saved
document to the task **as its output**, but Step 6.7 in
`emdx/commands/core.py` actually wrote `source_doc_id`:

```python
update_kwargs: dict[str, Any] = {"source_doc_id": doc_id}
```

The task model deliberately distinguishes the two fields:
- `source_doc_id` — the doc a task came **from** (`task add --from-doc`, gameplans)
- `output_doc_id` — the doc a task **produced** (`task done N --output-doc D`)

Consequences of the bug:
1. The `save-output.sh` SubagentStop hook uses `emdx save --task $EMDX_TASK_ID` to
   link agent findings — those landed in `source_doc_id`, so `emdx task brief`
   showed no output doc for tasks completed this way.
2. If a task already had a real source doc (e.g. the gameplan that spawned it),
   `save --task` silently overwrote it.
3. `emdx save --task N --done` marked the task done with an empty `output_doc_id`,
   defeating the documented completion flow (`task done N --output-doc D`).

**Fix:** Step 6.7 now sets `output_doc_id` instead of `source_doc_id`. Updated
`tests/test_save_task_flags.py` assertions to match (the tests were enforcing
the wrong-but-existing behavior).

### 2. `emdx find --tags` surfaces superseded documents (#1088)

`emdx save --supersede` correctly links the prior version (`parent_id` set on
the old doc) and `emdx find --all` correctly hides superseded docs by default
(`list_documents()` filters `parent_id IS NULL`). But `search_by_tags()`
(backing `emdx find --tags`) had no equivalent filter in either its ALL-tags
or ANY-tags query branch, so superseded docs came back indistinguishable from
genuine duplicates.

**Fix:** Added `AND d.parent_id IS NULL` to both `search_by_tags()` query
branches, matching `list_documents()`'s default. Superseded docs remain
reachable directly via `emdx view <id>` or `--similar`. Added regression
tests covering both branches (`prefix_match=True`/ANY and
`prefix_match=False`/ALL) to `tests/test_models_tags.py`.

## Test plan

- [x] `poetry run pytest tests/ -x -q` — full suite, 2122 passed, 8 skipped
- [x] `poetry run ruff check` / `ruff format --check` on all changed files — clean
- [x] `poetry run mypy` on changed files — no issues
- [x] New regression tests confirmed to fail without their respective fix (verified by
      temporarily reverting each fix and re-running)
- [x] Manual end-to-end verification against scratch DBs for both issues:
  - `save --task N --done` → `task brief N --json` now shows the doc under
    `related_documents` with `"relation": "output"` (was `"source"`, with the
    real output slot empty)
  - The exact repro from #1088 (`save --title "Versioned Doc" ... ` then
    `--supersede`, then `find --tags ... --json`) now returns only the
    current doc, not both versions
