### PR TITLE
fix: alias commonly-guessed CLI verbs, clearer errors for near-miss task-list flags

### DIFF
--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -1554,7 +1554,8 @@ emdx task epic delete 510 --force
 
 ## 🏔️ Epic Management (`emdx task epic`)
 
-Organize tasks into epics for larger initiatives.
+Organize tasks into epics for larger initiatives. Also available as the top-level
+shortcut `emdx epic` (e.g. `emdx epic list` is the same as `emdx task epic list`).
 
 ```bash
 # Create an epic

--- a/emdx/commands/core.py
+++ b/emdx/commands/core.py
@@ -436,7 +436,9 @@ def find(
     limit: int = typer.Option(10, "--limit", "-n", help="Maximum results to return"),
     snippets: bool = typer.Option(False, "--snippets", "-s", help="Show content snippets"),
     fuzzy: bool = typer.Option(False, "--fuzzy", "-f", help="Use fuzzy search"),
-    tags: str | None = typer.Option(None, "--tags", "-t", help="Filter by tags (comma-separated)"),
+    tags: str | None = typer.Option(
+        None, "--tags", "-t", "--tag", "--tag-search", help="Filter by tags (comma-separated)"
+    ),
     any_tags: bool = typer.Option(False, "--any-tags", help="Match ANY tag instead of ALL tags"),
     no_tags: str | None = typer.Option(None, "--no-tags", help="Exclude documents with these tags"),
     ids_only: bool = typer.Option(

--- a/emdx/commands/tasks.py
+++ b/emdx/commands/tasks.py
@@ -18,7 +18,9 @@ from emdx.models.types import TaskRef
 from emdx.utils.lazy_group import make_alias_group
 from emdx.utils.output import console, is_non_interactive, print_json
 
-app = typer.Typer(help="Agent work queue", cls=make_alias_group({"create": "add"}))
+app = typer.Typer(
+    help="Agent work queue", cls=make_alias_group({"create": "add", "show": "view"})
+)
 app.add_typer(epics_app, name="epic", help="Manage task epics")
 app.add_typer(categories_app, name="cat", help="Manage task categories")
 
@@ -848,6 +850,9 @@ def list_cmd(
     ),
     today: bool = typer.Option(False, "--today", help="Show tasks completed today"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+    search: str | None = typer.Option(None, "--search", hidden=True),
+    tag: str | None = typer.Option(None, "--tag", hidden=True),
+    project: str | None = typer.Option(None, "--project", hidden=True),
 ) -> None:
     """List tasks.
 
@@ -864,6 +869,26 @@ def list_cmd(
         emdx task list --epic 510
         emdx task list --epic SEC-1
     """
+    if search is not None:
+        console.print(
+            "[red]task list has no --search filter.[/red] "
+            "Use [cyan]emdx find[/cyan] to search document content instead."
+        )
+        raise typer.Exit(code=1)
+    if tag is not None:
+        console.print(
+            "[red]task list has no --tag filter.[/red] "
+            "Tasks aren't tagged — use [cyan]emdx find --tags ...[/cyan] for documents, "
+            "or [cyan]--cat[/cyan]/[cyan]--epic[/cyan] to filter tasks."
+        )
+        raise typer.Exit(code=1)
+    if project is not None:
+        console.print(
+            "[red]task list has no --project filter.[/red] "
+            "Use [cyan]emdx find --project ...[/cyan] for documents."
+        )
+        raise typer.Exit(code=1)
+
     since_date: str | None = None
     if today:
         since_date = date.today().isoformat()

--- a/emdx/main.py
+++ b/emdx/main.py
@@ -28,6 +28,7 @@ LAZY_SUBCOMMANDS = {
     "task": "emdx.commands.tasks:app",
     "tag": "emdx.commands.tags:app",
     "trash": "emdx.commands.trash:app",
+    "epic": "emdx.commands.epics:app",
 }
 
 # Pre-computed help strings so --help doesn't trigger imports
@@ -41,6 +42,7 @@ LAZY_HELP = {
     "task": "Agent work queue",
     "tag": "Manage document tags",
     "trash": "Manage deleted documents",
+    "epic": "Manage task epics",
 }
 
 
@@ -49,7 +51,7 @@ LAZY_HELP = {
 register_lazy_commands(LAZY_SUBCOMMANDS, LAZY_HELP)
 
 # Register top-level command aliases (alias -> canonical name)
-register_aliases({"show": "view"})
+register_aliases({"show": "view", "list": "find", "recent": "find"})
 
 # =============================================================================
 # EAGER IMPORTS - Core KB commands (fast, always needed)

--- a/tests/test_cli_aliases.py
+++ b/tests/test_cli_aliases.py
@@ -1,0 +1,92 @@
+"""Tests for CLI verb aliases (issue #1104).
+
+Covers: top-level `list`/`recent` -> `find`, `task show` -> `task view`,
+and the top-level `epic` command forwarding to `task epic`.
+"""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from emdx.main import app
+
+runner = CliRunner()
+
+
+def _body(output: str) -> str:
+    """Strip the 'Usage: emdx <name> ...' line, which legitimately differs
+    between an alias and its canonical command (Click echoes the name
+    actually invoked)."""
+    return "\n".join(line for line in output.splitlines() if "Usage:" not in line)
+
+
+class TestTopLevelAliases:
+    """Top-level verb aliases registered via register_aliases()."""
+
+    def test_list_help_matches_find_help(self):
+        """`emdx list --help` should show find's help (list -> find)."""
+        list_result = runner.invoke(app, ["list", "--help"])
+        find_result = runner.invoke(app, ["find", "--help"])
+
+        assert list_result.exit_code == 0
+        assert _body(list_result.stdout) == _body(find_result.stdout)
+
+    def test_recent_help_matches_find_help(self):
+        """`emdx recent --help` should show find's help (recent -> find)."""
+        recent_result = runner.invoke(app, ["recent", "--help"])
+        find_result = runner.invoke(app, ["find", "--help"])
+
+        assert recent_result.exit_code == 0
+        assert _body(recent_result.stdout) == _body(find_result.stdout)
+
+    @patch("emdx.models.documents.list_documents")
+    def test_list_all_invokes_find(self, mock_list_docs):
+        """`emdx list --all` should behave like `emdx find --all`."""
+        mock_list_docs.return_value = []
+
+        result = runner.invoke(app, ["list", "--all"])
+
+        assert result.exit_code == 0
+        mock_list_docs.assert_called_once()
+
+    def test_show_help_matches_view_help(self):
+        """`emdx show --help` should show view's help (pre-existing alias)."""
+        show_result = runner.invoke(app, ["show", "--help"])
+        view_result = runner.invoke(app, ["view", "--help"])
+
+        assert show_result.exit_code == 0
+        assert _body(show_result.stdout) == _body(view_result.stdout)
+
+
+class TestTopLevelEpicCommand:
+    """Top-level `epic` should forward into the same app as `task epic`."""
+
+    def test_epic_help_matches_task_epic_help(self):
+        epic_result = runner.invoke(app, ["epic", "--help"])
+        task_epic_result = runner.invoke(app, ["task", "epic", "--help"])
+
+        assert epic_result.exit_code == 0
+        assert _body(epic_result.stdout) == _body(task_epic_result.stdout)
+
+    def test_epic_list_subcommand_available(self):
+        result = runner.invoke(app, ["epic", "list", "--help"])
+        assert result.exit_code == 0
+
+
+class TestTaskShowAlias:
+    """`task show` should alias to `task view` (issue #1104)."""
+
+    def test_task_show_help_matches_task_view_help(self):
+        show_result = runner.invoke(app, ["task", "show", "--help"])
+        view_result = runner.invoke(app, ["task", "view", "--help"])
+
+        assert show_result.exit_code == 0
+        assert _body(show_result.stdout) == _body(view_result.stdout)
+
+    def test_task_create_alias_still_works(self):
+        """Pre-existing alias (create -> add) shouldn't regress."""
+        create_result = runner.invoke(app, ["task", "create", "--help"])
+        add_result = runner.invoke(app, ["task", "add", "--help"])
+
+        assert create_result.exit_code == 0
+        assert _body(create_result.stdout) == _body(add_result.stdout)

--- a/tests/test_cli_near_miss_flags.py
+++ b/tests/test_cli_near_miss_flags.py
@@ -1,0 +1,73 @@
+"""Tests for near-miss flag handling (issue #1105).
+
+Covers: `find --tag`/`--tag-search` aliasing to `--tags`, and `task list`
+giving a clear error (instead of Click's bare "No such option") for
+--search/--tag/--project, which don't exist on that command.
+"""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from emdx.main import app
+
+runner = CliRunner()
+
+
+class TestFindTagAliases:
+    """`find --tag`/`--tag-search` should behave like `find --tags`."""
+
+    @patch("emdx.commands.core.search_by_tags")
+    def test_tag_flag_matches_tags_flag(self, mock_search_by_tags):
+        mock_search_by_tags.return_value = []
+
+        tags_result = runner.invoke(app, ["find", "--tags", "notes"])
+        tag_result = runner.invoke(app, ["find", "--tag", "notes"])
+
+        assert tags_result.exit_code == 0
+        assert tag_result.exit_code == tags_result.exit_code
+        assert mock_search_by_tags.call_count == 2
+
+    @patch("emdx.commands.core.search_by_tags")
+    def test_tag_search_flag_matches_tags_flag(self, mock_search_by_tags):
+        mock_search_by_tags.return_value = []
+
+        tags_result = runner.invoke(app, ["find", "--tags", "notes"])
+        tag_search_result = runner.invoke(app, ["find", "--tag-search", "notes"])
+
+        assert tags_result.exit_code == 0
+        assert tag_search_result.exit_code == tags_result.exit_code
+        assert mock_search_by_tags.call_count == 2
+
+
+class TestTaskListNearMissFlags:
+    """`task list --search/--tag/--project` should give a clear pointer, not a bare Click error."""
+
+    def test_search_flag_gives_clear_error(self):
+        result = runner.invoke(app, ["task", "list", "--search", "foo"])
+
+        assert result.exit_code == 1
+        assert "no such option" not in result.output.lower()
+        assert "emdx find" in result.output
+
+    def test_tag_flag_gives_clear_error(self):
+        result = runner.invoke(app, ["task", "list", "--tag", "foo"])
+
+        assert result.exit_code == 1
+        assert "no such option" not in result.output.lower()
+        assert "emdx find" in result.output
+
+    def test_project_flag_gives_clear_error(self):
+        result = runner.invoke(app, ["task", "list", "--project", "foo"])
+
+        assert result.exit_code == 1
+        assert "no such option" not in result.output.lower()
+        assert "emdx find" in result.output
+
+    @patch("emdx.models.tasks.list_tasks")
+    def test_plain_list_unaffected(self, mock_list_tasks):
+        mock_list_tasks.return_value = []
+
+        result = runner.invoke(app, ["task", "list"])
+
+        assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Closes #1104, closes #1105.

Two related "reduce guessing" issues, both about verbs/flags that get guessed repeatedly and either fail silently or with Click's unhelpful bare error.

**#1104 — alias commonly-guessed verbs**
- Top-level: `list` and `recent` now alias to `find` (mirrors the existing `show -> view` alias).
- Added a thin top-level `epic` command that forwards into the same `emdx.commands.epics:app` used by `task epic` — so `emdx epic list` works, not just `emdx task epic list`.
- `task` subgroup: added `show -> view` alias (the existing top-level `show -> view` alias didn't reach into the `task` subgroup).

**#1105 — near-miss flag names fail silently**
- `find --tag` / `--tag-search` now alias to `--tags` (the real, plural flag) — closes the singular/plural typo case outright.
- `task list --search` / `--tag` / `--project` don't exist on that command (only `find` has search/tag/project filtering). Instead of Click's bare "No such option", these now print a message pointing at `emdx find --tags ...` / `--project ...`, or `--cat`/`--epic` for task filtering.

## Test plan

- [x] `poetry run ruff check .` — zero errors
- [x] `poetry run mypy emdx/main.py emdx/commands/tasks.py emdx/commands/core.py` — no issues
- [x] `poetry run pytest tests/ -x -q` — 2211 passed, 8 skipped (full suite, no regressions)
- [x] Added `tests/test_cli_aliases.py` and `tests/test_cli_near_miss_flags.py` covering the new aliases and error messages
- [x] Manually exercised each new/changed path via `poetry run emdx`:
  - `emdx list --all`, `emdx recent --help`, `emdx epic list`, `emdx task show --help` — all resolve correctly
  - `emdx task list --search foo` / `--tag foo` / `--project foo` — each prints a clear message pointing at `emdx find`/`--cat`/`--epic` instead of Click's "No such option"
  - `emdx find --tag <name>` — behaves identically to `emdx find --tags <name>`
- [x] `emdx --help` still lists `epic` alongside the other top-level commands with the right help text

Also updated `docs/cli-api.md` to note the new `emdx epic` shortcut.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X9gFJGz1qoydMQv1kzSPnQ)_