### PR TITLE
fix: drop obsolete typer[all] extra to silence install warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.11"
-typer = {extras = ["all"], version = ">=0.24.1,<0.26.0"}
+typer = ">=0.24.1,<0.26.0"
 click = ">=8.3.2"  # Typer 0.15+ requires click 8.1+
 rich = ">=14.3,<16.0"
 textual = "^8.2.3"


### PR DESCRIPTION
## Summary
- Typer removed the `all` extra in 0.25 (rich and shellingham are now regular dependencies of typer itself), so `pyproject.toml`'s `typer = {extras = ["all"], ...}` is a no-op that only produces a warning on every install/upgrade (`warning: The package 'typer==0.25.1' does not have an extra named 'all'`).
- Changed the dependency spec to `typer = ">=0.24.1,<0.26.0"` (no extras), matching how typer 0.25+ ships its own dependencies.

Fixes #1109

## Test plan
- [x] `poetry install` — no more "does not have an extra named `all`" warning
- [x] `poetry run pip show typer shellingham rich` — confirms shellingham (1.5.4) and rich (15.0.0) still get installed transitively via typer, no functionality lost
- [x] `poetry run emdx --help` — CLI still starts, `--install-completion`/`--show-completion` (shellingham-dependent) options still present
- [x] `poetry run ruff check .` — all checks passed
- [x] `poetry run pytest tests/ -x -q` — 2206 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uqkccbg1BzkBSXYdruLp7h)_