### PR TITLE
chore(deps): update typer, rich, and google-api-python-client requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,13 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.11"
-typer = {extras = ["all"], version = "^0.24.1"}
+typer = {extras = ["all"], version = ">=0.24.1,<0.26.0"}
 click = ">=8.3.2"  # Typer 0.15+ requires click 8.1+
-rich = "^14.3.0"
+rich = ">=14.3,<16.0"
 textual = "^8.2.3"
 psutil = "^7.0.0"
 pyyaml = ">=6.0.3"
-google-api-python-client = "^2.100.0"
+google-api-python-client = "^2.194.0"
 google-auth-httplib2 = "^0.3.0"
 google-auth-oauthlib = "^1.3.1"
 


### PR DESCRIPTION
## Summary

Combines the three remaining dependabot bumps into one commit on current main:

- `typer` `^0.24.1` → `>=0.24.1,<0.26.0` (#1031)
- `rich` `^14.3.0` → `>=14.3,<16.0` (#1030)
- `google-api-python-client` `^2.100.0` → `^2.194.0` (#1024)

Each of these passed full CI individually against current main earlier today (after the venv-cache fix in #1091). Their branches became unmergeable as the other pyproject bumps landed on adjacent lines — GitHub's update-branch API now 422s on all three — so this PR supersedes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtjYpEXbTgvSVZPCNJvwhu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtjYpEXbTgvSVZPCNJvwhu)_