### PR TITLE
chore(deps): update sentence-transformers requirement from ^5.2.2 to ^5.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ google-auth-oauthlib = "^1.2.0"
 scikit-learn = "^1.6.0"
 datasketch = "^1.6.0"
 fastembed = "^0.8.0"
-sentence-transformers = "^5.2.2"
+sentence-transformers = "^5.4.0"
 numpy = "^2.4.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary

Same one-line bump as dependabot's #1026 (`sentence-transformers ^5.2.2` → `^5.4.0`), recreated on top of current main.

#1026 has a merge conflict with the `fastembed = "^0.8.0"` line added directly above it by #1045, GitHub's update-branch API rejects it (422), and dependabot isn't responding to rebase commands — so this PR supersedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtjYpEXbTgvSVZPCNJvwhu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtjYpEXbTgvSVZPCNJvwhu)_