### PR TITLE
Fix version reporting and typer install warning

### DIFF
--- a/emdx/__init__.py
+++ b/emdx/__init__.py
@@ -4,9 +4,30 @@ emdx - A knowledge base that AI agents can read, write, and search
 
 import hashlib
 import time
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
-__version__ = "0.33.1"
+import tomllib
+
+
+def _get_version() -> str:
+    """Return the installed package version, falling back to pyproject.toml.
+
+    Reading from importlib.metadata reflects what was actually installed
+    (e.g. by ``uv tool upgrade``), rather than a hardcoded string that can
+    drift from the running package. The pyproject.toml fallback covers
+    running from a source checkout without an installed distribution.
+    """
+    try:
+        return version("emdx")
+    except PackageNotFoundError:
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        with pyproject.open("rb") as f:
+            data = tomllib.load(f)
+        return str(data["tool"]["poetry"]["version"])
+
+
+__version__ = _get_version()
 
 
 # Generate a unique build identifier based on current timestamp and file modification times

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.11"
-typer = {extras = ["all"], version = ">=0.24.1,<0.26.0"}
+typer = ">=0.24.1,<0.26.0"
 click = ">=8.3.2"  # Typer 0.15+ requires click 8.1+
 rich = ">=14.3,<16.0"
 textual = "^8.2.3"


### PR DESCRIPTION
## Summary

Fixes two small install/upgrade-related bugs reported after a `uv tool upgrade emdx` run on 2026-08-04:

- **#1110** — `emdx --version` printed the hardcoded string in `emdx/__init__.py` instead of the actually-installed package version, so it couldn't be used to tell whether an upgrade had really landed. `__version__` is now derived from `importlib.metadata.version("emdx")` (what pip/uv actually recorded), falling back to reading `pyproject.toml` directly when running from an uninstalled source checkout (e.g. `poetry run emdx` before `poetry install`, or `python -m emdx`).
- **#1109** — `typer = {extras = ["all"], ...}` in `pyproject.toml` printed `warning: The package 'typer==0.25.1' does not have an extra named 'all'` on every install, since typer dropped the `all` extra in 0.25 (rich/shellingham became regular deps). Dropped the extra; `rich` is already a direct project dependency.

## Test plan

- [x] `poetry run pytest tests/ -x -q` — full suite passes (2206 passed, 8 skipped)
- [x] `poetry run pytest tests/test_init.py tests/test_version_sync.py -v` — version-sync guards (pyproject.toml / plugin.json / marketplace.json vs `__version__`) still pass
- [x] `poetry run ruff check .` and `poetry run mypy emdx/__init__.py` — clean
- [x] Manually verified the `PackageNotFoundError` fallback path by monkeypatching `importlib.metadata.version` to raise — falls back to parsing `pyproject.toml` correctly
- [x] Built a wheel (`poetry build`) and installed it into a fresh venv: `emdx --version` now reports the version from the installed distribution's metadata, and the install produces **no** `does not have an extra named 'all'` warning

---
_Generated by [Claude Code](https://claude.ai/code/session_011U9VtQRHcSBL83ipSriD1X)_