### PR TITLE
chore: Release v0.33.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "emdx",
       "description": "Knowledge base skills for Claude Code. Save research, maintain session memory, and keep knowledge current across conversations.",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "author": {
         "name": "Alex Rockwell"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "emdx",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Knowledge base skills for Claude Code. Save research, maintain session memory, and keep knowledge current across conversations.",
   "author": {
     "name": "Alex Rockwell"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.1] - 2026-08-04
+
+**Fewer guessed commands, one dev-DB fix.** Common near-misses now resolve instead of failing: `list`/`recent` alias to `find`, a top-level `emdx epic` shortcut forwards to `task epic`, and `task list --search/--tag/--project` point at the right flag instead of a bare Click error. Also fixes a dev-checkout detection bug, plus routine dependency maintenance.
+
+### Added
+
+- **CLI alias & near-miss fixes** (#1104, #1105, #1106) — `list`/`recent` alias to `find`; new top-level `emdx epic` command; `task show` aliases to `task view`; `find --tag`/`--tag-search` alias to `--tags`; `task list --search`/`--tag`/`--project` (which don't exist on that command) now print a message pointing at `emdx find --tags`/`--project` or `--cat`/`--epic` instead of Click's bare "No such option"
+
+### Fixed
+
+- **Dev-database misdetection under editable installs** — `poetry run emdx` in a worktree could silently fall through to the production database instead of the local dev DB (#1096)
+
+### Dependencies
+
+- mypy, ruff, leidenalg, datasketch, google-auth-httplib2, GitHub Actions refreshed (#1097, #1098, #1100, #1101, #1102, #1103)
+
+[0.33.1]: https://github.com/arockwell/emdx/compare/v0.33.0...v0.33.1
+
 ## [0.33.0] - 2026-07-23
 
 **Fast embeddings and a hardened core.** Embedding operations now run on fastembed's ONNX runtime — the same `all-MiniLM-L6-v2` model without importing torch — cutting cold start from 5.5s to 0.4s, so auto-link-on-save stays synchronous and instant. Around it: a wave of audit-driven fixes (security hardening, dev-DB isolation that actually works, atomic backup restore), a big dependency refresh, and a CI cache fix that makes dependency PRs testable again.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # emdx
 
-[![Version](https://img.shields.io/badge/version-0.33.0-blue.svg)](https://github.com/arockwell/emdx/releases)
+[![Version](https://img.shields.io/badge/version-0.33.1-blue.svg)](https://github.com/arockwell/emdx/releases)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
 

--- a/emdx/__init__.py
+++ b/emdx/__init__.py
@@ -6,7 +6,7 @@ import hashlib
 import time
 from pathlib import Path
 
-__version__ = "0.33.0"
+__version__ = "0.33.1"
 
 
 # Generate a unique build identifier based on current timestamp and file modification times

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "emdx"
-version = "0.33.0"
+version = "0.33.1"
 description = "Send agents. Save everything. Track what's next."
 authors = ["Alex Rockwell <arockwell@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Patch release v0.33.1, bumping from v0.33.0.

- CLI alias & near-miss fixes (#1104, #1105, #1106): `list`/`recent` → `find` aliases, top-level `emdx epic` command, `task show` → `task view` alias, `find --tag`/`--tag-search` → `--tags`, clearer errors for `task list --search`/`--tag`/`--project`
- Fixed dev-database misdetection under editable installs (#1096)
- Routine dependency maintenance: mypy, ruff, leidenalg, datasketch, google-auth-httplib2, GitHub Actions (#1097, #1098, #1100, #1101, #1102, #1103)

Version bumped in `pyproject.toml`, `emdx/__init__.py`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`. Changelog entry added, README version badge updated.

## Test plan

- [x] `poetry run ruff check .` — zero errors
- [x] `poetry run mypy emdx` — no issues
- [x] `poetry run pytest tests/ -x -q` — 2100 passed, 14 skipped, no regressions

## Post-merge

After this merges, tag the release:
```
git fetch origin main && git tag v0.33.1 origin/main && git push origin v0.33.1
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVwZW4gHfQo6Q4EM23LiGn)_