### PR TITLE
fix: dev-database misdetection under editable installs

### DIFF
--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -39,7 +39,7 @@ from emdx.models.tags import (
 )
 from emdx.services.auto_tagger import AutoTagger
 from emdx.ui.formatting import format_tags
-from emdx.utils.output import console, is_non_interactive
+from emdx.utils.output import console, is_non_interactive, print_json
 from emdx.utils.text_formatting import truncate_title
 
 app = typer.Typer(help="Core CRUD operations for documents")
@@ -273,6 +273,7 @@ def save(
     mark_done: bool = typer.Option(
         False, "--done", help="Also mark the linked task as done (requires --task)"
     ),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
     """Save content to the knowledge base.
 
@@ -280,7 +281,11 @@ def save(
     """
     # Validate --done requires --task
     if mark_done and task is None:
-        console.print("[red]Error: --done requires --task[/red]")
+        msg = "--done requires --task"
+        if json_output:
+            print_json({"error": msg})
+        else:
+            console.print(f"[red]Error: {msg}[/red]")
         raise typer.Exit(1)
 
     # Validate task exists before doing any work
@@ -289,7 +294,11 @@ def save(
 
         linked_task = get_task(task)
         if not linked_task:
-            console.print(f"[red]Error: Task #{task} not found[/red]")
+            msg = f"Task #{task} not found"
+            if json_output:
+                print_json({"error": msg})
+            else:
+                console.print(f"[red]Error: {msg}[/red]")
             raise typer.Exit(1)
 
     # Step 1: Get input content
@@ -328,25 +337,27 @@ def save(
         from emdx.services.wikify_service import title_match_wikify
 
         wikify_result = title_match_wikify(doc_id)
-        if wikify_result.links_created > 0:
+        if wikify_result.links_created > 0 and not json_output:
             console.print(
                 f"   [dim]Wiki-linked to {wikify_result.links_created} doc(s) by title match[/dim]"
             )
     except Exception as e:
-        console.print(f"   [yellow]Wikify skipped: {e}[/yellow]")
+        if not json_output:
+            console.print(f"   [yellow]Wikify skipped: {e}[/yellow]")
 
     # Step 6.55: Entity extraction + entity-match wikification (zero cost)
     try:
         from emdx.services.entity_service import entity_match_wikify
 
         entity_result = entity_match_wikify(doc_id)
-        if entity_result.links_created > 0:
+        if entity_result.links_created > 0 and not json_output:
             console.print(
                 f"   [dim]Entity-linked to {entity_result.links_created}"
                 " doc(s) by shared concepts[/dim]"
             )
     except Exception as e:
-        console.print(f"   [yellow]Entity wikify skipped: {e}[/yellow]")
+        if not json_output:
+            console.print(f"   [yellow]Entity wikify skipped: {e}[/yellow]")
     # Step 6.6: Auto-link to similar documents (default on, use --no-auto-link to skip)
     if auto_link:
         try:
@@ -355,12 +366,13 @@ def save(
             # Scope to same project unless --cross-project is set
             scope_project = None if cross_project else final_project
             link_result = auto_link_document(doc_id, project=scope_project)
-            if link_result.links_created > 0:
+            if link_result.links_created > 0 and not json_output:
                 console.print(f"   [dim]Linked to {link_result.links_created} similar doc(s)[/dim]")
         except ImportError:
             pass  # AI extras not installed — silently skip
         except Exception as e:
-            console.print(f"   [yellow]Auto-link skipped: {e}[/yellow]")
+            if not json_output:
+                console.print(f"   [yellow]Auto-link skipped: {e}[/yellow]")
 
     # Step 6.7: Link to task if specified
     if task is not None:
@@ -377,9 +389,24 @@ def save(
         auto_applied = tagger.auto_tag_document(doc_id, confidence_threshold=0.7)
         if auto_applied:
             applied_tags.extend(auto_applied)
-            console.print(f"   [dim]Auto-tagged:[/dim] {format_tags(auto_applied)}")
+            if not json_output:
+                console.print(f"   [dim]Auto-tagged:[/dim] {format_tags(auto_applied)}")
 
     # Step 8: Display result
+    if json_output:
+        result: dict[str, Any] = {
+            "id": doc_id,
+            "title": metadata.title,
+            "project": metadata.project,
+            "tags": applied_tags,
+        }
+        if task is not None:
+            result["task_id"] = task
+        if supersede_target:
+            result["superseded_id"] = supersede_target.id
+        print_json(result)
+        return
+
     display_save_result(doc_id, metadata, applied_tags, supersede_target)
 
     # Step 8.5: Display task link

--- a/emdx/config/settings.py
+++ b/emdx/config/settings.py
@@ -19,13 +19,25 @@ def _project_root() -> Path:
 
 
 def _is_dev_checkout() -> bool:
-    """Detect if running from an editable install (dev checkout).
+    """Detect if actually working inside the emdx dev checkout.
 
-    Checks if the emdx package source lives inside a directory with
-    pyproject.toml — i.e., running via `poetry run emdx` from the repo.
+    Requires BOTH: the package source lives under a directory with
+    pyproject.toml, AND the current working directory is inside that
+    same checkout — i.e., running `poetry run emdx` (or an editable
+    `uv tool install`) from within the repo. The pyproject.toml check
+    alone is not enough: `uv tool install --editable <checkout>` makes
+    every invocation of the globally-installed binary resolve its
+    package source to the checkout, regardless of the caller's actual
+    cwd, which silently redirected writes from unrelated projects into
+    the checkout's throwaway .emdx/dev.db instead of the shared
+    production database.
     """
     try:
-        return (_project_root() / "pyproject.toml").is_file()
+        project_root = _project_root()
+        if not (project_root / "pyproject.toml").is_file():
+            return False
+        cwd = Path.cwd().resolve()
+        return cwd == project_root or project_root in cwd.parents
     except Exception:
         return False
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
     ],
     "SubagentStop": [
       {
-        "matcher": "Explore|general-purpose|Plan",
+        "matcher": "Explore|general-purpose|Plan|worker|auditor|reviewer|scout|verifier|epic-runner|recorder|pr-reviewer|sentry-issue-investigator",
         "hooks": [
           {
             "type": "command",

--- a/hooks/save-subagent-output.sh
+++ b/hooks/save-subagent-output.sh
@@ -44,9 +44,26 @@ msg = data.get("last_assistant_message", "")
 if not msg or len(msg) < 200:
     sys.exit(0)
 
-# Only save output from substantive agent types
-allowed_types = {"explore", "plan", "general-purpose"}
+# Agent types whose final output is worth a knowledge-base record.
+# DRIFT CONTRACT: this set must match the SubagentStop matcher in
+# hooks.json — update both together (the /new-agent skill's checklist).
+#   - built-ins:  explore, plan, general-purpose
+#   - role fleet: worker, auditor, reviewer, scout, verifier,
+#                 epic-runner, recorder, pr-reviewer,
+#                 sentry-issue-investigator
+#   - monitor is excluded on purpose: watch/poll output is transient
+allowed_types = {
+    "explore", "plan", "general-purpose",
+    "worker", "auditor", "reviewer", "scout", "verifier",
+    "epic-runner", "recorder", "pr-reviewer", "sentry-issue-investigator",
+}
 if agent_type.lower() not in allowed_types:
+    sys.exit(0)
+
+# Backstop, not duplicator: role-fleet agents are instructed to save
+# their own findings and cite the doc id in their final report. A message
+# that already cites a doc id has its content in emdx — skip.
+if re.search(r"(?:emdx|doc)\s*#\d{3,}", msg):
     sys.exit(0)
 
 # Check emdx is available

--- a/hooks/save-subagent-output.sh
+++ b/hooks/save-subagent-output.sh
@@ -74,6 +74,50 @@ tags = ["subagent", f"agent:{agent_type.lower()}"]
 if re.search(r"https://github\.com/[^/]+/[^/]+/pull/\d+", msg):
     tags.append("has-pr")
 
+# --- Extract ticket IDs from title + first 2000 chars of body ---
+TICKET_RE = re.compile(r"\b(KEEP|COL|HDC|DASH|DEVOPS|PZR|COLO)-(\d+)\b", re.IGNORECASE)
+search_text = title + " " + msg[:2000]
+ticket_matches = set()
+for prefix, num in TICKET_RE.findall(search_text):
+    ticket_matches.add(f"{prefix.lower()}-{num}")
+for ticket in sorted(ticket_matches):
+    tags.append(ticket)
+
+# --- Extract ticket from git branch if nothing found in text ---
+if not ticket_matches:
+    try:
+        branch = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+        ).stdout.strip()
+        branch_match = TICKET_RE.search(branch)
+        if branch_match:
+            tags.append(f"{branch_match.group(1).lower()}-{branch_match.group(2)}")
+    except Exception:
+        pass
+
+# --- Extract PR numbers from text ---
+pr_nums = set(re.findall(r"(?:PR\s*#?|pull/)(\d{3,})", msg[:2000], re.IGNORECASE))
+for pr in sorted(pr_nums):
+    tags.append(f"pr-{pr}")
+
+# --- Infer content type from title keywords ---
+title_lower = title.lower()
+CONTENT_TYPE_MAP = [
+    (r"\b(?:investigat|root.cause|deep.dive)\b", "investigation"),
+    (r"\b(?:gameplan|implementation.plan|plan)\b", "gameplan"),
+    (r"\b(?:saga|narrative|write.?up)\b", "saga"),
+    (r"\b(?:review|code.review|pr.review)\b", "pr-review"),
+    (r"\b(?:decision|chose|decided|going.with)\b", "decision"),
+    (r"\b(?:lit(?:erate)?.review|walkthrough)\b", "literate-review"),
+    (r"\b(?:exploration|research|summary.of.findings)\b", "analysis"),
+    (r"\b(?:coding.standard|convention|pattern)\b", "coding-standards"),
+]
+for pattern, content_tag in CONTENT_TYPE_MAP:
+    if re.search(pattern, title_lower):
+        tags.append(content_tag)
+        break
+
 tag_str = ",".join(tags)
 
 # --- Save to KB ---

--- a/scripts/ensure-emdx.sh
+++ b/scripts/ensure-emdx.sh
@@ -10,8 +10,6 @@ cat > /dev/null
 if command -v emdx &> /dev/null; then
     version=$(emdx --version 2>/dev/null || echo "unknown")
     echo "● emdx ${version} — knowledge base ready"
-    echo ""
-    emdx prime 2>/dev/null || true
 else
     echo "⚠ emdx CLI not found."
     echo ""

--- a/tests/test_commands_core.py
+++ b/tests/test_commands_core.py
@@ -216,6 +216,125 @@ class TestSaveCommand:
         result = runner.invoke(app, ["save"])
         assert result.exit_code != 0
 
+    @patch("emdx.commands.core.apply_tags")
+    @patch("emdx.commands.core.create_document")
+    @patch("emdx.commands.core.detect_project")
+    def test_save_json_output_file(self, mock_detect, mock_create, mock_tags, tmp_path):
+        """--json with --file emits a single JSON object on stdout."""
+        f = tmp_path / "doc.md"
+        f.write_text("# Hello\nWorld")
+
+        mock_detect.return_value = "test-proj"
+        mock_create.return_value = 42
+        mock_tags.return_value = ["python"]
+
+        result = runner.invoke(app, ["save", "--file", str(f), "--json", "--tags", "python"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data == {
+            "id": 42,
+            "title": "doc",
+            "project": "test-proj",
+            "tags": ["python"],
+        }
+
+    @patch("emdx.commands.core.apply_tags")
+    @patch("emdx.commands.core.create_document")
+    @patch("emdx.commands.core.detect_project")
+    def test_save_json_output_stdin(self, mock_detect, mock_create, mock_tags):
+        """--json with stdin input emits a single JSON object on stdout."""
+        mock_detect.return_value = None
+        mock_create.return_value = 7
+        mock_tags.return_value = []
+
+        result = runner.invoke(
+            app,
+            ["save", "--json", "--title", "Piped Doc"],
+            input="Analysis results here\n",
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data == {"id": 7, "title": "Piped Doc", "project": None, "tags": []}
+
+    @patch("emdx.models.tasks.update_task")
+    @patch("emdx.models.tasks.get_task")
+    @patch("emdx.commands.core.apply_tags")
+    @patch("emdx.commands.core.create_document")
+    @patch("emdx.commands.core.detect_project")
+    def test_save_json_output_with_task(
+        self, mock_detect, mock_create, mock_tags, mock_get_task, mock_update_task, tmp_path
+    ):
+        """--json with --task still links the doc to the task and reports task_id."""
+        f = tmp_path / "doc.md"
+        f.write_text("content")
+
+        mock_detect.return_value = None
+        mock_create.return_value = 99
+        mock_tags.return_value = []
+        mock_get_task.return_value = {"id": 5, "title": "Research task", "status": "open"}
+        mock_update_task.return_value = True
+
+        result = runner.invoke(
+            app, ["save", "--file", str(f), "--task", "5", "--done", "--json"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["id"] == 99
+        assert data["task_id"] == 5
+        mock_update_task.assert_called_once_with(5, source_doc_id=99, status="done")
+
+    @patch("emdx.services.link_service.auto_link_document")
+    @patch("emdx.services.entity_service.entity_match_wikify")
+    @patch("emdx.services.wikify_service.title_match_wikify")
+    @patch("emdx.commands.core.apply_tags")
+    @patch("emdx.commands.core.create_document")
+    @patch("emdx.commands.core.detect_project")
+    def test_save_json_suppresses_decorative_output(
+        self,
+        mock_detect,
+        mock_create,
+        mock_tags,
+        mock_wikify,
+        mock_entity,
+        mock_autolink,
+        tmp_path,
+    ):
+        """--json suppresses wiki-link/entity-link/auto-link notices.
+
+        Forces all three auto-linking side effects to report created links;
+        json.loads succeeding on the full stdout proves nothing else leaked
+        onto it.
+        """
+        from emdx.services.entity_service import EntityWikifyResult
+        from emdx.services.link_service import AutoLinkResult
+        from emdx.services.wikify_service import WikifyResult
+
+        f = tmp_path / "doc.md"
+        f.write_text("content")
+
+        mock_detect.return_value = "proj"
+        mock_create.return_value = 55
+        mock_tags.return_value = []
+        mock_wikify.return_value = WikifyResult(doc_id=55, links_created=2)
+        mock_entity.return_value = EntityWikifyResult(
+            doc_id=55, entities_extracted=1, links_created=1
+        )
+        mock_autolink.return_value = AutoLinkResult(
+            doc_id=55, links_created=1, linked_doc_ids=[1], scores=[0.9]
+        )
+
+        result = runner.invoke(app, ["save", "--file", str(f), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["id"] == 55
+
+    def test_save_json_done_without_task_errors_as_json(self):
+        """--json --done without --task reports the error as JSON, not rich text."""
+        result = runner.invoke(app, ["save", "x", "--done", "--json"])
+        assert result.exit_code != 0
+        data = json.loads(result.stdout)
+        assert data["error"] == "--done requires --task"
+
 
 # ---------------------------------------------------------------------------
 # find command

--- a/tests/test_commands_core.py
+++ b/tests/test_commands_core.py
@@ -281,7 +281,7 @@ class TestSaveCommand:
         data = json.loads(result.stdout)
         assert data["id"] == 99
         assert data["task_id"] == 5
-        mock_update_task.assert_called_once_with(5, source_doc_id=99, status="done")
+        mock_update_task.assert_called_once_with(5, output_doc_id=99, status="done")
 
     @patch("emdx.services.link_service.auto_link_document")
     @patch("emdx.services.entity_service.entity_match_wikify")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -134,7 +134,25 @@ def test_is_dev_checkout_true_when_pyproject_at_root(
 ) -> None:
     fake_settings = _fake_checkout(tmp_path, with_pyproject=True)
     monkeypatch.setattr(settings, "__file__", str(fake_settings))
+    monkeypatch.chdir(fake_settings.parent.parent.parent)
     assert _is_dev_checkout() is True
+
+
+def test_is_dev_checkout_false_when_cwd_outside_checkout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression guard for the uv-tool-install bug: an editable install's
+    package source always lives inside the checkout (pyproject.toml
+    present), but if the caller's cwd is some unrelated project, this
+    must NOT be treated as a dev checkout — it would otherwise silently
+    redirect that unrelated project's emdx writes into the checkout's
+    throwaway dev.db."""
+    fake_settings = _fake_checkout(tmp_path, with_pyproject=True)
+    monkeypatch.setattr(settings, "__file__", str(fake_settings))
+    unrelated = tmp_path / "some-other-project"
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+    assert _is_dev_checkout() is False
 
 
 def test_is_dev_checkout_false_without_pyproject(
@@ -169,10 +187,11 @@ def test_dev_checkout_returns_local_dev_db(
 ) -> None:
     fake_settings = _fake_checkout(tmp_path, with_pyproject=True)
     monkeypatch.setattr(settings, "__file__", str(fake_settings))
+    root = fake_settings.parent.parent.parent
+    monkeypatch.chdir(root)
 
     db_path = get_db_path()
 
-    root = fake_settings.parent.parent.parent
     assert db_path == root / ".emdx" / "dev.db"
     assert db_path.parent.is_dir()
     # First run announces the dev DB on stderr.
@@ -188,6 +207,7 @@ def test_dev_checkout_existing_dev_db_is_quiet(
     fake_settings = _fake_checkout(tmp_path, with_pyproject=True)
     monkeypatch.setattr(settings, "__file__", str(fake_settings))
     root = fake_settings.parent.parent.parent
+    monkeypatch.chdir(root)
     dev_db = root / ".emdx" / "dev.db"
     dev_db.parent.mkdir(parents=True)
     dev_db.touch()
@@ -244,6 +264,7 @@ def test_dev_checkout_beats_production_default(
 ) -> None:
     fake_settings = _fake_checkout(tmp_path, with_pyproject=True)
     monkeypatch.setattr(settings, "__file__", str(fake_settings))
+    monkeypatch.chdir(fake_settings.parent.parent.parent)
     db_path = get_db_path()
     assert db_path.name == "dev.db"
     assert db_path != clean_env / "knowledge.db"
@@ -258,6 +279,7 @@ def test_full_priority_chain_order(
     fake_settings = _fake_checkout(tmp_path, with_pyproject=True)
     monkeypatch.setattr(settings, "__file__", str(fake_settings))
     root = fake_settings.parent.parent.parent
+    monkeypatch.chdir(root)
 
     monkeypatch.setenv("EMDX_TEST_DB", str(test_db))
     monkeypatch.setenv("EMDX_DB", str(explicit_db))


### PR DESCRIPTION
## Summary
- \`_is_dev_checkout()\` only checked whether the package source lived under a directory with \`pyproject.toml\`. For an editable \`uv tool install\`, that's always true regardless of the caller's actual working directory, since the installed binary's package source always resolves to the checkout — so every invocation of the globally installed \`emdx\` binary silently redirected writes into the checkout's throwaway \`.emdx/dev.db\` instead of the shared production database, no matter what project the caller was actually working in.
- Fix requires the current working directory to also be inside the checkout itself before treating it as a dev checkout.
- Includes a regression test for the editable-install case and updates 5 existing tests to \`chdir\` into the fake checkout so they still exercise a true dev-checkout scenario under the new cwd-aware logic.
- Also carries 4 already-committed, previously-unpushed commits (hook hot-patch port, SubagentStop role-fleet fix, \`emdx save --json\`, retiring a redundant SessionStart dump) that were sitting ahead of \`origin/main\`.

## Test plan
- [x] \`pytest tests/test_config.py -v\` — 19/19 passing