### PR TITLE
Add flag/command aliases for common near-misses

### DIFF
--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -436,7 +436,14 @@ def find(
     limit: int = typer.Option(10, "--limit", "-n", help="Maximum results to return"),
     snippets: bool = typer.Option(False, "--snippets", "-s", help="Show content snippets"),
     fuzzy: bool = typer.Option(False, "--fuzzy", "-f", help="Use fuzzy search"),
-    tags: str | None = typer.Option(None, "--tags", "-t", help="Filter by tags (comma-separated)"),
+    tags: str | None = typer.Option(
+        None,
+        "--tags",
+        "--tag",
+        "--tag-search",
+        "-t",
+        help="Filter by tags (comma-separated)",
+    ),
     any_tags: bool = typer.Option(False, "--any-tags", help="Match ANY tag instead of ALL tags"),
     no_tags: str | None = typer.Option(None, "--no-tags", help="Exclude documents with these tags"),
     ids_only: bool = typer.Option(

--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -18,7 +18,7 @@ from emdx.models.types import TaskRef
 from emdx.utils.lazy_group import make_alias_group
 from emdx.utils.output import console, is_non_interactive, print_json
 
-app = typer.Typer(help="Agent work queue", cls=make_alias_group({"create": "add"}))
+app = typer.Typer(help="Agent work queue", cls=make_alias_group({"create": "add", "show": "view"}))
 app.add_typer(epics_app, name="epic", help="Manage task epics")
 app.add_typer(categories_app, name="cat", help="Manage task categories")
 
@@ -848,6 +848,9 @@ def list_cmd(
     ),
     today: bool = typer.Option(False, "--today", help="Show tasks completed today"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+    search: str | None = typer.Option(None, "--search", hidden=True),
+    tag: str | None = typer.Option(None, "--tag", hidden=True),
+    project: str | None = typer.Option(None, "--project", hidden=True),
 ) -> None:
     """List tasks.
 
@@ -864,6 +867,23 @@ def list_cmd(
         emdx task list --epic 510
         emdx task list --epic SEC-1
     """
+    if search is not None:
+        console.print(
+            f"[red]task list has no --search filter.[/red] Try [cyan]emdx find {search!r}[/cyan]."
+        )
+        raise typer.Exit(1)
+    if tag is not None:
+        console.print(
+            f"[red]task list has no --tag filter.[/red] Try [cyan]emdx find --tags {tag!r}[/cyan]."
+        )
+        raise typer.Exit(1)
+    if project is not None:
+        console.print(
+            "[red]task list has no --project filter.[/red] "
+            f"Try [cyan]emdx find --project {project!r}[/cyan]."
+        )
+        raise typer.Exit(1)
+
     since_date: str | None = None
     if today:
         since_date = date.today().isoformat()

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -28,6 +28,7 @@ LAZY_SUBCOMMANDS = {
     "task": "emdx.commands.tasks:app",
     "tag": "emdx.commands.tags:app",
     "trash": "emdx.commands.trash:app",
+    "epic": "emdx.commands.epics:app",
 }
 
 # Pre-computed help strings so --help doesn't trigger imports
@@ -41,6 +42,7 @@ LAZY_HELP = {
     "task": "Agent work queue",
     "tag": "Manage document tags",
     "trash": "Manage deleted documents",
+    "epic": "Manage task epics",
 }
 
 
@@ -49,7 +51,7 @@ LAZY_HELP = {
 register_lazy_commands(LAZY_SUBCOMMANDS, LAZY_HELP)
 
 # Register top-level command aliases (alias -> canonical name)
-register_aliases({"show": "view"})
+register_aliases({"show": "view", "list": "find", "recent": "find"})
 
 # =============================================================================
 # EAGER IMPORTS - Core KB commands (fast, always needed)

--- a/tests/test_commands_core.py
+++ b/tests/test_commands_core.py
@@ -274,9 +274,7 @@ class TestSaveCommand:
         mock_get_task.return_value = {"id": 5, "title": "Research task", "status": "open"}
         mock_update_task.return_value = True
 
-        result = runner.invoke(
-            app, ["save", "--file", str(f), "--task", "5", "--done", "--json"]
-        )
+        result = runner.invoke(app, ["save", "--file", str(f), "--task", "5", "--done", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert data["id"] == 99
@@ -443,6 +441,36 @@ class TestFindCommand:
         result = runner.invoke(app, ["find", "--tags", "python"])
         assert result.exit_code == 0
         assert "Tagged" in _out(result)
+
+    @patch("emdx.commands.core.get_tags_for_documents")
+    @patch("emdx.commands.core.search_by_tags")
+    def test_find_by_tag_singular_alias(self, mock_search_tags, mock_get_tags):
+        """GH #1105: --tag is an alias for --tags."""
+        mock_search_tags.return_value = [
+            {
+                "id": 5,
+                "title": "Tagged",
+                "project": None,
+                "created_at": datetime(2024, 6, 1),
+                "access_count": 1,
+            }
+        ]
+        mock_get_tags.return_value = {5: ["python"]}
+
+        result = runner.invoke(app, ["find", "--tag", "python"])
+        assert result.exit_code == 0
+        mock_search_tags.assert_called_once_with(["python"], mode="all", project=None, limit=10)
+
+    @patch("emdx.commands.core.get_tags_for_documents")
+    @patch("emdx.commands.core.search_by_tags")
+    def test_find_by_tag_search_alias(self, mock_search_tags, mock_get_tags):
+        """GH #1105: --tag-search is an alias for --tags."""
+        mock_search_tags.return_value = []
+        mock_get_tags.return_value = {}
+
+        result = runner.invoke(app, ["find", "--tag-search", "python"])
+        assert result.exit_code == 0
+        mock_search_tags.assert_called_once_with(["python"], mode="all", project=None, limit=10)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -287,6 +287,46 @@ class TestCLIIntegration:
         assert result.exit_code == 0
         assert "Search" in result.output or "find" in result.output.lower()
 
+    def test_list_is_an_alias_for_find(self) -> None:
+        """GH #1104: `emdx list` should resolve to `emdx find`."""
+        from emdx.main import app
+
+        result = runner.invoke(app, ["list", "--help"])
+        find_result = runner.invoke(app, ["find", "--help"])
+
+        assert result.exit_code == 0
+        # Usage line echoes the invoked name ("list" vs "find"); everything
+        # else (options, help text) comes from the same underlying command.
+        result_lines = [line for line in result.output.splitlines() if "Usage:" not in line]
+        find_lines = [line for line in find_result.output.splitlines() if "Usage:" not in line]
+        assert result_lines == find_lines
+
+    def test_recent_is_an_alias_for_find(self) -> None:
+        """GH #1104: `emdx recent` should resolve to `emdx find`."""
+        from emdx.main import app
+
+        result = runner.invoke(app, ["recent", "--help"])
+        find_result = runner.invoke(app, ["find", "--help"])
+
+        assert result.exit_code == 0
+        result_lines = [line for line in result.output.splitlines() if "Usage:" not in line]
+        find_lines = [line for line in find_result.output.splitlines() if "Usage:" not in line]
+        assert result_lines == find_lines
+
+    def test_epic_is_a_top_level_command(self) -> None:
+        """GH #1104: `emdx epic` should forward into `emdx task epic`."""
+        import importlib
+
+        import emdx.main
+
+        importlib.reload(emdx.main)
+        from emdx.main import app
+
+        result = runner.invoke(app, ["epic", "--help"])
+
+        assert result.exit_code == 0
+        assert "epic" in result.output.lower()
+
 
 class TestLazyRegistry:
     """Test the lazy command registry."""

--- a/tests/test_task_commands.py
+++ b/tests/test_task_commands.py
@@ -580,6 +580,37 @@ class TestTaskList:
         assert "quite a bit" in out
 
 
+class TestTaskListUnsupportedFilters:
+    """GH #1105: --search/--tag/--project don't exist on task list; point at emdx find."""
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_search_flag_errors_with_find_suggestion(self, mock_tasks):
+        result = runner.invoke(app, ["list", "--search", "foo"])
+        assert result.exit_code == 1
+        out = _out(result)
+        assert "--search" in out
+        assert "emdx find" in out
+        mock_tasks.list_tasks.assert_not_called()
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_tag_flag_errors_with_find_tags_suggestion(self, mock_tasks):
+        result = runner.invoke(app, ["list", "--tag", "urgent"])
+        assert result.exit_code == 1
+        out = _out(result)
+        assert "--tag" in out
+        assert "emdx find --tags" in out
+        mock_tasks.list_tasks.assert_not_called()
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_project_flag_errors_with_find_project_suggestion(self, mock_tasks):
+        result = runner.invoke(app, ["list", "--project", "emdx"])
+        assert result.exit_code == 1
+        out = _out(result)
+        assert "--project" in out
+        assert "emdx find --project" in out
+        mock_tasks.list_tasks.assert_not_called()
+
+
 class TestTaskListDateFilters:
     """Tests for task list --since and --today date filters."""
 
@@ -760,6 +791,34 @@ class TestTaskView:
         assert "Fix auth bug" in out
         assert "open" in out
         assert "race condition" in out
+
+    @patch("emdx.commands.tasks.tasks")
+    def test_show_is_an_alias_for_view(self, mock_tasks):
+        """GH #1104: `task show` should resolve to `task view`."""
+        mock_tasks.resolve_task_id.return_value = 42
+        mock_tasks.get_task.return_value = Task.from_row(
+            {
+                "id": 42,
+                "title": "Fix auth bug",
+                "status": "open",
+                "description": "The auth middleware has a race condition",
+                "epic_key": None,
+                "epic_seq": None,
+                "parent_task_id": None,
+                "source_doc_id": None,
+                "priority": 3,
+                "created_at": "2026-01-15",
+            }
+        )
+        mock_tasks.get_dependencies.return_value = []
+        mock_tasks.get_dependents.return_value = []
+        mock_tasks.get_task_log.return_value = []
+
+        result = runner.invoke(app, ["show", "42"])
+        assert result.exit_code == 0
+        out = _out(result)
+        assert "#42" in out
+        assert "Fix auth bug" in out
 
     @patch("emdx.models.documents.get_document")
     @patch("emdx.commands.tasks.tasks")


### PR DESCRIPTION
## Summary

Closes #1104 and #1105. Both issues are about the same root problem: guessable-but-wrong CLI invocations that fail with an unhelpful error instead of doing the right thing.

**#1105 — near-miss flag names**
- `emdx find --tag` / `--tag-search` now alias `--tags` (`emdx/commands/core.py`) — closes the singular/plural typo case.
- `emdx task list --search/--tag/--project` don't exist as filters on `task list`. Instead of Click's bare `No such option`, these now print a clear message pointing at the equivalent `emdx find` invocation and exit 1 (`emdx/commands/tasks.py`).

**#1104 — commonly-guessed verbs**
- `task show` → `task view` (extends the task subgroup's existing `make_alias_group({"create": "add"})` table, mirroring the top-level `show -> view` alias).
- Top-level `list` and `recent` now alias `find`.
- Added a thin top-level `epic` command that forwards into the existing `task epic` sub-app (registered via the same lazy-loading mechanism as `task`/`tag`/`trash`), since `epic` previously only existed nested under `task`.

## How I verified this

- `poetry run ruff check .` — zero errors on touched files (some pre-existing formatting drift in unrelated files, left untouched)
- `poetry run mypy` on all changed files — no issues
- Added tests covering each change:
  - `tests/test_commands_core.py`: `find --tag` / `--tag-search` resolve to the same tag search as `--tags`
  - `tests/test_task_commands.py`: `task list --search/--tag/--project` each exit 1 with a message referencing `emdx find`; `task show` renders the same as `task view`
  - `tests/test_lazy_loading.py`: top-level `list`/`recent` produce the same help output as `find` (module-driven Usage line aside); top-level `epic --help` works
- Full test suite: `poetry run pytest tests/ -q` → **2206 passed, 8 skipped**, no failures/regressions

## Test plan
- [x] `poetry run ruff check .`
- [x] `poetry run mypy` on changed files
- [x] `poetry run pytest tests/` (full suite, all green)
- [x] Manually exercised `emdx find --tag`, `emdx task list --search foo`, `emdx task show <id>`, `emdx list --help`, `emdx epic --help`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01TJyrh4gBaGQJjS6v1GMtcy

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJyrh4gBaGQJjS6v1GMtcy)_