### PR TITLE
ci: key venv cache on pyproject.toml instead of missing poetry.lock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: .venv
-        key: venv-${{ runner.os }}-3.13-noml-${{ hashFiles('**/poetry.lock') }}
+        key: venv-${{ runner.os }}-3.13-noml-${{ hashFiles('pyproject.toml') }}
 
     - name: Install dependencies
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
@@ -79,7 +79,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ matrix.python-version }}-noml-${{ hashFiles('**/poetry.lock') }}
+        key: venv-${{ runner.os }}-${{ matrix.python-version }}-noml-${{ hashFiles('pyproject.toml') }}
 
     - name: Install dependencies
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

No `poetry.lock` is committed to this repo, so the CI venv cache key `venv-${{ runner.os }}-<py>-noml-${{ hashFiles('**/poetry.lock') }}` always ended in an **empty hash** — every branch shared a single cache entry regardless of its dependency state.

This is what broke the dependabot PRs: their runs restored a venv cached by an unrelated branch, then failed with infra errors unrelated to the bumps themselves — `pytest: error: unrecognized arguments: --cov` (pytest-cov missing) on #1031/#1030 and `Command not found: mypy` on #1037. It also meant "green" runs on cache hits logged "No dependencies to install or update", so bumped versions were never actually exercised.

## Fix

Key the cache on `hashFiles('pyproject.toml')` in both the `type-check` and `test` jobs. Any dependency change now gets a fresh venv; unchanged branches keep the cache speedup. No `restore-keys` fallback on purpose — a partial-match restore would reintroduce the stale-venv poisoning this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtjYpEXbTgvSVZPCNJvwhu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtjYpEXbTgvSVZPCNJvwhu)_